### PR TITLE
Prevent starting Slot-1 via touch if no cartridge is present.

### DIFF
--- a/gui/source/gamecard.cpp
+++ b/gui/source/gamecard.cpp
@@ -21,7 +21,7 @@ static union {
 } twl_gameid;	// 4-character game ID
 bool twl_inserted = false;
 static GameCardType twl_card_type = CARD_TYPE_UNKNOWN;
-static string twl_product_code;
+static char twl_product_code[16] = { };
 static u8 twl_revision = 0xFF;
 static sf2d_texture *twl_icon = NULL;
 static vector<wstring> twl_text;
@@ -35,7 +35,7 @@ void gamecardClearCache(void)
 	twl_gameid.d = 0;
 	sf2d_free_texture(twl_icon);
 	twl_card_type = CARD_TYPE_UNKNOWN;
-	twl_product_code.clear();
+	twl_product_code[0] = 0;
 	twl_revision = 0xFF;
 	twl_icon = NULL;
 	twl_text.clear();
@@ -113,9 +113,7 @@ bool gamecardPoll(bool force)
 	}
 
 	// Product code. Format: NTR-P-XXXX or TWL-P-XXXX
-	char buf[16];
-	snprintf(buf, sizeof(buf), "%s-P-%.4s", prefix, twl_gameid.id4);
-	twl_product_code = string(buf);
+	snprintf(twl_product_code, sizeof(twl_product_code), "%s-P-%.4s", prefix, twl_gameid.id4);
 
 	// Revision.
 	twl_revision = header.romversion;
@@ -150,7 +148,7 @@ GameCardType gamecardGetType(void)
  */
 const char *gamecardGetProductCode(void)
 {
-	return twl_product_code.c_str();
+	return twl_product_code;
 }
 
 /**

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -2314,19 +2314,33 @@ int main()
 								}
 							}
 						} else if (touch_x >= 128 && touch_x <= 192 && touch_y >= 112 && touch_y <= 192) {
+							bool playlaunchsound = true;
 							if (titleboxXmovetimer == 0) {
 								if(cursorPosition == -2) {
 									titleboxXmovetimer = 1;
 									screenmodeswitch = true;
 									applaunchprep = true;
 								} else if(cursorPosition == -1) {
-									titleboxXmovetimer = 1;
-									settings.twl.launchslot1 = true;
-									if (settings.twl.forwarder) {
-										keepsdvalue = 1;
-										rom = "_nds/twloader.nds";
+									if (!settings.twl.forwarder && romsel_gameline.empty()) {
+										// Slot-1 is selected, but no
+										// cartridge is present.
+										if (!playwrongsounddone) {
+											if (dspfirmfound) {
+												sfx_wrong->stop();
+												sfx_wrong->play();
+											}
+											playwrongsounddone = true;
+										}
+										playlaunchsound = false;
+									} else {
+										titleboxXmovetimer = 1;
+										settings.twl.launchslot1 = true;
+										if (settings.twl.forwarder) {
+											keepsdvalue = 1;
+											rom = "_nds/twloader.nds";
+										}
+										applaunchprep = true;
 									}
-									applaunchprep = true;
 								} else {
 									titleboxXmovetimer = 1;
 									if (settings.twl.forwarder) {
@@ -2341,7 +2355,7 @@ int main()
 								}
 							}
 							updatebotscreen = true;
-							if (dspfirmfound) {
+							if (playlaunchsound && dspfirmfound) {
 								bgm_menu->stop();
 								sfx_launch->play();
 							}


### PR DESCRIPTION
...and another follow-up PR. I disabled starting Slot-1 if no cartridge was present by pressing A, but not by the touchscreen.