### PR TITLE
Fix crashes in 3.0 caused by missing files.

### DIFF
--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -507,6 +507,12 @@ void downloadBoxArt(void)
 		u32 tid;
 		memcpy(&tid, ba_TID, sizeof(tid));
 		tid = __builtin_bswap32(tid);
+		if (tid == 0x4E54524A) {
+			// NTRJ: Generic game code used for
+			// prototypes and some DL Play games.
+			// No boxart is available.
+			continue;
+		}
 		if (boxart_all_tids.find(tid) != boxart_all_tids.end()) {
 			// Already checked for this boxart.
 			continue;
@@ -540,6 +546,12 @@ void downloadBoxArt(void)
 		u32 tid;
 		memcpy(&tid, ba_TID.c_str(), sizeof(tid));
 		tid = __builtin_bswap32(tid);
+		if (tid == 0x4E54524A) {
+			// NTRJ: Generic game code used for
+			// prototypes and some DL Play games.
+			// No boxart is available.
+			continue;
+		}
 		if (boxart_all_tids.find(tid) != boxart_all_tids.end()) {
 			// Already checked for this boxart.
 			continue;

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -271,7 +271,7 @@ void DialogBoxAppear(const char *text, int mode) {
 		return;
 
 	// Save the dialog text so we can make
-	// use if it if nullptr is specified.
+	// use if it if NULL is specified.
 	if (text) {
 		dialog_text = text;
 	}
@@ -307,7 +307,7 @@ void DialogBoxDisappear(const char *text, int mode) {
 		return;
 
 	// Save the dialog text so we can make
-	// use if it if nullptr is specified.
+	// use if it if NULL is specified.
 	if (text) {
 		dialog_text = text;
 	}
@@ -444,8 +444,11 @@ static void OpenBNRIcon(void) {
 		// Selected banner icon is on the current page.
 		if (ndsFile[idx]) {
 			fclose(ndsFile[idx]);
+			ndsFile[idx] = NULL;
 		}
-		ndsFile[idx] = fopen(bnriconpath[idx], "rb");
+		if (bnriconpath[idx]) {
+			ndsFile[idx] = fopen(bnriconpath[idx], "rb");
+		}
 	}
 }
 
@@ -459,7 +462,7 @@ static void StoreBNRIconPath(const char *path) {
 	if (idx >= 0 && idx < 20) {
 		// Selected banner icon is on the current page.
 		free(bnriconpath[idx]);
-		bnriconpath[idx] = strdup(path);
+		bnriconpath[idx] = (path ? strdup(path) : NULL);
 	}
 }
 
@@ -473,7 +476,7 @@ static void StoreBoxArtPath(const char *path) {
 	if (idx >= 0 && idx < 20) {
 		// Selected boxart is on the current page.
 		free(boxartpath[idx]);
-		boxartpath[idx] = strdup(path);
+		boxartpath[idx] = (path ? strdup(path) : NULL);
 	}
 }
 
@@ -499,25 +502,6 @@ static void LoadBNRIcon(void) {
 	}
 }
 
-// May not be needed
-/* static void LoadBNRIconatLaunch(void) {
-	// Get the bnriconnum relative to the current page.
-	const int idx = bnriconnum - (pagenum * 20);
-	if (idx >= 0 && idx < 20) {
-		// Selected bnriconnum is on the current page.
-		sf2d_free_texture(bnricontexlaunch);
-		bnricontexlaunch = NULL;
-		if (ndsFile[idx]) {
-			bnricontexlaunch = grabIcon(ndsFile[idx]); // Banner icon
-		}
-		if (!bnricontexlaunch) {
-			FILE *f_nobnr = fopen("romfs:/notextbanner", "rb");
-			bnricontexlaunch = grabIcon(f_nobnr);
-			fclose(f_nobnr);
-		}
-	}
-} */
-
 static void LoadBoxArt(void) {
 	// Get the boxartnum relative to the current page.
 	const int idx = boxartnum - (pagenum * 20);
@@ -525,6 +509,8 @@ static void LoadBoxArt(void) {
 		// Selected boxart is on the current page.
 		// NOTE: Only 6 slots for boxart.
 		sf2d_free_texture(boxarttex[idx % 6]);
+		// NOTE: boxart_null indicates "no" boxart because no cartridge is present.
+		// "Unknown" boxart because it's unavailable is boxart_unknown.png.
 		const char *path = (boxartpath[idx] ? boxartpath[idx] : "romfs:/graphics/boxart_null.png");
 		boxarttex[idx % 6] = sfil_load_PNG_file(path, SF2D_PLACE_RAM); // Box art
 	}
@@ -739,7 +725,7 @@ void update_battery_level(sf2d_texture *texchrg, sf2d_texture *texarray[])
 /**
  * Scan a directory for matching files.
  * @param path Directory path.
- * @param ext File extension, case-insensitive. (If nullptr, matches all files.)
+ * @param ext File extension, case-insensitive. (If NULL, matches all files.)
  * @param files Vector to append files to.
  * @return Number of files matched. (-1 if the directory could not be opened.)
  */
@@ -1212,7 +1198,7 @@ int main()
 							snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
 							StoreBNRIconPath(path);
 						} else {
-							StoreBNRIconPath("romfs:/notextbanner");
+							StoreBNRIconPath(NULL);
 						}
 						OpenBNRIcon();
 						LoadBNRIcon();
@@ -1230,10 +1216,10 @@ int main()
 							if (access(path, F_OK) != -1) {
 								StoreBNRIconPath(path);
 							} else {
-								StoreBNRIconPath("romfs:/notextbanner");
+								StoreBNRIconPath(NULL);
 							}
 						} else {
-							StoreBNRIconPath("romfs:/notextbanner");
+							StoreBNRIconPath(NULL);
 						}
 						OpenBNRIcon();
 						LoadBNRIcon();

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -855,6 +855,42 @@ static void loadSlot1BoxArt(void)
 	slot1boxarttexloaded = true;
 }
 
