### PR TITLE
Improve perfomance and check if TWLNand version is installed or not

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -3,6 +3,7 @@ cd twlnand-side
 make
 patch_ndsheader_dsiware.py TWLapp-hb.nds --mode dsi --maker 01 --code TWLD --title "TWLOADER-TWL" --out TWLapp.nds
 make_cia --srl="TWLapp.nds"
+mkdir "../7zfile/sdroot/_nds/twloader/cia/"
 copy "TWLapp.cia" "../7zfile/sdroot/_nds/twloader/cia/TWLoader - TWLNAND side.cia"
 cd ..
 cd NTR_Launcher

--- a/flashcard-side/arm9/source/main.cpp
+++ b/flashcard-side/arm9/source/main.cpp
@@ -44,6 +44,8 @@
 
 using namespace std;
 
+bool logEnabled = false;
+
 //---------------------------------------------------------------------------------
 void stop (void) {
 //---------------------------------------------------------------------------------
@@ -135,10 +137,14 @@ int main(int argc, char **argv) {
 	std::string fcromfolder;
 	char fcfolder_path[256];
 	
-
+	/* Log file is dissabled by default. If _nds/twloader/log exist, we turn log file on, else, log is dissabled */
+	struct stat logBuf;
+	logEnabled = stat("sd:/_nds/twloader/log", &logBuf) == 0;
+	/* Log configuration file end */
+	
 	if (fatInitDefault()) {
 		CIniFile twloaderini( "sd:/_nds/twloader/settings.ini" );
-		LogFM("Flashcard.Main", "Fat inited");
+		if (logEnabled)	LogFM("Flashcard.Main", "Fat inited");
 
 		// overwrite reboot stub identifier
 		// extern u64 *fake_heap_end;
@@ -215,10 +221,10 @@ int main(int argc, char **argv) {
 
 			TWLDsNDSHeader NDSHeader;
 
-			LogFMA("Flashcard.Main", "Reading .NDS file:", filePath);
+			if (logEnabled)	LogFMA("Flashcard.Main", "Reading .NDS file:", filePath);
 			fseek ( ndsFile , 0 , SEEK_SET );
 			fread(&NDSHeader,1,sizeof(NDSHeader),ndsFile);
-			LogFMA("Flashcard.Main", ".NDS file read:", filePath);
+			if (logEnabled)	LogFMA("Flashcard.Main", ".NDS file read:", filePath);
 						
 			// Set banner path
 			free(bannerfilepath);
@@ -243,7 +249,7 @@ int main(int argc, char **argv) {
 					fread(&myBanner,1,sizeof(myBanner),ndsFile);
 					
 					iprintf ("Now caching banner data.\n");
-					LogFMA("Flashcard.Main", "Caching banner data:", NDSHeader.gameCode);
+					if (logEnabled)	LogFMA("Flashcard.Main", "Caching banner data:", NDSHeader.gameCode);
 					if (myBanner.version == 0x0103 || myBanner.version == 0x0003) {
 						fwrite(&myBanner,1,sizeof(myBanner),filetosave);
 					} else if (myBanner.version == 0x0002) {
@@ -252,8 +258,8 @@ int main(int argc, char **argv) {
 						fwrite(&myBanner,1,sizeof(myBannersize1),filetosave);
 					}
 
-					iprintf ("Banner data cached.\n");
-					LogFMA("Flashcard.Main", "Banner data cached:", NDSHeader.gameCode);
+					if (logEnabled)	iprintf ("Banner data cached.\n");
+					if (logEnabled)	LogFMA("Flashcard.Main", "Banner data cached:", NDSHeader.gameCode);
 					for (int i = 0; i < 60; i++) { swiWaitForVBlank(); }
 				} else {
 					iprintf ("Banner data doesn't exist.\n");
@@ -270,7 +276,7 @@ int main(int argc, char **argv) {
 				rominini.SetString("FLASHCARD-ROM", "NDS_PATH", filePath+5);
 				rominini.SetString("FLASHCARD-ROM", "TID", NDSHeader.gameCode);
 				iprintf (".ini file created.\n");
-				LogFMA("Flashcard.Main", ".ini file created:", NDSHeader.gameCode);
+				if (logEnabled)	LogFMA("Flashcard.Main", ".ini file created:", NDSHeader.gameCode);
 				rominini.SaveIniFile( inifilepathfixed );
 				for (int i = 0; i < 60; i++) { swiWaitForVBlank(); }
 			} else {

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -244,8 +244,18 @@ void DownloadTWLoaderCIAs(void) {
 	sf2d_end_frame();
 	sf2d_swapbuffers();	
 	
-	mkdir("sdmc:/_nds/twloader/cia", 0777);
-	int res = downloadFile(DOWNLOAD_TWLOADER_URL,"/_nds/twloader/cia/TWLoader.cia", MEDIA_SD_CIA);
+	int res;
+	
+	// Check if sdmc:/cia folder exist (most A9LH users have that folder already)
+	struct stat st;
+	if(stat("sdmc:/cia",&st) == 0){		
+		// Use root/cia folder instead
+		res = downloadFile(DOWNLOAD_TWLOADER_URL,"/cia/TWLoader.cia", MEDIA_SD_CIA);
+	}else{		
+		mkdir("sdmc:/_nds/twloader/cia", 0777); // Use twloader/cia folder instead
+		res = downloadFile(DOWNLOAD_TWLOADER_URL,"/_nds/twloader/cia/TWLoader.cia", MEDIA_SD_CIA);
+	}
+	
 	sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
 	if (screenmode == 1) {
 		sf2d_draw_texture(settingstex, 0, 0);
@@ -255,8 +265,13 @@ void DownloadTWLoaderCIAs(void) {
 		sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, "Now downloading latest TWLoader version...");
 		sftd_draw_textf(font, 12, 30, RGBA8(0, 0, 0, 255), 12, "(TWLNAND side CIA)");
 		sf2d_end_frame();
-		sf2d_swapbuffers();
-		res = downloadFile(DOWNLOAD_TWLNANDSIDE_URL,"/_nds/twloader/cia/TWLoader - TWLNAND side.cia", MEDIA_NAND_CIA);
+		sf2d_swapbuffers();		
+		if(stat("sdmc:/cia",&st) == 0){		
+			// Use root/cia folder instead
+			res = downloadFile(DOWNLOAD_TWLNANDSIDE_URL,"/cia/TWLoader - TWLNAND side.cia", MEDIA_NAND_CIA);
+		}else{		
+			res = downloadFile(DOWNLOAD_TWLNANDSIDE_URL,"/_nds/twloader/cia/TWLoader - TWLNAND side.cia", MEDIA_NAND_CIA);
+		}
 		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
 		if (screenmode == 1) {
 			sf2d_draw_texture(settingstex, 0, 0);

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -34,6 +34,7 @@ extern bool showdialogbox;
 extern bool run;	// Set to false to exit to the Home Menu.
 extern std::string settings_releasebootstrapver;
 extern std::string settings_unofficialbootstrapver;
+extern bool logEnabled;
 
 extern int screenmode;
 // 0: ROM select
@@ -70,10 +71,10 @@ bool checkWifiStatus(void) {
 	bool res = false;
 
 	if (R_SUCCEEDED(ACU_GetWifiStatus(&wifiStatus)) && wifiStatus) {
-		LogFMA("WifiStatus", "Active internet connection found", RetTime().c_str());
+		if (logEnabled)	LogFMA("WifiStatus", "Active internet connection found", RetTime().c_str());
 		res = true;
 	} else {
-		LogFMA("WifiStatus", "No Internet connection found!", RetTime().c_str());
+		if (logEnabled)	LogFMA("WifiStatus", "No Internet connection found!", RetTime().c_str());
 	}
 
 	return res;
@@ -175,7 +176,7 @@ int downloadFile(const char* url, const char* file, MediaType mediaType) {
  * @return 0 if an update is available; non-zero if up to date or an error occurred.
  */
 int checkUpdate(void) {
-	LogFM("checkUpdate", "Checking updates...");
+	if (logEnabled)	LogFM("checkUpdate", "Checking updates...");
 	static const char title[] = "Now checking TWLoader version...";
 	DialogBoxAppear(title, 0);
 	sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
@@ -188,7 +189,7 @@ int checkUpdate(void) {
 	sf2d_swapbuffers();
 
 	int res = downloadFile(DOWNLOAD_VER_URL, "/_nds/twloader/ver", MEDIA_SD_FILE);
-	LogFM("checkUpdate", "downloadFile() end");
+	if (logEnabled)	LogFM("checkUpdate", "downloadFile() end");
 	if (res == 0) {
 		sVerfile Verfile;
 
@@ -203,8 +204,8 @@ int checkUpdate(void) {
 			strcpy(settings_latestvertext, "Unknown");
 			isUnknown = true;
 		}
-		LogFMA("checkUpdate", "Reading downloaded version:", settings_latestvertext);
-		LogFMA("checkUpdate", "Reading ROMFS version:", settings_vertext);
+		if (logEnabled)	LogFMA("checkUpdate", "Reading downloaded version:", settings_latestvertext);
+		if (logEnabled)	LogFMA("checkUpdate", "Reading ROMFS version:", settings_vertext);
 
 		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
 		if (screenmode == 1) {
@@ -213,7 +214,7 @@ int checkUpdate(void) {
 		sf2d_draw_texture(dialogboxtex, 0, 0);
 		if (!isUnknown && !strcmp(settings_latestvertext, settings_vertext)) {
 			// Version is different.
-			LogFMA("checkUpdate", "Comparing...", "Are equals");
+			if (logEnabled)	LogFMA("checkUpdate", "Comparing...", "Are equals");
 		
 			if (screenmode == 1) {				
 				showdialogbox = false;
@@ -222,14 +223,14 @@ int checkUpdate(void) {
 				sf2d_swapbuffers();
 			}
 			
-			LogFM("checkUpdate", "TWLoader is up-to-date!");			
+			if (logEnabled)	LogFM("checkUpdate", "TWLoader is up-to-date!");			
 			return -1;
 		}
-		LogFMA("checkUpdate", "Comparing...", "NO equals");
+		if (logEnabled)	LogFMA("checkUpdate", "Comparing...", "NO equals");
 		showdialogbox = false;
 		return 0;
 	}
-	LogFM("checkUpdate", "Problem downloading ver file!");
+	if (logEnabled)	LogFM("checkUpdate", "Problem downloading ver file!");
 	showdialogbox = false;
 	return -1;
 }
@@ -443,7 +444,7 @@ static int downloadBoxArt_internal(const char *ba_TID)
 {
 	char path[256];
 	char http_url[256];
-	LogFMA("downloadBoxArt_internal", "Downloading boxart for TID", ba_TID);
+	if (logEnabled)	LogFMA("downloadBoxArt_internal", "Downloading boxart for TID", ba_TID);
 
 	const char *ba_region_fallback = NULL;
 	const char *ba_region = getGameTDBRegion(ba_TID[3], &ba_region_fallback);
@@ -581,7 +582,7 @@ void checkBootstrapVersion(void){
  */
 void downloadSlot1BoxArt(const char* TID)
 {
-	LogFM("Main.downloadSlot1BoxArt", "Checking box art (Slot-1 card).");
+	if (logEnabled)	LogFM("Main.downloadSlot1BoxArt", "Checking box art (Slot-1 card).");
 	
 	char ba_TID[5];
 	snprintf(ba_TID, sizeof(ba_TID), "%.4s", TID);
@@ -594,7 +595,7 @@ void downloadSlot1BoxArt(const char* TID)
 		return;
 	}
 
-	LogFM("Main.downloadSlot1BoxArt", "Downloading box art (Slot-1 card)");
+	if (logEnabled)	LogFM("Main.downloadSlot1BoxArt", "Downloading box art (Slot-1 card)");
 	downloadBoxArt_internal(ba_TID);
 }
 
@@ -610,7 +611,7 @@ void downloadBoxArt(void)
 	vector<u32> boxart_dl_tids;	// Title IDs of boxart to download.
 	boxart_all_tids.reserve(files.size() + fcfiles.size());
 	boxart_dl_tids.reserve(files.size() + fcfiles.size());
-	LogFM("Download.downloadBoxArt", "Checking missing boxart on SD card...");
+	if (logEnabled)	LogFM("Download.downloadBoxArt", "Checking missing boxart on SD card...");
 
 	// Check if we're missing any boxart for ROMs on the SD card.
 	for (size_t boxartnum = 0; boxartnum < files.size(); boxartnum++) {
@@ -621,7 +622,7 @@ void downloadBoxArt(void)
 		if (!f_nds_file)
 			continue;
 		
-		LogFMA("DownloadBoxArt.SD CARD", "Path: ", path);
+		if (logEnabled)	LogFMA("DownloadBoxArt.SD CARD", "Path: ", path);
 		char ba_TID[5];
 		grabTID(f_nds_file, ba_TID);
 		ba_TID[4] = 0;
@@ -675,7 +676,7 @@ void downloadBoxArt(void)
 			continue;
 		}
 		
-		LogFMA("DownloadBoxArt.FLASHCARD", "TID: ", ba_TID.c_str());		
+		if (logEnabled)	LogFMA("DownloadBoxArt.FLASHCARD", "TID: ", ba_TID.c_str());		
 		// Did we already check for this boxart?
 		// NOTE: Storing byteswapped in order to sort correctly.
 		u32 tid;
@@ -733,10 +734,10 @@ void downloadBoxArt(void)
 		}
 	}
 	
-	LogFM("DownloadBoxArt.Read_BoxArt", "Boxart read correctly.");
+	if (logEnabled)	LogFM("DownloadBoxArt.Read_BoxArt", "Boxart read correctly.");
 	if (boxart_dl_tids.empty()) {
 		// No boxart to download.
-		LogFM("Download.downloadBoxArt", "No boxart to download.");
+		if (logEnabled)	LogFM("Download.downloadBoxArt", "No boxart to download.");
 		return;
 	}
 
@@ -746,7 +747,7 @@ void downloadBoxArt(void)
 	// Download the boxart.
 	char s_boxart_total[12];
 	snprintf(s_boxart_total, sizeof(s_boxart_total), "%zu", boxart_dl_tids.size());
-	LogFM("DownloadBoxArt.downloading_process", "Downloading missing boxart");
+	if (logEnabled)	LogFM("DownloadBoxArt.downloading_process", "Downloading missing boxart");
 	for (size_t boxartnum = 0; boxartnum < boxart_dl_tids.size(); boxartnum++) {
 		static const char title[] = "Downloading missing boxart...";
 

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -216,6 +216,7 @@ static const char fcboxartfolder[] = "sdmc:/_nds/twloader/boxart/flashcard";
 bool keepsdvalue = false;
 int gbarunnervalue = 0;
 
+bool logEnabled = false;
 
 static std::string ReplaceAll(std::string str, const std::string& from, const std::string& to) {
     size_t start_pos = 0;
@@ -469,7 +470,7 @@ static int RainbowLED(void) {
 		return -1;
 	ptmsysmSetInfoLedPattern(&pat);
 	ptmsysmExit();
-	LogFM("Main.RainbowLED", "Rainbow LED is on");
+	if (logEnabled)	LogFM("Main.RainbowLED", "Rainbow LED is on");
 	return 0;
 }
 
@@ -562,7 +563,7 @@ static void LoadBootstrapConfig(void)
 			settings.twl.console = 0;
 			break;
 	}
-	LogFM("Main.LoadBootstrapConfig", "Bootstrap configuration loaded successfully");
+	if (logEnabled)	LogFM("Main.LoadBootstrapConfig", "Bootstrap configuration loaded successfully");
 }
 
 /**
@@ -628,7 +629,7 @@ static void LoadPerGameSettings(void)
 	settings.pergame.extvram = gamesettingsini.GetInt("GAME-SETTINGS", "TWL_VRAM", -1);
 	settings.pergame.lockarm9scfgext = gamesettingsini.GetInt("GAME-SETTINGS", bootstrapini_lockarm9scfgext, -1);
 
-	LogFM("Main.SavePerGameSettings", "Per-game settings loaded successfully");
+	if (logEnabled)	LogFM("Main.SavePerGameSettings", "Per-game settings loaded successfully");
 }
 
 /**
@@ -651,7 +652,7 @@ static void SavePerGameSettings(void)
 	gamesettingsini.SetInt("GAME-SETTINGS", "TWL_VRAM", settings.pergame.extvram);
 	gamesettingsini.SetInt("GAME-SETTINGS", bootstrapini_lockarm9scfgext, settings.pergame.lockarm9scfgext);
 	gamesettingsini.SaveIniFile(path);
-	LogFM("Main.SavePerGameSettings", "Per-game settings saved successfully");
+	if (logEnabled)	LogFM("Main.SavePerGameSettings", "Per-game settings saved successfully");
 }
 
 /**
@@ -882,14 +883,14 @@ static void loadSlot1BoxArt(void)
 		}
 		char path[256];
 		// example: ASME.png
-		LogFMA("Main", "Loading Slot-1 box art", gameID);
+		if (logEnabled)	LogFMA("Main", "Loading Slot-1 box art", gameID);
 		snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, gameID);
 		if (access(path, F_OK) != -1) {
 			new_tex = sfil_load_PNG_file(path, SF2D_PLACE_RAM);
 		} else {
 			new_tex = sfil_load_PNG_file("romfs:/graphics/boxart_unknown.png", SF2D_PLACE_RAM);
 		}
-		LogFMA("Main", "Done loading Slot-1 box art", gameID);
+		if (logEnabled)	LogFMA("Main", "Done loading Slot-1 box art", gameID);
 	} else {
 		// No cartridge, or unrecognized cartridge.
 		new_tex = sfil_load_PNG_file("romfs:/graphics/boxart_null.png", SF2D_PLACE_RAM);
@@ -1143,7 +1144,12 @@ int main()
 	hidInit();
 	acInit();
 	
-	createLog();
+	/* Log file is dissabled by default. If _nds/twloader/log exist, we turn log file on, else, log is dissabled */
+	struct stat logBuf;
+	logEnabled = stat("sdmc:/_nds/twloader/log", &logBuf) == 0;
+	/* Log configuration file end */ 
+	
+	if (logEnabled)	createLog();
 
 	// make folders if they don't exist
 	mkdir("sdmc:/_nds", 0777);
@@ -1162,7 +1168,7 @@ int main()
 	font_b = sftd_load_font_file("romfs:/fonts/FOT-RodinBokutoh Pro DB.otf");
 	sftd_draw_text(font, 0, 0, RGBA8(0, 0, 0, 255), 16, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890&:-.'!?()\"end"); //Hack to avoid blurry text!
 	sftd_draw_text(font_b, 0, 0, RGBA8(0, 0, 0, 255), 24, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890&:-.'!?()\"end"); //Hack to avoid blurry text!	
-	LogFM("Main.Font loading", "Fonts load correctly");
+	if (logEnabled)	LogFM("Main.Font loading", "Fonts load correctly");
 	
 	sVerfile Verfile;
 	
@@ -1170,7 +1176,7 @@ int main()
 	fread(&Verfile,1,sizeof(Verfile),VerFile);
 	strcpy(settings_vertext, Verfile.text);
 	fclose(VerFile);
-	LogFMA("Main.Verfile (ROMFS)", "Successful reading ver from ROMFS",Verfile.text);
+	if (logEnabled)	LogFMA("Main.Verfile (ROMFS)", "Successful reading ver from ROMFS",Verfile.text);
 
 	LoadSettings();	
 	bootstrapPath = settings.twl.bootstrapfile ? "fat:/_nds/release-bootstrap.nds" : "fat:/_nds/unofficial-bootstrap.nds";	
@@ -1231,23 +1237,23 @@ int main()
 	sf2d_texture *bracetex = sfil_load_PNG_file("romfs:/graphics/brace.png", SF2D_PLACE_RAM); // Brace (C-shaped thingy)
 	sf2d_texture *bubbletex = sfil_load_PNG_file("romfs:/graphics/bubble.png", SF2D_PLACE_RAM); // Text bubble
 
-	LogFM("Main.sf2d_textures", "Textures load successfully");
+	if (logEnabled)	LogFM("Main.sf2d_textures", "Textures load successfully");
 
 	dspfirmfound = false;
  	if( access( "sdmc:/3ds/dspfirm.cdc", F_OK ) != -1 ) {
 		ndspInit();
 		dspfirmfound = true;
-		LogFM("Main.dspfirm", "DSP Firm found!");
+		if (logEnabled)	LogFM("Main.dspfirm", "DSP Firm found!");
 	}else{
-		LogFM("Main.dspfirm", "DSP Firm not found");
+		if (logEnabled)	LogFM("Main.dspfirm", "DSP Firm not found");
 	}
 
 	bool musicbool = false;
 	if( access( "sdmc:/_nds/twloader/music.wav", F_OK ) != -1 ) {
 		musicpath = "sdmc:/_nds/twloader/music.wav";
-		LogFM("Main.music", "Custom music file found!");
+		if (logEnabled)	LogFM("Main.music", "Custom music file found!");
 	}else {
-		LogFM("Main.dspfirm", "No music file found");
+		if (logEnabled)	LogFM("Main.dspfirm", "No music file found");
 	}
 
 	// Load the sound effects if DSP is available.
@@ -1267,11 +1273,11 @@ int main()
 
 	char romsel_counter2sd[16];	// Number of ROMs on the SD card.
 	snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
-	LogFMA("Main. ROM scanning", "Number of ROMs on the SD card detected", romsel_counter2sd);
+	if (logEnabled)	LogFMA("Main. ROM scanning", "Number of ROMs on the SD card detected", romsel_counter2sd);
 	
 	char romsel_counter2fc[16];	// Number of ROMs on the flash card.
 	snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size());
-	LogFMA("Main. ROM scanning", "Number of ROMs on the flashcard detected", romsel_counter2fc);
+	if (logEnabled)	LogFMA("Main. ROM scanning", "Number of ROMs on the flashcard detected", romsel_counter2fc);
 	
 	// Download box art
 	if (checkWifiStatus()) {
@@ -1280,7 +1286,7 @@ int main()
 
 	// Cache banner data for ROMs on the SD card.
 	// TODO: Re-cache if it's 0 bytes?
-	Log("********************************************************\n");
+	if (logEnabled)	Log("********************************************************\n");
 	for (bnriconnum = 0; bnriconnum < (int)files.size(); bnriconnum++) {
 		static const char title[] = "Now checking if banner data exists (SD Card)...";
 		char romsel_counter1[16];
@@ -1302,8 +1308,14 @@ int main()
 		FILE *f_nds_file = fopen(nds_path, "rb");
 		if (!f_nds_file)
 			continue;
-		LogFMA("Main. Banner scanning", "Trying to read banner from file", nds_path);
-		cacheBanner(f_nds_file, tempfile, font) == 0 ? LogFM("Main. Banner scanning", "Done!") : LogFM("Main. Banner scanning", "Error!");			
+		if (logEnabled)	LogFMA("Main. Banner scanning", "Trying to read banner from file", nds_path);
+		
+		if(cacheBanner(f_nds_file, tempfile, font) == 0) {
+			if (logEnabled)	LogFM("Main. Banner scanning", "Done!");
+		}else {
+			if (logEnabled)	LogFM("Main. Banner scanning", "Error!");
+		}
+		
 		fclose(f_nds_file);
 	}
 
@@ -1920,7 +1932,7 @@ int main()
 							}
 						}
 					}
-					LogFM("Main.applaunchprep", "Switching to NTR/TWL-mode");
+					if (logEnabled)	LogFM("Main.applaunchprep", "Switching to NTR/TWL-mode");
 					applaunchon = true;
 				}
 			}
@@ -2157,7 +2169,7 @@ int main()
 							}
 						}
 					}
-					LogFM("Main.applaunchprep", "Switching to NTR/TWL-mode");
+					if (logEnabled)	LogFM("Main.applaunchprep", "Switching to NTR/TWL-mode");
 					applaunchon = true;
 				}
 			}
@@ -2847,7 +2859,7 @@ int main()
 								}
 								
 								std::string gameName = keyboardInput("Use the keyboard to find roms");
-								LogFMA("Main.search","Text written", gameName.c_str());
+								if (logEnabled)	LogFMA("Main.search","Text written", gameName.c_str());
 								
 								if (!gameName.empty()){
 									for (auto iter = files.cbegin(); iter != files.cend(); ++iter) {
@@ -2937,7 +2949,7 @@ int main()
 									}
 									
 									std::string gameName = keyboardInput("Use the keyboard to find roms");
-									LogFMA("Main.search","Text written", gameName.c_str());
+									if (logEnabled)	LogFMA("Main.search","Text written", gameName.c_str());
 									
 									if (!gameName.empty()){
 										for (auto iter = files.cbegin(); iter != files.cend(); ++iter) {

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -2848,32 +2848,37 @@ int main()
 								
 								std::string gameName = keyboardInput("Use the keyboard to find roms");
 								LogFMA("Main.search","Text written", gameName.c_str());
-																	
-								for (auto iter = files.cbegin(); iter != files.cend(); ++iter) {
-									if (iter->size() < gameName.size()) {
-										// Filename we're checking is shorter than the search term,
-										// so it can't match.
-										continue;
+								
+								if (!gameName.empty()){
+									for (auto iter = files.cbegin(); iter != files.cend(); ++iter) {
+										if (iter->size() < gameName.size()) {
+											// Filename we're checking is shorter than the search term,
+											// so it can't match.
+											continue;
+										}
+										// Use C string comparison for case-insensitive checks.
+										if (compareString(iter->c_str(), gameName.c_str())){
+											// String matches.
+											matching_files.push_back(*iter);
+										}
 									}
-									// Use C string comparison for case-insensitive checks.
-									if (compareString(iter->c_str(), gameName.c_str())){
-										// String matches.
-										matching_files.push_back(*iter);
+									if (matching_files.size() != 0){
+										/** Prepare some stuff to show correctly the filtered roms */
+										
+										pagenum = 0; // Go to page 0
+										cursorPosition = 0; // Move the cursor to 0
+										storedcursorPosition = cursorPosition; // Move the cursor to 0
+										titleboxXmovepos = 0; // Move the cursor to 0
+										boxartXmovepos = 0; // Move the cursor to 0
+										snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", matching_files.size()); // Reload counter
+										boxarttexloaded = false; // Reload boxarts
+										bnricontexloaded = false; // Reload banner icons
 									}
 								}
-								if (matching_files.size() != 0){
-									/** Prepare some stuff to show correctly the filtered roms */
-									
-									pagenum = 0; // Go to page 0
-									cursorPosition = 0; // Move the cursor to 0
-									storedcursorPosition = cursorPosition; // Move the cursor to 0
-									titleboxXmovepos = 0; // Move the cursor to 0
-									boxartXmovepos = 0; // Move the cursor to 0
-									snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", matching_files.size()); // Reload counter
-									boxarttexloaded = false; // Reload boxarts
-									bnricontexloaded = false; // Reload banner icons
-								}
-								sf2d_draw_texture(dboxtex_button, 161, menudbox_Ypos + 111); // Light the button to print it always								
+								sf2d_draw_texture(dboxtex_button, 161, menudbox_Ypos + 111); // Light the button to print it always
+								showdialogbox_menu = false;
+								menudbox_movespeed = 1;
+								menu_ctrlset = CTRL_SET_GAMESEL;			
 							}else if (touch_x >= 233 && touch_x <= 299 && touch_y >= (menudbox_Ypos + 191) && touch_y <= (menudbox_Ypos + 217)){ // Back button
 								showdialogbox_menu = false;
 								menudbox_movespeed = 1;
@@ -2933,32 +2938,36 @@ int main()
 									
 									std::string gameName = keyboardInput("Use the keyboard to find roms");
 									LogFMA("Main.search","Text written", gameName.c_str());
-																		
-									for (auto iter = files.cbegin(); iter != files.cend(); ++iter) {
-										if (iter->size() < gameName.size()) {
-											// Filename we're checking is shorter than the search term,
-											// so it can't match.
-											continue;
+									
+									if (!gameName.empty()){
+										for (auto iter = files.cbegin(); iter != files.cend(); ++iter) {
+											if (iter->size() < gameName.size()) {
+												// Filename we're checking is shorter than the search term,
+												// so it can't match.
+												continue;
+											}
+											// Use C string comparison for case-insensitive checks.
+											if (compareString(iter->c_str(), gameName.c_str())){
+												// String matches.
+												matching_files.push_back(*iter);
+											}
 										}
-										// Use C string comparison for case-insensitive checks.
-										if (compareString(iter->c_str(), gameName.c_str())){
-											// String matches.
-											matching_files.push_back(*iter);
+										if (matching_files.size() != 0){
+											/** Prepare some stuff to show correctly the filtered roms */
+											
+											pagenum = 0; // Go to page 0
+											cursorPosition = 0; // Move the cursor to 0
+											storedcursorPosition = cursorPosition; // Move the cursor to 0
+											titleboxXmovepos = 0; // Move the cursor to 0
+											boxartXmovepos = 0; // Move the cursor to 0
+											snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", matching_files.size()); // Reload counter
+											boxarttexloaded = false; // Reload boxarts
+											bnricontexloaded = false; // Reload banner icons
 										}
 									}
-									
-									if (matching_files.size() != 0){
-										/** Prepare some stuff to show correctly the filtered roms */
-										
-										pagenum = 0; // Go to page 0
-										cursorPosition = 0; // Move the cursor to 0
-										storedcursorPosition = cursorPosition; // Move the cursor to 0
-										titleboxXmovepos = 0; // Move the cursor to 0
-										boxartXmovepos = 0; // Move the cursor to 0
-										snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", matching_files.size()); // Reload counter
-										boxarttexloaded = false; // Reload boxarts
-										bnricontexloaded = false; // Reload banner icons
-									}									
+									showdialogbox_menu = false;
+									menudbox_movespeed = 1;
+									menu_ctrlset = CTRL_SET_GAMESEL;
 									break;
 								}
 							}

--- a/gui/source/ndsheaderbanner.cpp
+++ b/gui/source/ndsheaderbanner.cpp
@@ -12,6 +12,8 @@ using std::string;
 using std::vector;
 using std::wstring;
 
+extern bool logEnabled;
+
 /**
  * Convert a color from NDS BGR555 to RGB5A1.
  * @param px16 BGR555 color value.
@@ -145,11 +147,11 @@ int cacheBanner(FILE* ndsFile, const char* filename, sftd_font* setfont) {
 		return 0;
 	}
 
-	LogFMA("NDSBannerHeader.cacheBanner", "Reading .NDS file:", filename);
+	if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Reading .NDS file:", filename);
 	sNDSHeader NDSHeader;
 	fseek(ndsFile, 0, SEEK_SET);
 	fread(&NDSHeader, 1, sizeof(NDSHeader), ndsFile);
-	LogFMA("NDSBannerHeader.cacheBanner", ".NDS file read:", filename);
+	if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", ".NDS file read:", filename);
 
 	sNDSBanner ndsBanner;
 	memset(&ndsBanner, 0, sizeof(ndsBanner));
@@ -162,7 +164,7 @@ int cacheBanner(FILE* ndsFile, const char* filename, sftd_font* setfont) {
 		sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Now caching banner data (SD Card)...");
 		sf2d_end_frame();
 		sf2d_swapbuffers();
-		LogFMA("NDSBannerHeader.cacheBanner", "Caching banner data:", bannerpath);
+		if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Caching banner data:", bannerpath);
 
 		switch (ndsBanner.version) {
 			case NDS_BANNER_VER_DSi:
@@ -185,7 +187,7 @@ int cacheBanner(FILE* ndsFile, const char* filename, sftd_font* setfont) {
 		sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Now caching banner data (SD Card)...");
 		sf2d_end_frame();
 		sf2d_swapbuffers();
-		LogFMA("NDSBannerHeader.cacheBanner", "Caching banner data (empty):", bannerpath);
+		if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Caching banner data (empty):", bannerpath);
 		// notextbanner is v0003 (ZH/KO)
 		bannersize = NDS_BANNER_SIZE_ZH_KO;
 		fread(&ndsBanner, 1, bannersize, nobannerFile);
@@ -194,7 +196,7 @@ int cacheBanner(FILE* ndsFile, const char* filename, sftd_font* setfont) {
 
 	if (bannersize == 0) {
 		// Invalid banner.
-		LogFMA("NDSBannerHeader.cacheBanner", "Failed to open NDS source file:", filename);
+		if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Failed to open NDS source file:", filename);
 		sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Invalid banner loaded; not caching.");
 		sf2d_end_frame();
 		sf2d_swapbuffers();
@@ -205,7 +207,7 @@ int cacheBanner(FILE* ndsFile, const char* filename, sftd_font* setfont) {
 	FILE* filetosave = fopen(bannerpath, "wb");
 	if (!filetosave) {
 		// Error opening the banner cache file.
-		LogFMA("NDSBannerHeader.cacheBanner", "Failed to write banner cache file:", bannerpath);
+		if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Failed to write banner cache file:", bannerpath);
 		sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Error writing the banner cache file.");
 		sf2d_end_frame();
 		sf2d_swapbuffers();
@@ -213,7 +215,7 @@ int cacheBanner(FILE* ndsFile, const char* filename, sftd_font* setfont) {
 	}
 	fwrite(&ndsBanner, 1, bannersize, filetosave);
 	fclose(filetosave);
-	LogFMA("NDSBannerHeader.cacheBanner", "Banner data cached:", bannerpath);
+	if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Banner data cached:", bannerpath);
 	return 0;
 }
 

--- a/gui/source/settings.cpp
+++ b/gui/source/settings.cpp
@@ -51,6 +51,7 @@ extern std::string settings_unofficialbootstrapver;
 
 extern bool keepsdvalue;
 extern int gbarunnervalue;
+extern bool logEnabled;
 
 // Sound effects from main.cpp.
 extern sound *sfx_select;
@@ -1076,7 +1077,7 @@ void LoadColor(void) {
 	if (settings.ui.color < 0 || settings.ui.color > 18)
 		settings.ui.color = 0;
 	color_data = &colors[settings.ui.color];
-	LogFM("LoadColor()", "Colors load successfully");
+	if (logEnabled)	LogFM("LoadColor()", "Colors load successfully");
 }
 
 /**
@@ -1106,7 +1107,7 @@ void LoadMenuColor(void) {
 	if (settings.ui.menucolor < 0 || settings.ui.menucolor > 16)
 		settings.ui.menucolor = 0;
 	menucolor = menu_colors[settings.ui.menucolor];
-	LogFM("LoadMenuColor()", "Menu color load successfully");
+	if (logEnabled)	LogFM("LoadMenuColor()", "Menu color load successfully");
 }
 
 /**
@@ -1118,10 +1119,10 @@ void LoadBottomImage() {
 	if (settings.ui.custombot == 1) {
 		if( access( "sdmc:/_nds/twloader/bottom.png", F_OK ) != -1 ) {
 			bottomloc = "sdmc:/_nds/twloader/bottom.png";
-			LogFM("LoadBottomImage()", "Using custom bottom image. Method load successfully");
+			if (logEnabled)	LogFM("LoadBottomImage()", "Using custom bottom image. Method load successfully");
 		} else {
 			bottomloc = "romfs:/graphics/bottom.png";
-			LogFM("LoadBottomImage()", "Using default bottom image. Method load successfully");
+			if (logEnabled)	LogFM("LoadBottomImage()", "Using default bottom image. Method load successfully");
 		}
 	}
 }
@@ -1186,7 +1187,7 @@ void LoadSettings(void) {
 			settings.twl.console = 0;
 			break;
 	}
-	LogFM("Settings.LoadSettings", "Settings loaded successfully");
+	if (logEnabled)	LogFM("Settings.LoadSettings", "Settings loaded successfully");
 }
 
 /**

--- a/twlnand-side/arm9/source/main.cpp
+++ b/twlnand-side/arm9/source/main.cpp
@@ -38,6 +38,8 @@
 
 using namespace std;
 
+bool logEnabled = false;
+
 //---------------------------------------------------------------------------------
 void stop (void) {
 //---------------------------------------------------------------------------------
@@ -122,6 +124,11 @@ int main(int argc, char **argv) {
 
 	bool consoleOn = false;
 
+	/* Log file is dissabled by default. If _nds/twloader/log exist, we turn log file on, else, log is dissabled */
+	struct stat logBuf;
+	logEnabled = stat("sd:/_nds/twloader/log", &logBuf) == 0;
+	/* Log configuration file end */
+	
 	/* scanKeys();
 	int pressed = keysDown(); */
 
@@ -144,11 +151,11 @@ int main(int argc, char **argv) {
 				p[i*2/2] = p[i*2];
 		}
 		
-		LogFMA("TWL.Main", "Got username", p);
+		if (logEnabled)	LogFMA("TWL.Main", "Got username", p);
 		
 		twloaderini.SetString("FRONTEND","NAME", p);
 		twloaderini.SaveIniFile( "sd:/_nds/twloader/settings.ini" );
-		LogFMA("TWL.Main", "Saved username to GUI", p);
+		if (logEnabled)	LogFMA("TWL.Main", "Saved username to GUI", p);
 		
 		gamesettingsPath = twloaderini.GetString( "TWL-MODE", "GAMESETTINGS_PATH", "");
 		
@@ -198,7 +205,7 @@ int main(int argc, char **argv) {
 		if(twloaderini.GetInt("TWL-MODE","GBARUNNER",0) == 0)
 			if(twloaderini.GetInt("TWL-MODE","BOOT_ANIMATION",0) == 1) {
 				BootSplashInit(UseNTRSplash, HealthandSafety_MSG, PersonalData->language);
-				LogFM("TWL.Main.BootSplashInit", "Boot splash played");
+				if (logEnabled)	LogFM("TWL.Main.BootSplashInit", "Boot splash played");
 			}
 		if(twloaderini.GetInt("TWL-MODE","DEBUG",0) != -1) {
 			consoleDemoInit();
@@ -206,14 +213,14 @@ int main(int argc, char **argv) {
 		}
 		if(!UseNTRSplash) {
 			REG_SCFG_CLK |= 0x1;
-			LogFM("TWL.Main", "ARM9 CPU Speed set to 133mhz(TWL)");
+			if (logEnabled)	LogFM("TWL.Main", "ARM9 CPU Speed set to 133mhz(TWL)");
 			if(twloaderini.GetInt("TWL-MODE","DEBUG",0) == 1) {
 				printf("TWL_CLOCK ON\n");		
 			}
 		} else {
 			REG_SCFG_CLK = 0x80;
 			fifoSendValue32(FIFO_USER_04, 1);
-			LogFM("TWL.Main", "ARM9 CPU Speed set to 67mhz(NTR)");
+			if (logEnabled)	LogFM("TWL.Main", "ARM9 CPU Speed set to 67mhz(NTR)");
 		}
 
 		if(twloaderini.GetInt("TWL-MODE","BOOT_ANIMATION",0) == 0) {
@@ -232,14 +239,14 @@ int main(int argc, char **argv) {
 			if(twloaderini.GetInt("TWL-MODE","FORWARDER",0) == 1) {
 				if(twloaderini.GetInt("TWL-MODE","FLASHCARD",0) == 0 || twloaderini.GetInt("TWL-MODE","FLASHCARD",0) == 1 || twloaderini.GetInt("TWL-MODE","FLASHCARD",0) == 2 || twloaderini.GetInt("TWL-MODE","FLASHCARD",0) == 4) {} else {
 					fifoSendValue32(FIFO_USER_02, 1);
-					LogFM("TWL.Main", "Reset Slot-1 ON");
+					if (logEnabled)	LogFM("TWL.Main", "Reset Slot-1 ON");
 					if(twloaderini.GetInt("TWL-MODE","DEBUG",0) == 1) {
 						printf("RESET_SLOT1 ON\n");		
 					}
 				}
 			} else {
 				fifoSendValue32(FIFO_USER_02, 1);
-				LogFM("TWL.Main", "Reset Slot-1 ON");
+				if (logEnabled)	LogFM("TWL.Main", "Reset Slot-1 ON");
 				if(twloaderini.GetInt("TWL-MODE","DEBUG",0) == 1) {
 					printf("RESET_SLOT1 ON\n");		
 				}
@@ -266,7 +273,7 @@ int main(int argc, char **argv) {
 		
 		if(TWLVRAM) {
 			REG_SCFG_EXT |= 0x2000;
-			LogFM("TWL.Main", "VRAM boost on");
+			if (logEnabled)	LogFM("TWL.Main", "VRAM boost on");
 			if(twloaderini.GetInt("TWL-MODE","DEBUG",0) == 1) {
 				printf("TWL_VRAM ON\n");		
 			}
@@ -280,7 +287,7 @@ int main(int argc, char **argv) {
 		if(twloaderini.GetInt("TWL-MODE","LAUNCH_SLOT1",0) == 1) {
 			if(twloaderini.GetInt("TWL-MODE","DEBUG",0) != -1) {
 				printf("Now booting Slot-1 card\n");					
-				LogFM("TWL.Main", "Now booting Slot-1 card");
+				if (logEnabled)	LogFM("TWL.Main", "Now booting Slot-1 card");
 			}
 		}
 		if(twloaderini.GetInt("TWL-MODE","FORWARDER",0) == 1) {
@@ -300,7 +307,7 @@ int main(int argc, char **argv) {
 		}
 		
 		if(twloaderini.GetInt("TWL-MODE","LAUNCH_SLOT1",0) == 0) {
-			LogFM("TWL.Main", "Now booting bootstrap");
+			if (logEnabled)	LogFM("TWL.Main", "Now booting bootstrap");
 			if(twloaderini.GetInt("TWL-MODE","DEBUG",0) != -1) {
 				printf("Now booting bootstrap\n");					
 			}

--- a/twlnand-side/clean and make.bat
+++ b/twlnand-side/clean and make.bat
@@ -3,5 +3,6 @@ make clean
 make
 patch_ndsheader_dsiware.py TWLapp-hb.nds --mode dsi --maker 01 --code TWLD --title "TWLOADER-TWL" --out TWLapp.nds
 make_cia --srl="TWLapp.nds"
+mkdir "../7zfile/sdroot/_nds/twloader/cia/"
 copy "TWLapp.cia" "../7zfile/sdroot/_nds/twloader/cia/TWLoader - TWLNAND side.cia"
 pause


### PR DESCRIPTION
Log file is dissabled by default because 99% users doesn't need a log file to register everytime TWLoader is launched. To enable log file, user must create a (/an empty) file in SD:\_nds\twloader and name it log.

Also, search function have been improved a bit checking first if keyboard input is empty. Also, after searching, dialogbox is closed automatically so that speeds up a lot the search query

A considerable amount of users have a SD:\cia folder in root so if that folder exist, twloader cias will download there. If that folder doesn't exist, it will download in default location (SD:\_nds\twloader\cia)

If TWLNand side is not installed, twloader will exit to home when user attempt to launch a rom