### PR TITLE
Remove some ini files

### DIFF
--- a/7zfile/sdroot/_nds/YSMenu.ini
+++ b/7zfile/sdroot/_nds/YSMenu.ini
@@ -1,4 +1,0 @@
-[YSMENU]
-AUTO_BOOT=/Games/rom.nds
-DEFAULT_DMA=true
-DEFAULT_RESET=false

--- a/7zfile/sdroot/_nds/dstwoautoboot.ini
+++ b/7zfile/sdroot/_nds/dstwoautoboot.ini
@@ -1,2 +1,0 @@
-[Dir Info]
-fullName = fat1:/Games/rom.nds

--- a/7zfile/sdroot/_nds/lastsave.ini
+++ b/7zfile/sdroot/_nds/lastsave.ini
@@ -1,2 +1,0 @@
-[Save Info]
-lastLoaded = fat0:/Games/rom.nds


### PR DESCRIPTION
All these files are automatically generated by twloader at runtime.
The only thing that doesn't is the dma and reset settings for ysmenu.

IF those are really needed the main.cpp should be modified to create those lines.