+/**
+ * Scan the ROM directories.
+ */
+static void scanRomDirectories(void)
+{
+	char path[256];
+
+	// Use default directory if none is specified
+	if (settings.ui.romfolder.empty()) {
+		settings.ui.romfolder = "roms/nds";
+		// Make sure the directory exists.
+		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.romfolder.c_str());
+		mkdir(path, 0777);
+	} else {
+		// Use the custom ROMs directory.
+		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.romfolder.c_str());
+	}
+
+	// Scan the ROMs directory for ".nds" files.
+	scan_dir_for_files(path, ".nds", files);
+	
+	// Use default directory if none is specified
+	if (settings.ui.fcromfolder.empty()) {
+		settings.ui.fcromfolder = "roms/flashcard/nds";
+		// Make sure the directory exists.
+		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.fcromfolder.c_str());
+		mkdir(path, 0777);
+	} else {
+		// Use the custom ROMs directory.
+		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.fcromfolder.c_str());
+	}
+
+	// Scan the flashcard directory for configuration files.
+	scan_dir_for_files(path, ".ini", fcfiles);
+}
+
 int main()
 {
 	aptInit();
@@ -996,36 +1032,9 @@ int main()
 		sfx_wrong = new sound("romfs:/sounds/wrong.wav", 2, false);
 		sfx_back = new sound("romfs:/sounds/back.wav", 2, false);
 	}
-	
-	// Use default directory if none is specified
-	char folder_path[256];
-	if (settings.ui.romfolder.empty()) {
-		settings.ui.romfolder = "roms/nds";
-		// Make sure the directory exists.
-		snprintf(folder_path, sizeof(folder_path), "sdmc:/%s", settings.ui.romfolder.c_str());
-		mkdir(folder_path, 0777);
-	} else {
-		// Use the custom ROMs directory.
-		snprintf(folder_path, sizeof(folder_path), "sdmc:/%s", settings.ui.romfolder.c_str());
-	}
 
-	// Scan the ROMs directory for ".nds" files.
-	scan_dir_for_files(folder_path, ".nds", files);
-	
-	// Use default directory if none is specified
-	char folder_path2[256];
-	if (settings.ui.fcromfolder.empty()) {
-		settings.ui.fcromfolder = "roms/flashcard/nds";
-		// Make sure the directory exists.
-		snprintf(folder_path2, sizeof(folder_path2), "sdmc:/%s", settings.ui.fcromfolder.c_str());
-		mkdir(folder_path2, 0777);
-	} else {
-		// Use the custom ROMs directory.
-		snprintf(folder_path2, sizeof(folder_path2), "sdmc:/%s", settings.ui.fcromfolder.c_str());
-	}
-
-	// Scan the flashcard directory for configuration files.
-	scan_dir_for_files(folder_path2, ".ini", fcfiles);
+	// Scan the ROM directories.
+	scanRomDirectories();
 
 	char romsel_counter2sd[16];	// Number of ROMs on the SD card.
 	snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -865,9 +865,12 @@ static void scanRomDirectories(void)
 	// Use default directory if none is specified
 	if (settings.ui.romfolder.empty()) {
 		settings.ui.romfolder = "roms/nds";
-		// Make sure the directory exists.
 		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.romfolder.c_str());
-		mkdir(path, 0777);
+		// Make sure the directory exists.
+		// NOTE: Parent directories might not exist, so we
+		// need to mkdir() each directory level.
+		mkdir("sdmc:/roms", 0777);
+		mkdir("sdmc:/roms/nds", 0777);
 	} else {
 		// Use the custom ROMs directory.
 		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.romfolder.c_str());
@@ -879,9 +882,13 @@ static void scanRomDirectories(void)
 	// Use default directory if none is specified
 	if (settings.ui.fcromfolder.empty()) {
 		settings.ui.fcromfolder = "roms/flashcard/nds";
-		// Make sure the directory exists.
 		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.fcromfolder.c_str());
