### PR TITLE
Fix Wi-Fi not working on some systems; also sounds.

### DIFF
--- a/gui/app/build-cia.rsf
+++ b/gui/app/build-cia.rsf
@@ -210,7 +210,7 @@ AccessControlInfo:
   # Maximum 34 services (32 if firmware is prior to 9.6.0)
   ServiceAccessControl:
    - APT:U
-   #- ac:u
+   - ac:u
    - am:net
    #- boss:U
    #- cam:u

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -55,7 +55,6 @@ extern vector<string> fcfiles;
  * @return True if Wi-Fi is connected; false if not.
  */
 bool checkWifiStatus(void) {
-	acInit();
 	u32 wifiStatus;
 	bool res = false;
 
@@ -66,7 +65,6 @@ bool checkWifiStatus(void) {
 		LogFMA("WifiStatus", "No Internet connetion active found", RetTime().c_str());
 	}
 
-	acExit();
 	return res;
 }
 
@@ -81,7 +79,6 @@ int downloadFile(const char* url, const char* file, MediaType mediaType) {
 	if (!checkWifiStatus())
 		return -1;
 
-	acInit();
 	fsInit();
 	httpcInit(0x1000);
 	u8 method = 0;
@@ -158,7 +155,6 @@ int downloadFile(const char* url, const char* file, MediaType mediaType) {
 	httpcCloseContext(&context);
 
 	httpcExit();
-	acExit();
 	fsExit();
 	return 0;
 }

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -859,6 +859,7 @@ int main()
 	romfsInit();
 	srvInit();
 	hidInit();
+	acInit();
 
 	sf2d_init();
 	sf2d_set_clear_color(RGBA8(0x00, 0x00, 0x00, 0x00));
@@ -2698,6 +2699,7 @@ int main()
 	sftd_fini();
 	sf2d_fini();
 
+	acExit();
 	hidExit();
 	srvExit();
 	romfsExit();

--- a/gui/source/settings.cpp
+++ b/gui/source/settings.cpp
@@ -827,22 +827,35 @@ bool settingsMoveCursor(u32 hDown)
 			sfx = sfx_switch;
 		} else if (hDown & KEY_X) {
 			if (checkWifiStatus()) {
+				// Play the sound now instead of waiting.
+				if (dspfirmfound && sfx_select) {
+					sfx_select->stop();	// Prevent freezing
+					sfx_select->play();
+				}
 				UpdateBootstrapRelease();
-				sfx = sfx_select;
 			} else {
 				// Wi-Fi is not connected.
 				sfx = sfx_wrong;
 			}
 		} else if (hDown & KEY_Y) {
 			if (checkWifiStatus()) {
+				// Play the sound now instead of waiting.
+				if (dspfirmfound && sfx_select) {
+					sfx_select->stop();	// Prevent freezing
+					sfx_select->play();
+				}
 				UpdateBootstrapUnofficial();
-				sfx = sfx_select;
 			} else {
 				// Wi-Fi is not connected.
 				sfx = sfx_wrong;
 			}
 		} else if (hDown & KEY_START && checkWifiStatus() && !is3DSX) {
 			if (checkUpdate() == 0) {
+				// Play the sound now instead of waiting.
+				if (dspfirmfound && sfx_select) {
+					sfx_select->stop();	// Prevent freezing
+					sfx_select->play();
+				}
 				DownloadTWLoaderCIAs();
 			}
 		} else if (hDown & KEY_B) {


### PR DESCRIPTION
This PR was originally to fix some sounds on the Settings screen (the sound was being played after the update), but it also fixes an issue with Wi-Fi not being detected. Specifically, when I was disabling services in commit e9f31ffca24dfc96ebf28bee3a9126d27b1dab1d, I accidentally disabled ac:u, which is used for GetWifiStatus().

Strangely, it still worked on my system... (Maybe related to having Luma3DS's ErrDisp option enabled?)

Also moved acInit() and acExit() out of individual functions and into main(). There's no point in repeatedly initializing and exiting the AC service every time the Wi-Fi status is checked.