### PR TITLE
[READY] Bugfixes for 3.3.1

### DIFF
--- a/gui/source/date.cpp
+++ b/gui/source/date.cpp
@@ -1,11 +1,17 @@
 #include "date.h"
+#include "language.h"
 
-#include <time.h>
-#include <stdio.h>
+#include <sftd.h>
+
+#include <ctime>
+#include <cstdio>
 #include <malloc.h>
 
 #include <string>
 using std::string;
+
+// from main.cpp
+extern sftd_font *font;
 
 /**
  * Get the current date as a C string.
@@ -72,4 +78,37 @@ string RetTime(int donotblink)
 	}
 
 	return string(Tmp);
+}
+
+/**
+ * Draw the date using the specified color.
+ * Date format depends on language setting.
+ * @param color Text color.
+ */
+void DrawDate(u32 color)
+{
+	// Date formats.
+	// - Index: Language ID.
+	// - Value: Date format.
+	static const uint8_t date_fmt[12] = {
+		FORMAT_MD,	// Japanese
+		FORMAT_MD,	// English
+		FORMAT_DM,	// French
+		FORMAT_M_D,	// German
+		FORMAT_DM,	// Italian
+		FORMAT_DM,	// Spanish
+		FORMAT_MD,	// Simplified Chinese
+		FORMAT_MD,	// Korean
+		FORMAT_DM,	// Dutch
+		FORMAT_DM,	// Portuguese
+		FORMAT_M_D,	// Russian
+		FORMAT_MD,	// Traditional Chinese
+	};
+
+	// NOTE: GetDate() malloc()'s the date string.
+	char *date_str = GetDate(date_fmt[language]);
+	if (!date_str)
+		return;
+	sftd_draw_text(font, 282, 3, color, 12, date_str);
+	free(date_str);
 }

--- a/gui/source/date.cpp
+++ b/gui/source/date.cpp
@@ -53,9 +53,10 @@ size_t GetDate(int format, char *buf, size_t size)
 /**
  * Get the current time formatted for the top bar.
  * This includes the blinking ':'.
+ * @param donotblink If true, reset the blink counter.
  * @return std::string containing the time.
  */
