### PR TITLE
Fix negative wraparound when adjusting the "Console output" seting by pressing Left.

### DIFF
--- a/gui/source/settings.cpp
+++ b/gui/source/settings.cpp
@@ -836,7 +836,7 @@ bool settingsMoveCursor(u32 hDown)
 					} else if (hDown & KEY_LEFT) {
 						settings.twl.console--;
 						if (settings.twl.console < 0) {
-							settings.twl.console = 16;
+							settings.twl.console = 2;
 						}
 					}
 					break;


### PR DESCRIPTION
Minor copy/paste error in the settings menu.