-		mkdir(path, 0777);
+		// Make sure the directory exists.
+		// NOTE: Parent directories might not exist, so we
+		// need to mkdir() each directory level.
+		mkdir("sdmc:/roms", 0777);
+		mkdir("sdmc:/roms/flashcard", 0777);
+		mkdir("sdmc:/roms/flashcard/nds", 0777);
 	} else {
 		// Use the custom ROMs directory.
 		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.fcromfolder.c_str());
@@ -925,6 +932,7 @@ int main()
 	createLog();
 
 	// make folders if they don't exist
+	mkdir("sdmc:/_nds", 0777);
 	mkdir("sdmc:/_nds/twloader", 0777);
 	mkdir("sdmc:/_nds/twloader/gamesettings", 0777);
 	mkdir("sdmc:/_nds/twloader/gamesettings/flashcard", 0777);

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -865,16 +865,13 @@ static void scanRomDirectories(void)
 	// Use default directory if none is specified
 	if (settings.ui.romfolder.empty()) {
 		settings.ui.romfolder = "roms/nds";
-		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.romfolder.c_str());
 		// Make sure the directory exists.
 		// NOTE: Parent directories might not exist, so we
 		// need to mkdir() each directory level.
 		mkdir("sdmc:/roms", 0777);
 		mkdir("sdmc:/roms/nds", 0777);
-	} else {
-		// Use the custom ROMs directory.
-		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.romfolder.c_str());
 	}
+	snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.romfolder.c_str());
 
 	// Scan the ROMs directory for ".nds" files.
 	scan_dir_for_files(path, ".nds", files);
@@ -882,17 +879,14 @@ static void scanRomDirectories(void)
 	// Use default directory if none is specified
 	if (settings.ui.fcromfolder.empty()) {
 		settings.ui.fcromfolder = "roms/flashcard/nds";
-		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.fcromfolder.c_str());
 		// Make sure the directory exists.
 		// NOTE: Parent directories might not exist, so we
 		// need to mkdir() each directory level.
 		mkdir("sdmc:/roms", 0777);
 		mkdir("sdmc:/roms/flashcard", 0777);
 		mkdir("sdmc:/roms/flashcard/nds", 0777);
-	} else {
-		// Use the custom ROMs directory.
-		snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.fcromfolder.c_str());
 	}
+	snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.fcromfolder.c_str());
 
 	// Scan the flashcard directory for configuration files.
 	scan_dir_for_files(path, ".ini", fcfiles);

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -525,7 +525,8 @@ static void LoadBoxArt(void) {
 		// Selected boxart is on the current page.
 		// NOTE: Only 6 slots for boxart.
 		sf2d_free_texture(boxarttex[idx % 6]);
-		boxarttex[idx % 6] = sfil_load_PNG_file(boxartpath[idx], SF2D_PLACE_RAM); // Box art
+		const char *path = (boxartpath[idx] ? boxartpath[idx] : "romfs:/graphics/boxart_null.png");
+		boxarttex[idx % 6] = sfil_load_PNG_file(path, SF2D_PLACE_RAM); // Box art
 	}
 }
 

--- a/gui/source/settings.h
+++ b/gui/source/settings.h
@@ -44,6 +44,7 @@ typedef struct _Settings_t {
 	struct {
 		std::string name;
 		std::string romfolder;
+		std::string fcromfolder;
 
 		int language;	// Language. (0-11; other for system)
 		int color;

--- a/gui/source/settings.h
+++ b/gui/source/settings.h
@@ -84,9 +84,10 @@ typedef struct _Settings_t {
 	} twl;
 	
 	struct {
-		bool cpuspeed;	// false == NTR, true == TWL
-		bool extvram;
-		bool lockarm9scfgext;
+		// -1 == default; 0 == off, 1 == on
+		s8 cpuspeed;	// false == NTR, true == TWL
+		s8 extvram;
+		s8 lockarm9scfgext;
 	} pergame;
 } Settings_t;
 extern Settings_t settings;


### PR DESCRIPTION
TWLoader 3.0 crashes if files are missing in roms/nds/ and/or roms/flashcard/nds/ (or both?). This is caused by boxartpath not being initialized, so it attempts to use a NULL pointer.

This PR fixes the behavior by automatically substituting the NULL pointer for boxart_null.png. (This is different from boxart_unknown.png, so boxart_unknown.png is still manually set if the boxart is missing.)

Similar code has been added for banner icons, though in that case I am setting the path to NULL if no banner icon is available. The banner icon functions will automatically substitute NULL with notextbanner, so this helps to save a bit of memory.

There's a few other bug fixes, including:
* Fixing mkdir() for multiple levels of subdirectories (mkdir() isn't recursive, so we have to create each level manually).
* Fixing per-game settings to use an s8 instead of bool so it doesn't get optimized out, and some refactoring for ROM directory scanning.
* Don't attempt to download boxart for "NTRJ". This is commonly used for prototypes and some DL Play titles, so the ID is ambiguous.