-string RetTime(int donotblink)
+string RetTime(bool donotblink)
 {
 	time_t Raw;
 	time(&Raw);
@@ -65,12 +66,14 @@ string RetTime(int donotblink)
 	// (120 is because two top frames are drawn every 1/60th
 	//  due to 3D.)
 	static int chartimer = 0;
-	if (donotblink == 0)
+	if (!donotblink) {
 		chartimer++;
-	else
+		if (chartimer >= 120*2) {
+			chartimer = 0;
+		}
+	} else {
 		chartimer = 0;
-	if (chartimer >= 120*2)
-		chartimer = 0;
+	}
 
 	char Tmp[24];
 	if (chartimer >= 120) {

--- a/gui/source/date.h
+++ b/gui/source/date.h
@@ -1,21 +1,27 @@
 #ifndef DATE_H
 #define DATE_H
 
-#define FORMAT_YDM 0
-#define FORMAT_YMD 1
-#define FORMAT_DM  2
-#define FORMAT_MD  3
-#define FORMAT_M_D 4
-
 #include <3ds/types.h>
 #include <string>
+#include <stddef.h>
+
+typedef enum {
+	FORMAT_YDM	= 0,
+	FORMAT_YMD	= 1,
+	FORMAT_DM	= 2,
+	FORMAT_MD	= 3,
+	FORMAT_M_D	= 4,
+} DateFormat;
 
 /**
  * Get the current date as a C string.
- * @param Format Date format.
+ * @param format Date format.
+ * @param buf Output buffer.
+ * @param size Size of the output buffer.
+ * @return Number of bytes written, excluding the NULL terminator.
  * @return Current date. (Caller must free() this string.)
  */
-char *GetDate(int Format);
+size_t GetDate(int format, char *buf, size_t size);
 
 /**
  * Get the current time formatted for the top bar.

--- a/gui/source/date.h
+++ b/gui/source/date.h
@@ -26,9 +26,10 @@ size_t GetDate(int format, char *buf, size_t size);
 /**
  * Get the current time formatted for the top bar.
  * This includes the blinking ':'.
+ * @param donotblink If true, reset the blink counter.
  * @return std::string containing the time.
  */
-std::string RetTime(int donotblink);
+std::string RetTime(bool donotblink);
 
 /**
  * Draw the date using the specified color.

--- a/gui/source/date.h
+++ b/gui/source/date.h
@@ -7,6 +7,7 @@
 #define FORMAT_MD  3
 #define FORMAT_M_D 4
 
+#include <3ds/types.h>
 #include <string>
 
 /**
@@ -22,5 +23,12 @@ char *GetDate(int Format);
  * @return std::string containing the time.
  */
 std::string RetTime(int donotblink);
+
+/**
+ * Draw the date using the specified color.
+ * Date format depends on language setting.
+ * @param color Text color.
+ */
+void DrawDate(u32 color);
 
 #endif // DATE_H

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -35,7 +35,9 @@ extern bool run;	// Set to false to exit to the Home Menu.
 extern std::string settings_releasebootstrapver;
 extern std::string settings_unofficialbootstrapver;
 extern bool logEnabled;
-extern bool checkTWLNANDSide();
+
+extern const u64 TWLNAND_TID;
+extern bool checkTWLNANDSide(void);
 
 extern int screenmode;
 // 0: ROM select
@@ -316,7 +318,7 @@ void DownloadTWLoaderCIAs(void) {
 		// Delete first if installed.
 		if(checkTWLNANDSide()){
 			amInit();
-			AM_DeleteTitle(MEDIATYPE_NAND, 0x0004800554574C44ULL);
+			AM_DeleteTitle(MEDIATYPE_NAND, TWLNAND_TID);
 			amExit();
 		}
 		if(stat("sdmc:/cia",&st) == 0){		

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -70,10 +70,10 @@ bool checkWifiStatus(void) {
 	bool res = false;
 
 	if (R_SUCCEEDED(ACU_GetWifiStatus(&wifiStatus)) && wifiStatus) {
-		if (logEnabled)	LogFMA("WifiStatus", "Active internet connection found", RetTime(1).c_str());
+		if (logEnabled)	LogFMA("WifiStatus", "Active internet connection found", RetTime(true).c_str());
 		res = true;
 	} else {
-		if (logEnabled)	LogFMA("WifiStatus", "No Internet connection found!", RetTime(1).c_str());
+		if (logEnabled)	LogFMA("WifiStatus", "No Internet connection found!", RetTime(true).c_str());
 	}
 
 	return res;

--- a/gui/source/language.cpp
+++ b/gui/source/language.cpp
@@ -37,8 +37,8 @@ static const char *const *lang_all[12] = {
 /** Functions. **/
 
 // System language setting.
-u8 language = 1;	// Default to English.
-u8 ntrtwlmode_language;
+u8 language = 1;	// UI language ID.
+u8 sys_language = 1;	// System language ID.
 static const char *const *lang_data = lang_all[1];
 
 // Translation cache.
@@ -50,16 +50,19 @@ static wchar_t *lang_cache[STR_MAX] = { };
  */
 void langInit(void)
 {
-	CFGU_GetSystemLanguage(&ntrtwlmode_language);
+	if (R_FAILED(CFGU_GetSystemLanguage(&sys_language)) ||
+	    (sys_language < 0 || sys_language >= 12))
+	{
+		// Invalid system language ID.
+		// Default to English.
+		sys_language = 1;
+	}
+
 	language = settings.ui.language;
 	if (language < 0 || language >= 12) {
-		// Get the system language setting.
-		CFGU_GetSystemLanguage(&language);
-		if (language < 0 || language >= 12) {
-			// Invalid language.
-			// Default to English.
-			language = 1;
-		}
+		// Invalid language ID.
+		// Default to the system language setting.
+		language = sys_language;
 	}
 
 	// Clear the language cache.

--- a/gui/source/language.h
+++ b/gui/source/language.h
@@ -6,6 +6,8 @@
 
 // Active language ID.
 extern u8 language;
+// System language ID.
+extern u8 sys_language;
 
 /**
  * Initialize translations.

--- a/gui/source/log.cpp
+++ b/gui/source/log.cpp
@@ -12,7 +12,7 @@ int createLog(void) {
 		}
 		LogCreated = true;
 		Log("************** Log file created at ");
-		Log(RetTime(1).c_str());
+		Log(RetTime(true).c_str());
 		Log(" **************");
 		Log("\n");
 		fclose(log);

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -2052,104 +2052,10 @@ int main()
 					if (settings.ui.topborder) {
 						sf2d_draw_texture_blend(toptex, 400/2 - toptex->width/2, 240/2 - toptex->height/2, menucolor);
 						sftd_draw_text(font, 328, 3, RGBA8(0, 0, 0, 255), 12, RetTime(0).c_str());
-						if(settings.ui.language != -1){
-							switch(settings.ui.language){			
-								case 3: // German
-								case 10: // Russian
-									sftd_draw_text(font, 282, 3, RGBA8(0, 0, 0, 255), 12, GetDate(4));
-									break;
-								case 2: // French
-								case 4: // Italian
-								case 5: // Spanish			
-								case 8: // Dutch
-								case 9: // Portuguese			
-									sftd_draw_text(font, 282, 3, RGBA8(0, 0, 0, 255), 12, GetDate(2));
-									break;
-								case 0: // Japanese
-								case 1: // English
-								case 6: // Simplified Chinese
-								case 7: // Korean			
-								case 11: // Traditional Chinese
-									sftd_draw_text(font, 282, 3, RGBA8(0, 0, 0, 255), 12, GetDate(3));
-									break;
-							}
-						}else{
-							u8 language;
-							CFGU_GetSystemLanguage(&language);
-							if (language < 0 || language >= 12) {
-								language = 1;
-							}
-							switch(language){			
-								case 3: // German
-								case 10: // Russian
-									sftd_draw_text(font, 282, 3, RGBA8(0, 0, 0, 255), 12, GetDate(4));
-									break;
-								case 2: // French
-								case 4: // Italian
-								case 5: // Spanish			
-								case 8: // Dutch
-								case 9: // Portuguese			
-									sftd_draw_text(font, 282, 3, RGBA8(0, 0, 0, 255), 12, GetDate(2));
-									break;
-								case 0: // Japanese
-								case 1: // English
-								case 6: // Simplified Chinese
-								case 7: // Korean			
-								case 11: // Traditional Chinese
-									sftd_draw_text(font, 282, 3, RGBA8(0, 0, 0, 255), 12, GetDate(3));
-									break;
-							}
-						}
+						DrawDate(RGBA8(0, 0, 0, 255));
 					} else {
 						sftd_draw_text(font, 328, 3, RGBA8(255, 255, 255, 255), 12, RetTime(0).c_str());
-						if(settings.ui.language != -1){
-							switch(settings.ui.language){			
-								case 3: // German
-								case 10: // Russian
-									sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(4));
-									break;
-								case 2: // French
-								case 4: // Italian
-								case 5: // Spanish			
-								case 8: // Dutch
-								case 9: // Portuguese			
-									sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(2));
-									break;
-								case 0: // Japanese
-								case 1: // English
-								case 6: // Simplified Chinese
-								case 7: // Korean			
-								case 11: // Traditional Chinese
-									sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(3));
-									break;
-							}
-						}else{
-							u8 language;
-							CFGU_GetSystemLanguage(&language);
-							if (language < 0 || language >= 12) {
-								language = 1;
-							}
-							switch(language){			
-								case 3: // German
-								case 10: // Russian
-									sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(4));
-									break;
-								case 2: // French
-								case 4: // Italian
-								case 5: // Spanish			
-								case 8: // Dutch
-								case 9: // Portuguese			
-									sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(2));
-									break;
-								case 0: // Japanese
-								case 1: // English
-								case 6: // Simplified Chinese
-								case 7: // Korean			
-								case 11: // Traditional Chinese
-									sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(3));
-									break;
-							}
-						}
+						DrawDate(RGBA8(255, 255, 255, 255));
 					}
 
 					draw_volume_slider(voltex);

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1150,6 +1150,21 @@ static void drawMenuDialogBox(void)
 				w = sftd_get_wtext_width(font, 12, value_desc);
 				x = ((132 - w) / 2) + buttons[i].x;
 				sftd_draw_wtext(font, x, y, RGBA8(0, 0, 0, 255), 12, value_desc);
+			} else if (i == 4) {
+				// Show the RGB value.
+				char rgb_str[32];
+				snprintf(rgb_str, sizeof(rgb_str), "%d, %d, %d",
+					settings.pergame.red,
+					settings.pergame.green,
+					settings.pergame.blue);
+				w = sftd_get_text_width(font, 12, rgb_str);
+				x = ((132 - w) / 2) + buttons[i].x;
+
+				// Print the RGB value using its color.
+				const u32 color = RGBA8(settings.pergame.red,
+					settings.pergame.green,
+					settings.pergame.blue, 255);
+				sftd_draw_text(font, x, y, color, 12, rgb_str);
 			}
 		}
 	} else {

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1906,10 +1906,10 @@ int main()
 				switch (settings.ui.subtheme) {
 					case 0:
 					default:
-						sftd_draw_text(font_b, 40+200, 148, RGBA8(16, 0, 0, 223), 22, RetTime(1).c_str());
+						sftd_draw_text(font_b, 40+200, 148, RGBA8(16, 0, 0, 223), 22, RetTime(true).c_str());
 						break;
 					case 1:
-						sftd_draw_text(font_b, 40+184, 8, RGBA8(255, 255, 255, 255), 33, RetTime(1).c_str());
+						sftd_draw_text(font_b, 40+184, 8, RGBA8(255, 255, 255, 255), 33, RetTime(true).c_str());
 						break;
 				}
 				sf2d_draw_rectangle(0, 0, 40, 240, RGBA8(0, 0, 0, 255)); // Left black bar
@@ -2051,10 +2051,10 @@ int main()
 					}
 					if (settings.ui.topborder) {
 						sf2d_draw_texture_blend(toptex, 400/2 - toptex->width/2, 240/2 - toptex->height/2, menucolor);
-						sftd_draw_text(font, 328, 3, RGBA8(0, 0, 0, 255), 12, RetTime(0).c_str());
+						sftd_draw_text(font, 328, 3, RGBA8(0, 0, 0, 255), 12, RetTime(false).c_str());
 						DrawDate(RGBA8(0, 0, 0, 255));
 					} else {
-						sftd_draw_text(font, 328, 3, RGBA8(255, 255, 255, 255), 12, RetTime(0).c_str());
+						sftd_draw_text(font, 328, 3, RGBA8(255, 255, 255, 255), 12, RetTime(false).c_str());
 						DrawDate(RGBA8(255, 255, 255, 255));
 					}
 
@@ -2570,7 +2570,7 @@ int main()
 							const int text_width = sftd_get_text_width(font, 14, selectiontext);
 							sftd_draw_textf(font, (320-text_width)/2, 220, RGBA8(255, 255, 255, 255), 14, selectiontext);
 						}
-						sftd_draw_text(font, 276, 220, RGBA8(255, 255, 255, 255), 14, RetTime(1).c_str());
+						sftd_draw_text(font, 276, 220, RGBA8(255, 255, 255, 255), 14, RetTime(true).c_str());
 					} else {
 						sf2d_draw_texture(bottomtex, 320/2 - bottomtex->width/2, 240/2 - bottomtex->height/2);
 						if (!bannertextloaded) {

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -509,33 +509,15 @@ static int RainbowLED(void) {
  * Set a user led color for notification LED
  * @return 0 on success; non-zero on error.
  */
-
 static int PergameLed(void) {
-	static const RGBLedPattern pattern = {
-		32, // Need to be 32 in order to be it constant
-		
-		// Red color
-		{
-			(u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], 
-			(u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], 
-			(u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0], (u8)RGB[0]
-		},
-		
-		// Green color
-		{
-			(u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], 
-			(u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], 
-			(u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1], (u8)RGB[1]			
-		},
-		
-		// Blue color
-		{
-			(u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], 
-			(u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], 
-			(u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2], (u8)RGB[2]
-		},		
-	};
-	
+	RGBLedPattern pattern;
+	pattern.ani = 32;	// Need to be 32 in order to be it constant
+
+	// Set the color values to a single RGB value.
+	memset(&pattern.r, (u8)RGB[0], sizeof(pattern.r));
+	memset(&pattern.g, (u8)RGB[1], sizeof(pattern.g));
+	memset(&pattern.b, (u8)RGB[2], sizeof(pattern.b));
+
 	if (ptmsysmInit() < 0)
 		return -1;
 	ptmsysmSetInfoLedPattern(&pattern);

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1225,38 +1225,20 @@ bool compareString(const char *iter, const char *input)
 	return false;
 }
 
+// TWLNAND side Title ID.
+extern const u64 TWLNAND_TID;
+const u64 TWLNAND_TID = 0x0004800554574C44ULL;
+
 /**
-* check if TWLNand side is installed or not
+* Check if the TWLNAND-side title is installed or not
 * Title ID: 0x0004800554574C44ULL
 * MediaType: MEDIATYPE_NAND
 * @return: true if installed, false if not
 */
-
-bool checkTWLNANDSide(void){
-	bool res = false;
-	
-	u32 count = 0;
-	FS_MediaType mediaType = MEDIATYPE_NAND;
-	u64 id = 0x0004800554574C44ULL;
-	
-	if(R_SUCCEEDED(AM_GetTitleCount(mediaType, &count))){
-		u64* titleIds = (u64*)calloc(count, sizeof(u64));
-        if(titleIds != NULL) {
-			if(R_SUCCEEDED(AM_GetTitleList(&count, mediaType, count, titleIds))) {
-				// Now we have the list of cia's installed on NAND
-				for(u32 i = 0; i < count; i++) {
-					// Try to find TWLNand ID
-					if(titleIds[i] == id){
-						res = true;
-						break;
-					}
-				}
-			}
-		}
-		free(titleIds);
-	}
-	
-	return res;
+bool checkTWLNANDSide(void) {
+	u64 tid = TWLNAND_TID;
+	AM_TitleEntry entry;
+	return R_SUCCEEDED(AM_GetTitleInfo(MEDIATYPE_NAND, 1, &tid, &entry));
 }
 
 int main()
@@ -4136,7 +4118,7 @@ int main()
 			SetPerGameSettings();
 			SaveBootstrapConfig();
 			
-			// Check if TWLNAND side is installed (0x0004800554574C44ULL)
+			// Check if TWLNAND side is installed.
 			if(!checkTWLNANDSide()){
 				sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
 				sf2d_draw_texture(dialogboxtex, 0, 0);
@@ -4146,7 +4128,7 @@ int main()
 			}
 			
 			// Prepare for the app launch.
-			u64 tid = 0x0004800554574C44ULL; // TWLNAND side's title ID
+			u64 tid = TWLNAND_TID;
 			FS_MediaType mediaType = MEDIATYPE_NAND;
 			bool switchToTwl = true;	
 			

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1107,8 +1107,8 @@ static void drawMenuDialogBox(void)
 			{ 23,  89, &settings.pergame.cpuspeed, TR(STR_START_ARM9_CPU_SPEED), {L"67 MHz (NTR)", L"133 MHz (TWL)"}},
 			{161,  89, &settings.pergame.extvram, TR(STR_START_VRAM_BOOST), {L"Off", L"On"}},
 			{ 23, 129, &settings.pergame.lockarm9scfgext, TR(STR_START_LOCK_ARM9_SCFG_EXT), {L"Off", L"On"}},
-			{161, 129, &settings.pergame.donor, TR(STR_START_SET_DONOR), {L"", L""}},
-			{23, 169, NULL, TR(STR_START_SET_LED), {NULL, NULL}},
+			{161, 129, &settings.pergame.donor, TR(STR_START_SET_DONOR), {NULL, NULL}},
+			{ 23, 169, NULL, TR(STR_START_SET_LED), {NULL, NULL}},
 		};
 		
 		for (int i = (int)(sizeof(buttons)/sizeof(buttons[0]))-1; i >= 0; i--) {
@@ -1122,7 +1122,7 @@ static void drawMenuDialogBox(void)
 
 			const wchar_t *title = buttons[i].title;
 			const wchar_t *value_desc = TR(STR_START_DEFAULT);
-			if(i != 4){
+			if (i < 3) {
 				switch (*(buttons[i].value)) {
 					case -1:
 					default:
@@ -1149,7 +1149,7 @@ static void drawMenuDialogBox(void)
 			y += 16;
 
 			// Draw the value.
-			if(i != 4){
+			if (i < 3) {
 				w = sftd_get_wtext_width(font, 12, value_desc);
 				x = ((132 - w) / 2) + buttons[i].x;
 				sftd_draw_wtext(font, x, y, RGBA8(0, 0, 0, 255), 12, value_desc);

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1509,15 +1509,29 @@ int main()
 		sf2d_set_3D(1);
 
 	// Loop as long as the status is not exit
-	bool saveOnExit = true;
+	const bool isTWLNANDInstalled = checkTWLNANDSide();
+	// Save by default if the TWLNAND-side title is installed.
+	// Otherwise, we don't want to save anything.
+	bool saveOnExit = !isTWLNANDInstalled;
 	while(run && aptMainLoop()) {
 	//while(run) {
 		// Scan hid shared memory for input events
 		hidScanInput();
-		
+
 		const u32 hDown = hidKeysDown();
 		const u32 hHeld = hidKeysHeld();
-		
+
+		// Check if the TWLNAND-side title is installed.
+		if (!isTWLNANDInstalled) {
+			sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+			sf2d_draw_texture(dialogboxtex, 0, 0);
+			sftd_draw_text(font, 12, 16, RGBA8(0, 0, 0, 255), 12, "Please, install TWLNand side and retry again");
+			sftd_draw_text(font, 12, 28, RGBA8(0, 0, 0, 255), 12, "Returning to Home...");
+			sf2d_end_frame();
+			sf2d_swapbuffers();
+			continue;
+		}
+
 		offset3D[0].topbg = CONFIG_3D_SLIDERSTATE * -12.0f;
 		offset3D[1].topbg = CONFIG_3D_SLIDERSTATE * 12.0f;
 		offset3D[0].boxart = CONFIG_3D_SLIDERSTATE * -5.0f;
@@ -4117,16 +4131,7 @@ int main()
 			SaveSettings();
 			SetPerGameSettings();
 			SaveBootstrapConfig();
-			
-			// Check if TWLNAND side is installed.
-			if(!checkTWLNANDSide()){
-				sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-				sf2d_draw_texture(dialogboxtex, 0, 0);
-				sftd_draw_text(font, 12, 16, RGBA8(0, 0, 0, 255), 12, "Please, install TWLNand side and retry again");
-				sftd_draw_text(font, 12, 28, RGBA8(0, 0, 0, 255), 12, "Returning to Home...");
-				break;
-			}
-			
+
 			// Prepare for the app launch.
 			u64 tid = TWLNAND_TID;
 			FS_MediaType mediaType = MEDIATYPE_NAND;

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1507,7 +1507,7 @@ int main()
 	const bool isTWLNANDInstalled = checkTWLNANDSide();
 	// Save by default if the TWLNAND-side title is installed.
 	// Otherwise, we don't want to save anything.
-	bool saveOnExit = !isTWLNANDInstalled;
+	bool saveOnExit = isTWLNANDInstalled;
 	while(run && aptMainLoop()) {
 	//while(run) {
 		// Scan hid shared memory for input events

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1523,10 +1523,28 @@ int main()
 
 		// Check if the TWLNAND-side title is installed.
 		if (!isTWLNANDInstalled) {
+			static const char twlnand_msg[] =
+				"The TWLNAND-side title has not been installed.\n"
+				"Please install the TWLNAND-side CIA:\n"
+				"\n"
+				"/_nds/twloader/cias/TWLoader - TWLNAND side.cia\n"
+				"\n"
+				"\n"
+				"\n"
+				"\n"
+				"\n"
+				"\n"
+				"\n"
+				"\n"
+				"\n"
+				"\n"
+				"\n"
+				"\n"
+				"                 Press the HOME button to exit.";
+			DialogBoxAppear(twlnand_msg, 0);
 			sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
 			sf2d_draw_texture(dialogboxtex, 0, 0);
-			sftd_draw_text(font, 12, 16, RGBA8(0, 0, 0, 255), 12, "Please, install TWLNand side and retry again");
-			sftd_draw_text(font, 12, 28, RGBA8(0, 0, 0, 255), 12, "Returning to Home...");
+			sftd_draw_text(font, 12, 16, RGBA8(0, 0, 0, 255), 12, twlnand_msg);
 			sf2d_end_frame();
 			sf2d_swapbuffers();
 			continue;

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1,3 +1,6 @@
+// for strcasestr()
+#define _GNU_SOURCE 1
+
 #include "download.h"
 #include "settings.h"
 #include "textfns.h"
@@ -1215,29 +1218,6 @@ static void drawMenuDialogBox(void)
 			}
 		}
 	}
-}
-
-/**
-* compare two strings case insensitive.
-* @param iterator const char*
-* @param input const char*
-*/
-bool compareString(const char *iter, const char *input)
-{
-	// First transform input to lower case
-    std::string inputText = input;
-	std::transform(inputText.begin(), inputText.end(), inputText.begin(), ::tolower);
-	
-	// Transform iterator string to lower case
-	std::string fileName = iter;
-	std::transform(fileName.begin(), fileName.end(), fileName.begin(), ::tolower);
-	
-	// Compare
-	if(strstr(fileName.c_str(), inputText.c_str())){
-		return true;
-	}
-	
-	return false;
 }
 
 // TWLNAND side Title ID.
@@ -3674,7 +3654,7 @@ int main()
 											continue;
 										}
 										// Use C string comparison for case-insensitive checks.
-										if (compareString(iter->c_str(), gameName.c_str())){
+										if (strcasestr(iter->c_str(), gameName.c_str()) != NULL) {
 											// String matches.
 											matching_files.push_back(*iter);
 										}
@@ -3688,16 +3668,15 @@ int main()
 											continue;
 										}
 										// Use C string comparison for case-insensitive checks.
-										if (compareString(iter->c_str(), gameName.c_str())){
+										if (strcasestr(iter->c_str(), gameName.c_str()) != NULL) {
 											// String matches.
 											matching_files.push_back(*iter);
 										}
 									}
 								}							
-								
-								if (matching_files.size() != 0){
+
+								if (matching_files.size() != 0) {
 									/** Prepare some stuff to show correctly the filtered roms */
-									
 									pagenum = 0; // Go to page 0
 									cursorPosition = 0; // Move the cursor to 0
 									storedcursorPosition = cursorPosition; // Move the cursor to 0
@@ -3781,15 +3760,17 @@ int main()
 											// so it can't match.
 											continue;
 										}
-										// Use C string comparison for case-insensitive checks.
-										if (compareString(iter->c_str(), gameName.c_str())){
+
+										// Check if the game name contains the search term.
+										// (Case-insensitive search.)
+										if (strcasestr(iter->c_str(), gameName.c_str()) != NULL) {
 											// String matches.
 											matching_files.push_back(*iter);
 										}
 									}
-									if (matching_files.size() != 0){
+
+									if (matching_files.size() != 0) {
 										/** Prepare some stuff to show correctly the filtered roms */
-										
 										pagenum = 0; // Go to page 0
 										cursorPosition = 0; // Move the cursor to 0
 										storedcursorPosition = cursorPosition; // Move the cursor to 0

--- a/gui/source/settings.cpp
+++ b/gui/source/settings.cpp
@@ -146,7 +146,7 @@ void settingsLoadTextures(void)
 
 	dsboottex = sfil_load_PNG_file("romfs:/graphics/settings/dsboot.png", SF2D_PLACE_RAM); // DS boot screen in settings
 	dsiboottex = sfil_load_PNG_file("romfs:/graphics/settings/dsiboot.png", SF2D_PLACE_RAM); // DSi boot screen in settings
-	switch(sys_language) {
+	switch (sys_language) {
 		case 0:
 		case 6:
 		case 7:
@@ -292,54 +292,7 @@ void settingsDrawTopScreen(void)
 		if (!settings.ui.name.empty()) {
 			sftd_draw_textf(font, 34, 3, SET_ALPHA(color_data->color, 255), 12, settings.ui.name.c_str());
 		}
-		if(settings.ui.language != -1){
-			switch(settings.ui.language){			
-				case 3: // German
-				case 10: // Russian
-					sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(4));
-					break;
-				case 2: // French
-				case 4: // Italian
-				case 5: // Spanish			
-				case 8: // Dutch
-				case 9: // Portuguese			
-					sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(2));
-					break;
-				case 0: // Japanese
-				case 1: // English
-				case 6: // Simplified Chinese
-				case 7: // Korean			
-				case 11: // Traditional Chinese
-					sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(3));
-					break;
-			}
-		}else{
-			u8 language;
-			CFGU_GetSystemLanguage(&language);
-			if (language < 0 || language >= 12) {
-				language = 1;
-			}
-			switch(language){			
-				case 3: // German
-				case 10: // Russian
-					sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(4));
-					break;
-				case 2: // French
-				case 4: // Italian
-				case 5: // Spanish			
-				case 8: // Dutch
-				case 9: // Portuguese			
-					sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(2));
-					break;
-				case 0: // Japanese
-				case 1: // English
-				case 6: // Simplified Chinese
-				case 7: // Korean			
-				case 11: // Traditional Chinese
-					sftd_draw_text(font, 282, 3, RGBA8(255, 255, 255, 255), 12, GetDate(3));
-					break;
-			}
-		}
+		DrawDate(RGBA8(255, 255, 255, 255));
 		sf2d_draw_rectangle(0, 0, 400, 240, RGBA8(0, 0, 0, fadealpha)); // Fade in/out effect
 		sf2d_end_frame();
 	}

--- a/gui/source/settings.cpp
+++ b/gui/source/settings.cpp
@@ -277,7 +277,7 @@ void settingsDrawTopScreen(void)
 			}
 		}
 
-		sftd_draw_text(font, 328, 3, RGBA8(255, 255, 255, 255), 12, RetTime(0).c_str());
+		sftd_draw_text(font, 328, 3, RGBA8(255, 255, 255, 255), 12, RetTime(false).c_str());
 		
 		std::string version = settings_vertext;		
 		if (version.substr(version.find_first_not_of(' '), (version.find_last_not_of(' ') - version.find_first_not_of(' ') + 1)).size() > 8) {

--- a/gui/source/settings.cpp
+++ b/gui/source/settings.cpp
@@ -27,9 +27,6 @@ void update_battery_level(sf2d_texture *texchrg, sf2d_texture *texarray[]);
 // Variables from main.cpp.
 extern bool is3DSX;
 
-extern u8 language;
-extern u8 ntrtwlmode_language;
-
 extern touchPosition touch;
 u16 touch_x = 320/2;
 u16 touch_y = 240/2;
@@ -149,7 +146,7 @@ void settingsLoadTextures(void)
 
 	dsboottex = sfil_load_PNG_file("romfs:/graphics/settings/dsboot.png", SF2D_PLACE_RAM); // DS boot screen in settings
 	dsiboottex = sfil_load_PNG_file("romfs:/graphics/settings/dsiboot.png", SF2D_PLACE_RAM); // DSi boot screen in settings
-	switch(ntrtwlmode_language) {
+	switch(sys_language) {
 		case 0:
 		case 6:
 		case 7:


### PR DESCRIPTION
I originally wrote these bugfixes for 3.0.2. This is rebased on commit 737a29bfe9fccfd01ea2af3cac47c01d39e8cbff.

Changes:
* PergameLed(): Use memset() instead of a giant array.
* checkTWLNANDSide(): Use AM_GetTitleInfo() instead of AM_GetTitleList().
* Check the TWLNAND-side title immediately before displaying the main menu, instead of after selecting a game. Note that this currently makes it impossible to install the TWLNAND-side CIA using the updater; this could be changed to add an option to download and install the TWLNAND-side CIA.
* Show the RGB color in the per-game settings menu.
* Some language changes. (This may have broken due to the recent translation updates; I can't verify it at the moment.)
* New function drawDate() that draws the status bar date using the specified color.
* GetDate() no longer malloc()s strings. The caller can pass in a buffer instead. The malloc()'d string was leaked, resulting in a ~172 KB/min leak (or larger, depending on malloc() overhead).
* Other miscellaneous changes.

@Jolty95 I replaced the compareString() function with strcasestr(); this is a GNU extension that's basically a case-insensitive strstr(). I don't have my 3DS available at the moment; can you verify that the updated version works correctly?

As I mentioned above, I don't have access to my 3DS right now, so I can't check if the rebase screwed anything up. It does compile, though. I'd like some test feedback before it's merged.