### PR TITLE
Handle Unicode banners correctly.

### DIFF
--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -240,7 +240,7 @@ static bool fadeout = false;
 std::string name;
 
 const char* romsel_filename;
-vector<string> romsel_gameline;	// from banner (TODO: wstring?)
+vector<wstring> romsel_gameline;	// from banner
 
 static const char* rom = "";		// Selected ROM image.
 // TODO: Potential memory leaks for sav...
@@ -2114,8 +2114,8 @@ int main()
 							// Print the banner text, center-aligned.
 							const size_t banner_lines = std::min(3U, romsel_gameline.size());
 							for (size_t i = 0; i < banner_lines; i++, y += dy) {
-								int text_width = sftd_get_text_width(font_b, 16, romsel_gameline[i].c_str());
-								sftd_draw_textf(font_b, (320-text_width)/2, y, RGBA8(0, 0, 0, 255), 16, romsel_gameline[i].c_str());
+								int text_width = sftd_get_wtext_width(font_b, 16, romsel_gameline[i].c_str());
+								sftd_draw_wtextf(font_b, (320-text_width)/2, y, RGBA8(0, 0, 0, 255), 16, romsel_gameline[i].c_str());
 							}
 
 							if (settings_countervalue == 1) {

--- a/gui/source/ndsheaderbanner.h
+++ b/gui/source/ndsheaderbanner.h
@@ -202,7 +202,7 @@ void grabTID(FILE* ndsFile, char *buf);
  * @param bnrtitlenum Title number. (aka language)
  * @return Vector containing each line as a wide string.
  */
-std::vector<std::string> grabText(FILE* binFile, int bnrtitlenum);
+std::vector<std::wstring> grabText(FILE* binFile, int bnrtitlenum);
 
 void cacheBanner(FILE* ndsFile, const char* filename, sftd_font* setfont);
 sf2d_texture* grabIcon(FILE* binFile);


### PR DESCRIPTION
Here's a quick one-commit PR that improves support for Unicode banners. Instead of simply truncating the UTF-16 values and handling it as "ASCII", convert the UTF-16 to UTF-32 so we can use std::wstring. sftd has wide string functions, so we can use those to print the wstrings.

Tested with "Sonic & SEGA All-Stars Racing", which has a `™` (U+2122) in the banner. The `™` now shows up correctly instead of showing up as a `"` (U+0022).