### PR TITLE
keyboard.cpp: "fix" keyboard hint

### DIFF
--- a/gui/source/keyboard.cpp
+++ b/gui/source/keyboard.cpp
@@ -12,9 +12,14 @@
 std::string keyboardInput(const wchar_t* hint) {
     SwkbdState keyboardState;
 	char input[64];
-	 
+	char buffer[32];
+	
+	//wchart_t* to char*
+	wcstombs (buffer, hint, sizeof(buffer) );
+	buffer[31]='\0';
+	
     swkbdInit(&keyboardState, SWKBD_TYPE_QWERTY, 2, sizeof(input));
-    swkbdSetHintText(&keyboardState, (const char*)hint);
+    swkbdSetHintText(&keyboardState, buffer);
 	swkbdSetFeatures(&keyboardState, SWKBD_DEFAULT_QWERTY);
 
     swkbdInputText(&keyboardState, input, sizeof(input));


### PR DESCRIPTION
Since we're using wchar_t  pointers to show hint, we need to convert
that 16bit characters array to something software keyboard can
understand.

(This is the last PR for today. I think I've done enough just for only one day. Also, I'll like if someone review a bit my English :P)

TODO: reset cursorposition and currentcustomposition = cursorposition; after exiting settings.