### PR TITLE
Remove SeedDB requirement in Archive Access Permissions

### DIFF
--- a/gui/app/build-cia.rsf
+++ b/gui/app/build-cia.rsf
@@ -55,7 +55,7 @@ AccessControlInfo:
    - Shop
    - Shell
    - CategoryHomeMenu
-   - SeedDB
+  #- SeedDB
   IoAccessControl:
    - FsMountNand
    - FsMountNandRoWrite


### PR DESCRIPTION
As reported on GBATemp [here](https://gbatemp.net/threads/twloader-ctr-mode-nds-app.448375/page-100#post-7014106), [here](https://gbatemp.net/threads/twloader-ctr-mode-nds-app.448375/page-103#post-7014900) and [here](https://gbatemp.net/threads/twloader-ctr-mode-nds-app.448375/page-103#post-7014911) simply putting a `#` in front of `- SeedDB` solves the issue