### PR TITLE
Missing structs, boxarts and search improvements

### DIFF
--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -459,7 +459,7 @@ void downloadSlot1BoxArt(const char* TID)
 	ba_TID[4] = 0;
 
 	char path[256];
-	snprintf(path, sizeof(path), "/_nds/twloader/boxart/flashcard/%.4s.png", ba_TID);
+	snprintf(path, sizeof(path), "/_nds/twloader/boxart/%.4s.png", ba_TID);
 	if (!access(path, F_OK)) {
 		// File already exists.
 		return;

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -567,6 +567,13 @@ void downloadBoxArt(void)
 		if (!access(path, F_OK)) {
 			// Boxart file exists.
 			continue;
+		}else{
+			// Maybe boxart exist with fullname instead of TID
+			snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%s.png", tempfile);
+			if(!access(path, F_OK)){
+				// Boxart with fullname exist
+				continue;
+			}
 		}
 
 		// Boxart file does not exist. Download it.

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -522,7 +522,6 @@ void downloadBoxArt(void)
 			continue;
 		}else{
 			// Maybe boxart exist with fullname instead of TID
-			Log(tempfile);
 			snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%s.png", tempfile);
 			if(!access(path, F_OK)){
 				// Boxart with fullname exist

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -598,13 +598,6 @@ void downloadBoxArt(void)
 			if (access(path, F_OK) != 0) {
 				// Boxart file does not exist. Download it.
 				boxart_dl_tids.push_back(tid);
-			}else{
-				// Maybe boxart exist with fullname instead of TID
-				snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%s.png", tempfile);
-				if(!access(path, F_OK)){
-					// Boxart with fullname exist
-					continue;
-				}
 			}
 		}
 	}

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -459,7 +459,7 @@ void downloadSlot1BoxArt(const char* TID)
 	ba_TID[4] = 0;
 
 	char path[256];
-	snprintf(path, sizeof(path), "/_nds/twloader/boxart/%.4s.png", ba_TID);
+	snprintf(path, sizeof(path), "/_nds/twloader/boxart/flashcard/%.4s.png", ba_TID);
 	if (!access(path, F_OK)) {
 		// File already exists.
 		return;

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -598,6 +598,13 @@ void downloadBoxArt(void)
 			if (access(path, F_OK) != 0) {
 				// Boxart file does not exist. Download it.
 				boxart_dl_tids.push_back(tid);
+			}else{
+				// Maybe boxart exist with fullname instead of TID
+				snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%s.png", tempfile);
+				if(!access(path, F_OK)){
+					// Boxart with fullname exist
+					continue;
+				}
 			}
 		}
 	}

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -520,6 +520,14 @@ void downloadBoxArt(void)
 		if (!access(path, F_OK)) {
 			// Boxart file exists.
 			continue;
+		}else{
+			// Maybe boxart exist with fullname instead of TID
+			Log(tempfile);
+			snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%s.png", tempfile);
+			if(!access(path, F_OK)){
+				// Boxart with fullname exist
+				continue;
+			}
 		}
 
 		// Boxart file does not exist. Download it.

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -2754,7 +2754,7 @@ int main()
 									
 									break;
 							}
-						} else if (hDown & KEY_B) {
+						} else if (hDown & (KEY_B | KEY_START)) {
 							showdialogbox_menu = false;
 							menudbox_movespeed = 1;
 							menu_ctrlset = CTRL_SET_GAMESEL;
@@ -2821,7 +2821,7 @@ int main()
 									}
 									break;
 							}
-						} else if (hDown & KEY_B) {
+						} else if (hDown & (KEY_B | KEY_SELECT)) {
 							if (settings.twl.forwarder) {
 								rom = fcfiles.at(cursorPosition).c_str();
 							} else {

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1768,6 +1768,11 @@ int main()
 						snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size()); // Reload counter
 						boxarttexloaded = false; // Reload boxarts
 						bnricontexloaded = false; // Reload banner icons
+					
+						/** This is better than a glitched screen */
+						sf2d_start_frame(GFX_TOP, GFX_LEFT);
+						sf2d_end_frame();
+						sf2d_swapbuffers();
 					}
 				} else if (gbarunnervalue == 1) {
 					// run = false;

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1764,8 +1764,10 @@ int main()
 					
 					// Clear matching_files vector
 					if(matching_files.size() != 0) {
-						matching_files.clear();
-						snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
+						matching_files.clear(); // Clear filter
+						snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size()); // Reload counter
+						boxarttexloaded = false; // Reload boxarts
+						bnricontexloaded = false; // Reload banner icons
 					}
 				} else if (gbarunnervalue == 1) {
 					// run = false;

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -2742,6 +2742,7 @@ int main()
 									if (matching_files.size() != 0){
 										/** Prepare some stuff to show correctly the filtered roms */
 										
+										pagenum = 0; // Go to page 0
 										cursorPosition = 0; // Move the cursor to 0
 										storedcursorPosition = cursorPosition; // Move the cursor to 0
 										titleboxXmovepos = 0; // Move the cursor to 0

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1140,6 +1140,7 @@ int main()
 	mkdir("sdmc:/_nds/twloader/bnricons", 0777);
 	mkdir("sdmc:/_nds/twloader/bnricons/flashcard", 0777);
 	mkdir("sdmc:/_nds/twloader/boxart", 0777);
+	mkdir("sdmc:/_nds/twloader/cia", 0777);
 	//mkdir("sdmc:/_nds/twloader/tmp", 0777);
 
 	std::string	bootstrapPath = "";

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -956,9 +956,13 @@ static void drawMenuDialogBox(void)
 
 		char romsel_counter1[16];
 		char romsel_counter2[16];
-		snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", storedcursorPosition+1);
-		snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", file_count);
-
+		snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", storedcursorPosition+1);		
+		if(matching_files.size() == 0){
+			snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", file_count);
+		}else{
+			snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", matching_files.size());
+		}
+		
 		if (file_count < 100) {
 			sftd_draw_text(font, 16, 204+menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
 			sftd_draw_text(font, 35, 204+menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, "/");
@@ -1759,7 +1763,10 @@ int main()
 					bannertextloaded = false;
 					
 					// Clear matching_files vector
-					matching_files.clear();
+					if(matching_files.size() != 0) {
+						matching_files.clear();
+						snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
+					}
 				} else if (gbarunnervalue == 1) {
 					// run = false;
 					if (settings.twl.forwarder) {

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -2728,6 +2728,10 @@ int main()
 									if (matching_files.size() != 0){
 										/** Prepare some stuff to show correctly the filtered roms */
 										
+										cursorPosition = 0; // Move the cursor to 0
+										storedcursorPosition = cursorPosition; // Move the cursor to 0
+										titleboxXmovepos = 0; // Move the cursor to 0
+										boxartXmovepos = 0; // Move the cursor to 0
 										snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", matching_files.size()); // Reload counter
 										boxarttexloaded = false; // Reload boxarts
 										bnricontexloaded = false; // Reload banner icons

--- a/gui/source/settings.h
+++ b/gui/source/settings.h
@@ -81,6 +81,9 @@ typedef struct _Settings_t {
 		bool resetslot1;
 		int console;	// 0 = Off, 1 = On, 2 = On (Debug)
 		bool lockarm9scfgext;
+		
+		int mpuregion; // Region 0, 1, 2, 3
+		int mpusize; // Size 0, 1, 3145728
 	} twl;
 	
 	struct {


### PR DESCRIPTION
(first commits are updates for my fork. Do not know why are here tbh)

Changes:
-Add missing settings in setting struct
-Now, if your boxart for SD/Flashcard is `.nds.png` or `.ini.png`, auto download **WON'T** download it (because actually it is on sd)
-Fixed a crash on search function where rom filtered are less than current position. Now is solved.
-Fixed search counter after exiting settings and select menu rom counter
-Boxarts and icons are reloaded after cleaning search vector too
-Solve the glitch effect in settings after cleaning vector
-Fixed some bugs
-Now you can close dialogbox using B or Select/Start buttons.
-Create cia folder in `SD:\_nds\twloader\`