### PR TITLE
apply astyle

### DIFF
--- a/gui/source/date.cpp
+++ b/gui/source/date.cpp
@@ -19,35 +19,35 @@ using std::string;
  * @return Number of bytes written, excluding the NULL terminator.
  * @return Current date. (Caller must free() this string.)
  */
-size_t GetDate(DateFormat format, char *buf, size_t size)
+size_t GetDate(DateFormat format, char* buf, size_t size)
 {
-	time_t Raw;
-	time(&Raw);
-	const struct tm *Time = localtime(&Raw);
+    time_t Raw;
+    time(&Raw);
+    const struct tm* Time = localtime(&Raw);
 
-	switch (format) {
-		case FORMAT_YDM:
-			return strftime(buf, size, "%Y-%d-%m_%k-%M", Time);
-		case FORMAT_YMD:
-			return strftime(buf, size, "%Y-%m-%d_%k-%M", Time);
-		case FORMAT_DM:
-			return strftime(buf, size, "%d/%m", Time); // Ex: 26/12
-		case FORMAT_MD:
-			return strftime(buf, size, "%m/%d", Time); // Ex: 12/26
-		case FORMAT_M_D:
-			return strftime(buf, size, "%d.%m.", Time); // Ex: 26.12.
-		case FORMAT_MY:
-			return strftime(buf, size, "%m  %Y", Time);
-		default:
-			break;
-	}
+    switch (format) {
+        case FORMAT_YDM:
+            return strftime(buf, size, "%Y-%d-%m_%k-%M", Time);
+        case FORMAT_YMD:
+            return strftime(buf, size, "%Y-%m-%d_%k-%M", Time);
+        case FORMAT_DM:
+            return strftime(buf, size, "%d/%m", Time); // Ex: 26/12
+        case FORMAT_MD:
+            return strftime(buf, size, "%m/%d", Time); // Ex: 12/26
+        case FORMAT_M_D:
+            return strftime(buf, size, "%d.%m.", Time); // Ex: 26.12.
+        case FORMAT_MY:
+            return strftime(buf, size, "%m  %Y", Time);
+        default:
+            break;
+    }
 
-	// Invalid format.
-	// Should not get here...
-	if (size > 0) {
-		*buf = 0;
-	}
-	return 0;
+    // Invalid format.
+    // Should not get here...
+    if (size > 0) {
+        *buf = 0;
+    }
+    return 0;
 }
 
 /**
@@ -58,31 +58,31 @@ size_t GetDate(DateFormat format, char *buf, size_t size)
  */
 string RetTime(bool donotblink)
 {
-	time_t Raw;
-	time(&Raw);
-	const struct tm *Time = localtime(&Raw);
+    time_t Raw;
+    time(&Raw);
+    const struct tm* Time = localtime(&Raw);
 
-	// Blink the ':' approximately once per second.
-	// (120 is because two top frames are drawn every 1/60th
-	//  due to 3D.)
-	static int chartimer = 0;
-	if (!donotblink) {
-		chartimer++;
-		if (chartimer >= 120*2) {
-			chartimer = 0;
-		}
-	} else {
-		chartimer = 0;
-	}
+    // Blink the ':' approximately once per second.
+    // (120 is because two top frames are drawn every 1/60th
+    //  due to 3D.)
+    static int chartimer = 0;
+    if (!donotblink) {
+        chartimer++;
+        if (chartimer >= 120 * 2) {
+            chartimer = 0;
+        }
+    } else {
+        chartimer = 0;
+    }
 
-	char Tmp[24];
-	if (chartimer >= 120) {
-		strftime(Tmp, sizeof(Tmp), "%k %M", Time);
-	} else {
-		strftime(Tmp, sizeof(Tmp), "%k:%M", Time);
-	}
+    char Tmp[24];
+    if (chartimer >= 120) {
+        strftime(Tmp, sizeof(Tmp), "%k %M", Time);
+    } else {
+        strftime(Tmp, sizeof(Tmp), "%k:%M", Time);
+    }
 
-	return string(Tmp);
+    return string(Tmp);
 }
 
 /**
@@ -95,11 +95,12 @@ string RetTime(bool donotblink)
  */
 void DrawDateF(int Xpos, int Ypos, DateFormat format, u32 color, int size)
 {
-	char date_str[24];
-	GetDate(format, date_str, sizeof(date_str));
-	if (date_str[0] == 0)
-		return;
-	sftd_draw_text(font, Xpos, Ypos, color, size, date_str);
+    char date_str[24];
+    GetDate(format, date_str, sizeof(date_str));
+    if (date_str[0] == 0) {
+        return;
+    }
+    sftd_draw_text(font, Xpos, Ypos, color, size, date_str);
 }
 
 /**
@@ -112,23 +113,23 @@ void DrawDateF(int Xpos, int Ypos, DateFormat format, u32 color, int size)
  */
 void DrawDate(int Xpos, int Ypos, u32 color, int size)
 {
-	// Date formats.
-	// - Index: Language ID.
-	// - Value: Date format.
-	static const uint8_t date_fmt[12] = {
-		FORMAT_MD,	// Japanese
-		FORMAT_MD,	// English
-		FORMAT_DM,	// French
-		FORMAT_M_D,	// German
-		FORMAT_DM,	// Italian
-		FORMAT_DM,	// Spanish
-		FORMAT_MD,	// Simplified Chinese
-		FORMAT_MD,	// Korean
-		FORMAT_DM,	// Dutch
-		FORMAT_DM,	// Portuguese
-		FORMAT_M_D,	// Russian
-		FORMAT_MD,	// Traditional Chinese
-	};
+    // Date formats.
+    // - Index: Language ID.
+    // - Value: Date format.
+    static const uint8_t date_fmt[12] = {
+        FORMAT_MD,  // Japanese
+        FORMAT_MD,  // English
+        FORMAT_DM,  // French
+        FORMAT_M_D, // German
+        FORMAT_DM,  // Italian
+        FORMAT_DM,  // Spanish
+        FORMAT_MD,  // Simplified Chinese
+        FORMAT_MD,  // Korean
+        FORMAT_DM,  // Dutch
+        FORMAT_DM,  // Portuguese
+        FORMAT_M_D, // Russian
+        FORMAT_MD,  // Traditional Chinese
+    };
 
-	DrawDateF(Xpos, Ypos, (DateFormat)date_fmt[language], color, size);
+    DrawDateF(Xpos, Ypos, (DateFormat)date_fmt[language], color, size);
 }

--- a/gui/source/date.h
+++ b/gui/source/date.h
@@ -6,12 +6,12 @@
 #include <stddef.h>
 
 typedef enum {
-	FORMAT_YDM	= 0,
-	FORMAT_YMD	= 1,
-	FORMAT_DM	= 2,
-	FORMAT_MD	= 3,
-	FORMAT_M_D	= 4,
-	FORMAT_MY	= 5,
+    FORMAT_YDM  = 0,
+    FORMAT_YMD  = 1,
+    FORMAT_DM   = 2,
+    FORMAT_MD   = 3,
+    FORMAT_M_D  = 4,
+    FORMAT_MY   = 5,
 } DateFormat;
 
 /**
@@ -22,7 +22,7 @@ typedef enum {
  * @return Number of bytes written, excluding the NULL terminator.
  * @return Current date. (Caller must free() this string.)
  */
-size_t GetDate(DateFormat format, char *buf, size_t size);
+size_t GetDate(DateFormat format, char* buf, size_t size);
 
 /**
  * Get the current time formatted for the top bar.

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -37,18 +37,23 @@ const char* DOWNLOAD_UNOFFICIALBOOTSTRAP_VER_URL = "https://github.com/Jolty95/T
  * Check Wi-Fi status.
  * @return True if Wi-Fi is connected; false if not.
  */
-bool checkWifiStatus(void) {
-	u32 wifiStatus;
-	bool res = false;
+bool checkWifiStatus(void)
+{
+    u32 wifiStatus;
+    bool res = false;
 
-	if (R_SUCCEEDED(ACU_GetWifiStatus(&wifiStatus)) && wifiStatus) {
-		if (logEnabled)	LogFMA("WifiStatus", "Active internet connection found", RetTime(true).c_str());
-		res = true;
-	} else {
-		if (logEnabled)	LogFMA("WifiStatus", "No Internet connection found!", RetTime(true).c_str());
-	}
+    if (R_SUCCEEDED(ACU_GetWifiStatus(&wifiStatus)) && wifiStatus) {
+        if (logEnabled) {
+            LogFMA("WifiStatus", "Active internet connection found", RetTime(true).c_str());
+        }
+        res = true;
+    } else {
+        if (logEnabled) {
+            LogFMA("WifiStatus", "No Internet connection found!", RetTime(true).c_str());
+        }
+    }
 
-	return res;
+    return res;
 }
 
 /**
@@ -58,311 +63,343 @@ bool checkWifiStatus(void) {
  * @param mediaType How the file should be handled.
  * @return 0 on success; non-zero on error.
  */
-int downloadFile(const char* url, const char* file, MediaType mediaType) {
-	if (!checkWifiStatus())
-		return -1;
+int downloadFile(const char* url, const char* file, MediaType mediaType)
+{
+    if (!checkWifiStatus()) {
+        return -1;
+    }
 
-	fsInit();
-	httpcInit(0x1000);
-	u8 method = 0;
-	httpcContext context;
-	u32 statuscode=0;
-	HTTPC_RequestMethod useMethod = HTTPC_METHOD_GET;
+    fsInit();
+    httpcInit(0x1000);
+    u8 method = 0;
+    httpcContext context;
+    u32 statuscode = 0;
+    HTTPC_RequestMethod useMethod = HTTPC_METHOD_GET;
 
-	if (method <= 3 && method >= 1) {
-		useMethod = (HTTPC_RequestMethod)method;
-	}
+    if (method <= 3 && method >= 1) {
+        useMethod = (HTTPC_RequestMethod)method;
+    }
 
-	do {
-		if (statuscode >= 301 && statuscode <= 308) {
-			char newurl[4096];
-			httpcGetResponseHeader(&context, (char*)"Location", &newurl[0], 4096);
-			url = &newurl[0];
+    do {
+        if (statuscode >= 301 && statuscode <= 308) {
+            char newurl[4096];
+            httpcGetResponseHeader(&context, (char*)"Location", &newurl[0], 4096);
+            url = &newurl[0];
 
-			httpcCloseContext(&context);
-		}
+            httpcCloseContext(&context);
+        }
 
-		Result ret = httpcOpenContext(&context, useMethod, (char*)url, 0);
-		httpcSetSSLOpt(&context, SSLCOPT_DisableVerify);
+        Result ret = httpcOpenContext(&context, useMethod, (char*)url, 0);
+        httpcSetSSLOpt(&context, SSLCOPT_DisableVerify);
 
-		if (ret==0) {
-			if(R_SUCCEEDED(httpcBeginRequest(&context))){
-				u32 contentsize=0;
-				if(R_FAILED(httpcGetResponseStatusCode(&context, &statuscode))){
-					if (logEnabled) LogFM("downloadFile.error", "An error has ocurred trying to get response status code");
-					httpcCloseContext(&context);
-					httpcExit();
-					fsExit();
-					return -1;
-				}
-				if (statuscode == 200) {
-					u32 readSize = 0;
-					long int bytesWritten = 0;
+        if (ret == 0) {
+            if (R_SUCCEEDED(httpcBeginRequest(&context))) {
+                u32 contentsize = 0;
+                if (R_FAILED(httpcGetResponseStatusCode(&context, &statuscode))) {
+                    if (logEnabled) {
+                        LogFM("downloadFile.error", "An error has ocurred trying to get response status code");
+                    }
+                    httpcCloseContext(&context);
+                    httpcExit();
+                    fsExit();
+                    return -1;
+                }
+                if (statuscode == 200) {
+                    u32 readSize = 0;
+                    long int bytesWritten = 0;
 
-					Handle fileHandle;
-					FS_Path filePath=fsMakePath(PATH_ASCII, file);
-					FSUSER_OpenFileDirectly(&fileHandle, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, ""), filePath, FS_OPEN_CREATE | FS_OPEN_WRITE, 0x00000000);
+                    Handle fileHandle;
+                    FS_Path filePath = fsMakePath(PATH_ASCII, file);
+                    FSUSER_OpenFileDirectly(&fileHandle, ARCHIVE_SDMC, fsMakePath(PATH_EMPTY, ""), filePath, FS_OPEN_CREATE | FS_OPEN_WRITE, 0x00000000);
 
-					if(R_FAILED(httpcGetDownloadSizeState(&context, NULL, &contentsize))){
-						if (logEnabled) LogFM("downloadFile.error", "An error has ocurred trying to get download size");
-						httpcCloseContext(&context);
-						httpcExit();
-						fsExit();
-						return -1;
-					}
-					u8* buf = (u8*)malloc(contentsize);
-					memset(buf, 0, contentsize);
+                    if (R_FAILED(httpcGetDownloadSizeState(&context, NULL, &contentsize))) {
+                        if (logEnabled) {
+                            LogFM("downloadFile.error", "An error has ocurred trying to get download size");
+                        }
+                        httpcCloseContext(&context);
+                        httpcExit();
+                        fsExit();
+                        return -1;
+                    }
+                    u8* buf = (u8*)malloc(contentsize);
+                    memset(buf, 0, contentsize);
 
-					do {
-						if(R_FAILED(ret = httpcDownloadData(&context, buf, contentsize, &readSize))){
-							// In case there is an error
-							if (logEnabled) LogFM("downloadFile.error", "An error has ocurred while downloading data");
-							free(buf);
-							httpcCloseContext(&context);
-							httpcExit();
-							fsExit();
-							return -1;
-						}
-						FSFILE_Write(fileHandle, NULL, bytesWritten, buf, readSize, 0x10001);
-						bytesWritten += readSize;
-					} while (ret == (s32)HTTPC_RESULTCODE_DOWNLOADPENDING);
+                    do {
+                        if (R_FAILED(ret = httpcDownloadData(&context, buf, contentsize, &readSize))) {
+                            // In case there is an error
+                            if (logEnabled) {
+                                LogFM("downloadFile.error", "An error has ocurred while downloading data");
+                            }
+                            free(buf);
+                            httpcCloseContext(&context);
+                            httpcExit();
+                            fsExit();
+                            return -1;
+                        }
+                        FSFILE_Write(fileHandle, NULL, bytesWritten, buf, readSize, 0x10001);
+                        bytesWritten += readSize;
+                    } while (ret == (s32)HTTPC_RESULTCODE_DOWNLOADPENDING);
 
-					FSFILE_Close(fileHandle);
-					svcCloseHandle(fileHandle);
+                    FSFILE_Close(fileHandle);
+                    svcCloseHandle(fileHandle);
 
-					if (mediaType != MEDIA_SD_FILE) {
-						// This is a CIA, so we should install it.
-						amInit();
-						Handle handle;
-						// FIXME: Should check the return values.
-						switch (mediaType) {
-							case MEDIA_SD_CIA:
-								AM_QueryAvailableExternalTitleDatabase(NULL);
-								AM_StartCiaInstall(MEDIATYPE_SD, &handle);
-								break;
-							case MEDIA_NAND_CIA:
-								AM_StartCiaInstall(MEDIATYPE_NAND, &handle);
-								break;
-							default:
-								break;
-						}
-						FSFILE_Write(handle, NULL, 0, buf, contentsize, 0);
-						AM_FinishCiaInstall(handle);
-						amExit();
-					}
+                    if (mediaType != MEDIA_SD_FILE) {
+                        // This is a CIA, so we should install it.
+                        amInit();
+                        Handle handle;
+                        // FIXME: Should check the return values.
+                        switch (mediaType) {
+                            case MEDIA_SD_CIA:
+                                AM_QueryAvailableExternalTitleDatabase(NULL);
+                                AM_StartCiaInstall(MEDIATYPE_SD, &handle);
+                                break;
+                            case MEDIA_NAND_CIA:
+                                AM_StartCiaInstall(MEDIATYPE_NAND, &handle);
+                                break;
+                            default:
+                                break;
+                        }
+                        FSFILE_Write(handle, NULL, 0, buf, contentsize, 0);
+                        AM_FinishCiaInstall(handle);
+                        amExit();
+                    }
 
-					free(buf);
-				}
-			}else{
-				// There was an error begining the request
-				if (logEnabled) LogFM("downloadFile.error", "An error has ocurred trying to request server");
-				httpcCloseContext(&context);
-				httpcExit();
-				fsExit();
-				return -1;
-			}
-		}else{
-			// There was a problem opening HTTP context
-			if (logEnabled) LogFM("downloadFile.error", "An error has ocurred trying to open HTTP context");
-			httpcCloseContext(&context);
-			httpcExit();
-			fsExit();
-			return -1;
-		}
-	} while ((statuscode >= 301 && statuscode <= 303) || (statuscode >= 307 && statuscode <= 308));
-	httpcCloseContext(&context);
+                    free(buf);
+                }
+            } else {
+                // There was an error begining the request
+                if (logEnabled) {
+                    LogFM("downloadFile.error", "An error has ocurred trying to request server");
+                }
+                httpcCloseContext(&context);
+                httpcExit();
+                fsExit();
+                return -1;
+            }
+        } else {
+            // There was a problem opening HTTP context
+            if (logEnabled) {
+                LogFM("downloadFile.error", "An error has ocurred trying to open HTTP context");
+            }
+            httpcCloseContext(&context);
+            httpcExit();
+            fsExit();
+            return -1;
+        }
+    } while ((statuscode >= 301 && statuscode <= 303) || (statuscode >= 307 && statuscode <= 308));
+    httpcCloseContext(&context);
 
-	httpcExit();
-	fsExit();
-	return 0;
+    httpcExit();
+    fsExit();
+    return 0;
 }
 
 /**
  * Check for a TWLoader update.
  * @return 0 if an update is available; non-zero if up to date or an error occurred.
  */
-int checkUpdate(void) {
-	if (logEnabled)	LogFM("checkUpdate", "Checking updates...");
-	static const char title[] = "Now checking TWLoader version...";
-	DialogBoxAppear(title, 0);
-	sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-	if (screenmode == SCREEN_MODE_SETTINGS) {
-		sf2d_draw_texture(settingstex, 0, 0);
-	}
-	sf2d_draw_texture(dialogboxtex, 0, 0);
-	sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, title);
-	sf2d_end_frame();
-	sf2d_swapbuffers();
-	remove("sdmc:/_nds/twloader/ver");
-	int res = downloadFile(DOWNLOAD_VER_URL, "/_nds/twloader/ver", MEDIA_SD_FILE);
-	if (logEnabled)	LogFM("checkUpdate", "downloadFile() end");
-	if (res == 0) {
+int checkUpdate(void)
+{
+    if (logEnabled) {
+        LogFM("checkUpdate", "Checking updates...");
+    }
+    static const char title[] = "Now checking TWLoader version...";
+    DialogBoxAppear(title, 0);
+    sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+    if (screenmode == SCREEN_MODE_SETTINGS) {
+        sf2d_draw_texture(settingstex, 0, 0);
+    }
+    sf2d_draw_texture(dialogboxtex, 0, 0);
+    sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, title);
+    sf2d_end_frame();
+    sf2d_swapbuffers();
+    remove("sdmc:/_nds/twloader/ver");
+    int res = downloadFile(DOWNLOAD_VER_URL, "/_nds/twloader/ver", MEDIA_SD_FILE);
+    if (logEnabled) {
+        LogFM("checkUpdate", "downloadFile() end");
+    }
+    if (res == 0) {
 
-		bool isUnknown = false;
-		FILE* VerFile = fopen("sdmc:/_nds/twloader/ver", "r");
-		if (VerFile) {
-			/** This is the same method as checkBootstrapVersion() **/
-			long fileSize;
-			
-			fseek(VerFile , 0 , SEEK_END);
-			fileSize = ftell(VerFile);
-			
-			char buf[fileSize + 1];
+        bool isUnknown = false;
+        FILE* VerFile = fopen("sdmc:/_nds/twloader/ver", "r");
+        if (VerFile) {
+            /** This is the same method as checkBootstrapVersion() **/
+            long fileSize;
 
-			// Clean buf array
-			for (size_t i=0; i< sizeof(buf); i++){
-				buf[i] = '\0';
-			}	
-			
-			rewind(VerFile);
-			fread(buf,1,sizeof(settings_latestvertext),VerFile);
-			buf[sizeof(buf) - 1] = '\0';
-			strcpy(settings_latestvertext, buf);
-			fclose(VerFile);
-			/** End **/
-		} else {
-			// Unable to open the version file.
-			strcpy(settings_latestvertext, "Unknown");
-			isUnknown = true;
-		}
-		if (logEnabled)	LogFMA("checkUpdate", "Reading downloaded version:", settings_latestvertext);
-		if (logEnabled)	LogFMA("checkUpdate", "Reading GUI version:", settings_vertext);
+            fseek(VerFile, 0, SEEK_END);
+            fileSize = ftell(VerFile);
 
-		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-		if (screenmode == SCREEN_MODE_SETTINGS) {
-			sf2d_draw_texture(settingstex, 0, 0);
-		}
-		sf2d_draw_texture(dialogboxtex, 0, 0);
-		if (!isUnknown && !strcmp(settings_latestvertext, settings_vertext)) {
-			// Version is not different.
-			if (logEnabled)	LogFMA("checkUpdate", "Comparing...", "Are equals");
-		
-			if (screenmode == SCREEN_MODE_SETTINGS) {				
-				showdialogbox = false;
-			}else{
-				sf2d_end_frame();
-				sf2d_swapbuffers();
-			}
-			
-			if (logEnabled)	LogFM("checkUpdate", "TWLoader is up-to-date!");			
-			return -1;
-		}
-		if (logEnabled)	LogFMA("checkUpdate", "Comparing...", "NO equals");
-		showdialogbox = false;
-		return 0;
-	}
-	if (logEnabled)	LogFM("checkUpdate", "Problem downloading ver file!");
-	showdialogbox = false;
-	return -1;
+            char buf[fileSize + 1];
+
+            // Clean buf array
+            for (size_t i = 0; i < sizeof(buf); i++) {
+                buf[i] = '\0';
+            }
+
+            rewind(VerFile);
+            fread(buf, 1, sizeof(settings_latestvertext), VerFile);
+            buf[sizeof(buf) - 1] = '\0';
+            strcpy(settings_latestvertext, buf);
+            fclose(VerFile);
+            /** End **/
+        } else {
+            // Unable to open the version file.
+            strcpy(settings_latestvertext, "Unknown");
+            isUnknown = true;
+        }
+        if (logEnabled) {
+            LogFMA("checkUpdate", "Reading downloaded version:", settings_latestvertext);
+        }
+        if (logEnabled) {
+            LogFMA("checkUpdate", "Reading GUI version:", settings_vertext);
+        }
+
+        sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+        if (screenmode == SCREEN_MODE_SETTINGS) {
+            sf2d_draw_texture(settingstex, 0, 0);
+        }
+        sf2d_draw_texture(dialogboxtex, 0, 0);
+        if (!isUnknown && !strcmp(settings_latestvertext, settings_vertext)) {
+            // Version is not different.
+            if (logEnabled) {
+                LogFMA("checkUpdate", "Comparing...", "Are equals");
+            }
+
+            if (screenmode == SCREEN_MODE_SETTINGS) {
+                showdialogbox = false;
+            } else {
+                sf2d_end_frame();
+                sf2d_swapbuffers();
+            }
+
+            if (logEnabled) {
+                LogFM("checkUpdate", "TWLoader is up-to-date!");
+            }
+            return -1;
+        }
+        if (logEnabled) {
+            LogFMA("checkUpdate", "Comparing...", "NO equals");
+        }
+        showdialogbox = false;
+        return 0;
+    }
+    if (logEnabled) {
+        LogFM("checkUpdate", "Problem downloading ver file!");
+    }
+    showdialogbox = false;
+    return -1;
 }
 
 /**
  * Download the TWLoader CIAs.
  */
-void DownloadTWLoaderCIAs(void) {
-	sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, "Now downloading TWLoader to latest version...");
-	sftd_draw_textf(font, 12, 30, RGBA8(0, 0, 0, 255), 12, "(GUI)");
-	sf2d_end_frame();
-	sf2d_swapbuffers();	
-	
-	int res;
-	
-	// Check if sdmc:/cia folder exist (most A9LH users have that folder already)
-	struct stat st;
-	if(stat("sdmc:/cia",&st) == 0){		
-		// Use root/cia folder instead
-		res = downloadFile(DOWNLOAD_TWLOADER_URL,"/cia/TWLoader.cia", MEDIA_SD_CIA);
-	}else{
-		mkdir("sdmc:/_nds/twloader/cia", 0777); // Use twloader/cia folder instead
-		res = downloadFile(DOWNLOAD_TWLOADER_URL,"/_nds/twloader/cia/TWLoader.cia", MEDIA_SD_CIA);
-	}
-	
-	sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-	if (screenmode == SCREEN_MODE_SETTINGS) {
-		sf2d_draw_texture(settingstex, 0, 0);
-	}
-	sf2d_draw_texture(dialogboxtex, 0, 0);
-	if (res == 0) {
-		sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, "Now downloading latest TWLoader version...");
-		sftd_draw_textf(font, 12, 30, RGBA8(0, 0, 0, 255), 12, "(TWLNAND side CIA)");
-		sf2d_end_frame();
-		sf2d_swapbuffers();
-		// Delete first if installed.
-		if(checkTWLNANDSide()){
-			amInit();
-			AM_DeleteTitle(MEDIATYPE_NAND, TWLNAND_TID);
-			amExit();
-		}
-		if(stat("sdmc:/cia",&st) == 0){		
-			// Use root/cia folder instead
-			res = downloadFile(DOWNLOAD_TWLNANDSIDE_URL,"/cia/TWLoader - TWLNAND side.cia", MEDIA_NAND_CIA);
-		}else{		
-			res = downloadFile(DOWNLOAD_TWLNANDSIDE_URL,"/_nds/twloader/cia/TWLoader - TWLNAND side.cia", MEDIA_NAND_CIA);
-		}
-		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-		if (screenmode == SCREEN_MODE_SETTINGS) {
-			sf2d_draw_texture(settingstex, 0, 0);
-		}
-		sf2d_draw_texture(dialogboxtex, 0, 0);
-		if (res == 0) {
-			sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, "Now returning to HOME Menu...");
-			sf2d_end_frame();
-			sf2d_swapbuffers();
-			run = false;
-		} else {
-			DialogBoxDisappear("Download failed.", 0);
-		}
-	} else {
-		DialogBoxDisappear("Update failed.", 0);
-	}
+void DownloadTWLoaderCIAs(void)
+{
+    sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, "Now downloading TWLoader to latest version...");
+    sftd_draw_textf(font, 12, 30, RGBA8(0, 0, 0, 255), 12, "(GUI)");
+    sf2d_end_frame();
+    sf2d_swapbuffers();
+
+    int res;
+
+    // Check if sdmc:/cia folder exist (most A9LH users have that folder already)
+    struct stat st;
+    if (stat("sdmc:/cia", &st) == 0) {
+        // Use root/cia folder instead
+        res = downloadFile(DOWNLOAD_TWLOADER_URL, "/cia/TWLoader.cia", MEDIA_SD_CIA);
+    } else {
+        mkdir("sdmc:/_nds/twloader/cia", 0777); // Use twloader/cia folder instead
+        res = downloadFile(DOWNLOAD_TWLOADER_URL, "/_nds/twloader/cia/TWLoader.cia", MEDIA_SD_CIA);
+    }
+
+    sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+    if (screenmode == SCREEN_MODE_SETTINGS) {
+        sf2d_draw_texture(settingstex, 0, 0);
+    }
+    sf2d_draw_texture(dialogboxtex, 0, 0);
+    if (res == 0) {
+        sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, "Now downloading latest TWLoader version...");
+        sftd_draw_textf(font, 12, 30, RGBA8(0, 0, 0, 255), 12, "(TWLNAND side CIA)");
+        sf2d_end_frame();
+        sf2d_swapbuffers();
+        // Delete first if installed.
+        if (checkTWLNANDSide()) {
+            amInit();
+            AM_DeleteTitle(MEDIATYPE_NAND, TWLNAND_TID);
+            amExit();
+        }
+        if (stat("sdmc:/cia", &st) == 0) {
+            // Use root/cia folder instead
+            res = downloadFile(DOWNLOAD_TWLNANDSIDE_URL, "/cia/TWLoader - TWLNAND side.cia", MEDIA_NAND_CIA);
+        } else {
+            res = downloadFile(DOWNLOAD_TWLNANDSIDE_URL, "/_nds/twloader/cia/TWLoader - TWLNAND side.cia", MEDIA_NAND_CIA);
+        }
+        sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+        if (screenmode == SCREEN_MODE_SETTINGS) {
+            sf2d_draw_texture(settingstex, 0, 0);
+        }
+        sf2d_draw_texture(dialogboxtex, 0, 0);
+        if (res == 0) {
+            sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, "Now returning to HOME Menu...");
+            sf2d_end_frame();
+            sf2d_swapbuffers();
+            run = false;
+        } else {
+            DialogBoxDisappear("Download failed.", 0);
+        }
+    } else {
+        DialogBoxDisappear("Update failed.", 0);
+    }
 }
 
 /**
  * Update nds-bootstrap to the latest unofficial build.
  */
-void UpdateBootstrapUnofficial(void) {
-	static const char title[] = "Now updating bootstrap (Unofficial)...";
-	DialogBoxAppear(title, 0);
-	sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-	if (screenmode == SCREEN_MODE_SETTINGS) {
-		sf2d_draw_texture(settingstex, 0, 0);
-	}
-	sf2d_draw_texture(dialogboxtex, 0, 0);
-	sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, title);
-	sf2d_end_frame();
-	sf2d_swapbuffers();
-	remove("sdmc:/_nds/bootstrap.nds");
-	remove("sdmc:/_nds/twloader/unofficial-bootstrap");
-	downloadBootstrapVersion(false);
-	checkBootstrapVersion();
-	downloadFile(DOWNLOAD_UNOFFICIALBOOTSTRAP_URL,"/_nds/unofficial-bootstrap.nds", MEDIA_SD_FILE);
-	if (screenmode == SCREEN_MODE_SETTINGS) {
-		DialogBoxDisappear("Done!", 0);
-	}
+void UpdateBootstrapUnofficial(void)
+{
+    static const char title[] = "Now updating bootstrap (Unofficial)...";
+    DialogBoxAppear(title, 0);
+    sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+    if (screenmode == SCREEN_MODE_SETTINGS) {
+        sf2d_draw_texture(settingstex, 0, 0);
+    }
+    sf2d_draw_texture(dialogboxtex, 0, 0);
+    sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, title);
+    sf2d_end_frame();
+    sf2d_swapbuffers();
+    remove("sdmc:/_nds/bootstrap.nds");
+    remove("sdmc:/_nds/twloader/unofficial-bootstrap");
+    downloadBootstrapVersion(false);
+    checkBootstrapVersion();
+    downloadFile(DOWNLOAD_UNOFFICIALBOOTSTRAP_URL, "/_nds/unofficial-bootstrap.nds", MEDIA_SD_FILE);
+    if (screenmode == SCREEN_MODE_SETTINGS) {
+        DialogBoxDisappear("Done!", 0);
+    }
 }
 
 /**
  * Update nds-bootstrap to the latest release build.
  */
-void UpdateBootstrapRelease(void) {
-	static const char title[] = "Now updating bootstrap (Release)...";
-	DialogBoxAppear(title, 0);
-	sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-	if (screenmode == SCREEN_MODE_SETTINGS) {
-		sf2d_draw_texture(settingstex, 0, 0);
-	}
-	sf2d_draw_texture(dialogboxtex, 0, 0);
-	sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, title);
-	sf2d_end_frame();
-	sf2d_swapbuffers();
-	remove("sdmc:/_nds/bootstrap.nds");
-	remove("sdmc:/_nds/twloader/release-bootstrap");
-	downloadBootstrapVersion(true);
-	checkBootstrapVersion();
-	downloadFile(DOWNLOAD_OFFICIALBOOTSTRAP_URL,"/_nds/release-bootstrap.nds", MEDIA_SD_FILE);
-	if (screenmode == SCREEN_MODE_SETTINGS) {
-		DialogBoxDisappear("Done!", 0);
-	}
+void UpdateBootstrapRelease(void)
+{
+    static const char title[] = "Now updating bootstrap (Release)...";
+    DialogBoxAppear(title, 0);
+    sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+    if (screenmode == SCREEN_MODE_SETTINGS) {
+        sf2d_draw_texture(settingstex, 0, 0);
+    }
+    sf2d_draw_texture(dialogboxtex, 0, 0);
+    sftd_draw_textf(font, 12, 16, RGBA8(0, 0, 0, 255), 12, title);
+    sf2d_end_frame();
+    sf2d_swapbuffers();
+    remove("sdmc:/_nds/bootstrap.nds");
+    remove("sdmc:/_nds/twloader/release-bootstrap");
+    downloadBootstrapVersion(true);
+    checkBootstrapVersion();
+    downloadFile(DOWNLOAD_OFFICIALBOOTSTRAP_URL, "/_nds/release-bootstrap.nds", MEDIA_SD_FILE);
+    if (screenmode == SCREEN_MODE_SETTINGS) {
+        DialogBoxDisappear("Done!", 0);
+    }
 }
 
 /**
@@ -371,111 +408,111 @@ void UpdateBootstrapRelease(void) {
  * @param ba_region_fallback Pointer to const char* to store the fallback region.
  * @return GameTDB region code.
  */
-static const char *getGameTDBRegion(u8 tid_region, const char **pFallback)
+static const char* getGameTDBRegion(u8 tid_region, const char** pFallback)
 {
-	// European boxart languages.
-	static const char *const ba_langs_eur[] = {
-		"EN",	// Japanese (English used in place)
-		"EN",	// English
-		"FR",	// French
-		"DE",	// German
-		"IT",	// Italian
-		"ES",	// Spanish
-		"ZHCN",	// Simplified Chinese
-		"KO",	// Korean
-		"NL",	// Dutch
-		"PT",	// Portugese
-		"RU",	// Russian
-		"ZHTW"	// Traditional Chinese
-	};
+    // European boxart languages.
+    static const char* const ba_langs_eur[] = {
+        "EN",   // Japanese (English used in place)
+        "EN",   // English
+        "FR",   // French
+        "DE",   // German
+        "IT",   // Italian
+        "ES",   // Spanish
+        "ZHCN", // Simplified Chinese
+        "KO",   // Korean
+        "NL",   // Dutch
+        "PT",   // Portugese
+        "RU",   // Russian
+        "ZHTW"  // Traditional Chinese
+    };
 
-	const char *ba_region_fallback = NULL;
-	const char *ba_region;
+    const char* ba_region_fallback = NULL;
+    const char* ba_region;
 
-	// Get the system region.
-	// This is needed in order to differentiate the 'O' region code
-	// for USA and Europe.
-	static u8 region = 0xFF;
-	if (region == 0xFF) {
-		int res = CFGU_SecureInfoGetRegion(&region);
-		if (res != 0) {
-			// Can't get the region. Assume USA.
-			region = CFG_REGION_USA;
-		}
-	}
+    // Get the system region.
+    // This is needed in order to differentiate the 'O' region code
+    // for USA and Europe.
+    static u8 region = 0xFF;
+    if (region == 0xFF) {
+        int res = CFGU_SecureInfoGetRegion(&region);
+        if (res != 0) {
+            // Can't get the region. Assume USA.
+            region = CFG_REGION_USA;
+        }
+    }
 
-	switch (tid_region) {
-		case 'E':
-		case 'T':
-			ba_region = "US";	// USA
-			break;
-		case 'J':
-			ba_region = "JA";	// Japanese
-			break;
-		case 'K':
-			ba_region = "KO";	// Korean
-			break;
+    switch (tid_region) {
+        case 'E':
+        case 'T':
+            ba_region = "US";   // USA
+            break;
+        case 'J':
+            ba_region = "JA";   // Japanese
+            break;
+        case 'K':
+            ba_region = "KO";   // Korean
+            break;
 
-		case 'O':			// USA/Europe
-			if (region == CFG_REGION_USA) {
-				// System is USA region.
-				// Get the USA boxart if it's available.
-				ba_region = "US";
-				ba_region_fallback = "EN";
-				break;
-			}
-			// fall-through
-		case 'P':			// Europe
-		default:
-			// System is not USA region.
-			// Get the European boxart that matches the system's language.
-			// TODO: Check country code for Australia.
-			// This requires parsing the Config savegame. (GetConfigInfoBlk2())
-			// Reference: https://3dbrew.org/wiki/Config_Savegame
-			ba_region = ba_langs_eur[language];
-			if (strcmp(ba_region, "EN") != 0) {
-				// Fallback to EN if the specified language isn't available.
-				ba_region_fallback = "EN";
-			}
-			break;
+        case 'O':           // USA/Europe
+            if (region == CFG_REGION_USA) {
+                // System is USA region.
+                // Get the USA boxart if it's available.
+                ba_region = "US";
+                ba_region_fallback = "EN";
+                break;
+            }
+        // fall-through
+        case 'P':           // Europe
+        default:
+            // System is not USA region.
+            // Get the European boxart that matches the system's language.
+            // TODO: Check country code for Australia.
+            // This requires parsing the Config savegame. (GetConfigInfoBlk2())
+            // Reference: https://3dbrew.org/wiki/Config_Savegame
+            ba_region = ba_langs_eur[language];
+            if (strcmp(ba_region, "EN") != 0) {
+                // Fallback to EN if the specified language isn't available.
+                ba_region_fallback = "EN";
+            }
+            break;
 
-		case 'U':
-			// Alternate country code for Australia.
-			ba_region = "AU";
-			ba_region_fallback = "EN";
-			break;
+        case 'U':
+            // Alternate country code for Australia.
+            ba_region = "AU";
+            ba_region_fallback = "EN";
+            break;
 
-		// European country-specific localizations.
-		case 'D':
-			ba_region = "DE";	// German
-			ba_region_fallback = "EN";
-			break;
-		case 'F':
-			ba_region = "FR";	// French
-			ba_region_fallback = "EN";
-			break;
-		case 'H':
-			ba_region = "NL";	// Dutch
-			ba_region_fallback = "EN";
-			break;
-		case 'I':
-			ba_region = "IT";	// Italian
-			ba_region_fallback = "EN";
-			break;
-		case 'R':
-			ba_region = "RU";	// Russian
-			ba_region_fallback = "EN";
-			break;
-		case 'S':
-			ba_region = "ES";	// Spanish
-			ba_region_fallback = "EN";
-			break;
-	}
+        // European country-specific localizations.
+        case 'D':
+            ba_region = "DE";   // German
+            ba_region_fallback = "EN";
+            break;
+        case 'F':
+            ba_region = "FR";   // French
+            ba_region_fallback = "EN";
+            break;
+        case 'H':
+            ba_region = "NL";   // Dutch
+            ba_region_fallback = "EN";
+            break;
+        case 'I':
+            ba_region = "IT";   // Italian
+            ba_region_fallback = "EN";
+            break;
+        case 'R':
+            ba_region = "RU";   // Russian
+            ba_region_fallback = "EN";
+            break;
+        case 'S':
+            ba_region = "ES";   // Spanish
+            ba_region_fallback = "EN";
+            break;
+    }
 
-	if (pFallback) {
-		*pFallback = ba_region_fallback;
-	}
-	return ba_region;
+    if (pFallback) {
+        *pFallback = ba_region_fallback;
+    }
+    return ba_region;
 }
 
 /**
@@ -483,30 +520,33 @@ static const char *getGameTDBRegion(u8 tid_region, const char **pFallback)
  * @param ba_TID Game ID. (4 characters, NULL-terminated)
  * @return 0 on success; non-zero on error.
  */
-static int downloadBoxArt_internal(const char *ba_TID)
+static int downloadBoxArt_internal(const char* ba_TID)
 {
-	char path[256];
-	char http_url[256];
-	if (logEnabled)	LogFMA("downloadBoxArt_internal", "Downloading boxart for TID", ba_TID);
+    char path[256];
+    char http_url[256];
+    if (logEnabled) {
+        LogFMA("downloadBoxArt_internal", "Downloading boxart for TID", ba_TID);
+    }
 
-	const char *ba_region_fallback = NULL;
-	const char *ba_region = getGameTDBRegion(ba_TID[3], &ba_region_fallback);
-	if (!ba_region)
-		return -1;
+    const char* ba_region_fallback = NULL;
+    const char* ba_region = getGameTDBRegion(ba_TID[3], &ba_region_fallback);
+    if (!ba_region) {
+        return -1;
+    }
 
-	// NOTE: downloadFile() doesn't use devoptab,
-	// so don't prefix the filename with sdmc:/.
-	snprintf(path, sizeof(path), "/_nds/twloader/boxart/%.4s.png", ba_TID);
-	snprintf(http_url, sizeof(http_url), "http://art.gametdb.com/ds/coverS/%s/%.4s.png",
-		 ba_region, ba_TID);
-	int res = downloadFile(http_url, path, MEDIA_SD_FILE);
-	if (res != 0 && ba_region_fallback != NULL) {
-		// Try the fallback region.
-		snprintf(http_url, sizeof(http_url), "http://art.gametdb.com/ds/coverS/%s/%.4s.png",
-			 ba_region_fallback, ba_TID);
-		res = downloadFile(http_url, path, MEDIA_SD_FILE);
-	}
-	return res;
+    // NOTE: downloadFile() doesn't use devoptab,
+    // so don't prefix the filename with sdmc:/.
+    snprintf(path, sizeof(path), "/_nds/twloader/boxart/%.4s.png", ba_TID);
+    snprintf(http_url, sizeof(http_url), "http://art.gametdb.com/ds/coverS/%s/%.4s.png",
+             ba_region, ba_TID);
+    int res = downloadFile(http_url, path, MEDIA_SD_FILE);
+    if (res != 0 && ba_region_fallback != NULL) {
+        // Try the fallback region.
+        snprintf(http_url, sizeof(http_url), "http://art.gametdb.com/ds/coverS/%s/%.4s.png",
+                 ba_region_fallback, ba_TID);
+        res = downloadFile(http_url, path, MEDIA_SD_FILE);
+    }
+    return res;
 }
 
 /**
@@ -516,146 +556,185 @@ static int downloadBoxArt_internal(const char *ba_TID)
 
 int downloadBootstrapVersion(bool type)
 {
-	int res = -1;
-	if (type){		
-		res = downloadFile(DOWNLOAD_OFFICIALBOOTSTRAP_VER_URL,"/_nds/twloader/release-bootstrap", MEDIA_SD_FILE);
-	}else{
-		res = downloadFile(DOWNLOAD_UNOFFICIALBOOTSTRAP_VER_URL,"/_nds/twloader/unofficial-bootstrap", MEDIA_SD_FILE);
-	}
-	
-	return res;
+    int res = -1;
+    if (type) {
+        res = downloadFile(DOWNLOAD_OFFICIALBOOTSTRAP_VER_URL, "/_nds/twloader/release-bootstrap", MEDIA_SD_FILE);
+    } else {
+        res = downloadFile(DOWNLOAD_UNOFFICIALBOOTSTRAP_VER_URL, "/_nds/twloader/unofficial-bootstrap", MEDIA_SD_FILE);
+    }
+
+    return res;
 }
 
 /**
  * check, download and store bootstrap version
  */
 
-void checkBootstrapVersion(void){
-	
-	bool res = false;
-	long fileSize;
-	char buf[26];
-	if (logEnabled) LogFM("download.checkBootstrapVersion()", "Checking bootstrap version");
-	// Clean buf array
-	for (size_t i=0; i< sizeof(buf); i++){
-		buf[i] = '\0';
-	}
-	
-	FILE* VerFile = fopen("sdmc:/_nds/twloader/release-bootstrap", "r");
-	if (!VerFile){
-		if (logEnabled) LogFM("download.checkBootstrapVersion()", "release-bootstrap ver file not found.");
-		if(checkWifiStatus()){
-			if (logEnabled) LogFM("download.checkBootstrapVersion()", "downloading release-bootstrap ver file.");
-			res = downloadBootstrapVersion(true); // true == release
-		}else{
-			if (logEnabled) LogFM("download.checkBootstrapVersion()", "No release version file available.");
-			settings_releasebootstrapver = "No version available";
-		}
-	}else{
-		fseek(VerFile , 0 , SEEK_END);
-		fileSize = ftell(VerFile);
-		rewind(VerFile);
-		fread(buf,1,fileSize,VerFile);
-		buf[fileSize - 1] = '\0';
-		settings_releasebootstrapver = buf;
-		fclose(VerFile);
-		if (logEnabled) LogFMA("download.checkBootstrapVersion()", "Reading release bootstrap ver file:", settings_releasebootstrapver.c_str());
-	}
-	
-	if (res == -1) settings_releasebootstrapver = "No version available";
-	
-	fclose(VerFile);
-	
-	// Clean buf array
-	for (size_t i=0; i< sizeof(buf); i++){
-		buf[i] = '\0';
-	}
-	
-	if(res == 0){
-		if (logEnabled) LogFM("download.checkBootstrapVersion()", "Re-opening release bootstrap ver file.");
-		// Try to open again
-		VerFile = fopen("sdmc:/_nds/twloader/release-bootstrap", "r");
-		if (!VerFile){
-				if (logEnabled) LogFM("download.checkBootstrapVersion()", "No release version file available #2.");
-				settings_releasebootstrapver = "No version available";
-		}else{
-			fseek(VerFile , 0 , SEEK_END);
-			fileSize = ftell(VerFile);
-			rewind(VerFile);
-			fread(buf,1,fileSize,VerFile);
-			buf[fileSize - 1] = '\0';
-			settings_releasebootstrapver = buf;
-			fclose(VerFile);
-			if (logEnabled) LogFMA("download.checkBootstrapVersion()", "Reading release bootstrap ver file #2:", settings_releasebootstrapver.c_str());
-		}
-	}
-	
-	res = false; // Just to be sure	
-	
-	VerFile = fopen("sdmc:/_nds/twloader/unofficial-bootstrap", "r");
-	if (!VerFile){
-		if (logEnabled) LogFM("download.checkBootstrapVersion()", "unofficial-bootstrap ver file not found.");
-		if(checkWifiStatus()){
-			if (logEnabled) LogFM("download.checkBootstrapVersion()", "downloading unofficial-bootstrap ver file.");
-			res = downloadBootstrapVersion(false); // false == unofficial
-		}else{
-			if (logEnabled) LogFM("download.checkBootstrapVersion()", "No unofficial version file available.");
-			settings_unofficialbootstrapver = "No version available";
-		}
-	}else{
-		fseek(VerFile , 0 , SEEK_END);
-		fileSize = ftell(VerFile);
-		rewind(VerFile);
-		fread(buf,1,fileSize,VerFile);
-		buf[fileSize - 1] = '\0';
-		settings_unofficialbootstrapver = buf;
-		fclose(VerFile);
-		if (logEnabled) LogFMA("download.checkBootstrapVersion()", "Reading unofficial bootstrap ver file:", settings_unofficialbootstrapver.c_str());
-	}
-	if (res == -1) settings_unofficialbootstrapver = "No version available";
+void checkBootstrapVersion(void)
+{
 
-	fclose(VerFile);
-	
-	if(res == 0){
-		if (logEnabled) LogFM("download.checkBootstrapVersion()", "Re-opening unofficial bootstrap ver file.");
-		// Try to open again
-		VerFile = fopen("sdmc:/_nds/twloader/unofficial-bootstrap", "r");
-		if (!VerFile){
-				if (logEnabled) LogFM("download.checkBootstrapVersion()", "No unofficial version file available #2.");		
-				settings_unofficialbootstrapver = "No version available";
-		}else{
-			fseek(VerFile , 0 , SEEK_END);
-			fileSize = ftell(VerFile);
-			rewind(VerFile);
-			fread(buf,1,fileSize,VerFile);
-			buf[fileSize - 1] = '\0';
-			settings_unofficialbootstrapver = buf;
-			fclose(VerFile);
-			if (logEnabled) LogFMA("download.checkBootstrapVersion()", "Reading unofficial bootstrap ver file #2:", settings_unofficialbootstrapver.c_str());
-		}
-	}
+    bool res = false;
+    long fileSize;
+    char buf[26];
+    if (logEnabled) {
+        LogFM("download.checkBootstrapVersion()", "Checking bootstrap version");
+    }
+    // Clean buf array
+    for (size_t i = 0; i < sizeof(buf); i++) {
+        buf[i] = '\0';
+    }
+
+    FILE* VerFile = fopen("sdmc:/_nds/twloader/release-bootstrap", "r");
+    if (!VerFile) {
+        if (logEnabled) {
+            LogFM("download.checkBootstrapVersion()", "release-bootstrap ver file not found.");
+        }
+        if (checkWifiStatus()) {
+            if (logEnabled) {
+                LogFM("download.checkBootstrapVersion()", "downloading release-bootstrap ver file.");
+            }
+            res = downloadBootstrapVersion(true); // true == release
+        } else {
+            if (logEnabled) {
+                LogFM("download.checkBootstrapVersion()", "No release version file available.");
+            }
+            settings_releasebootstrapver = "No version available";
+        }
+    } else {
+        fseek(VerFile, 0, SEEK_END);
+        fileSize = ftell(VerFile);
+        rewind(VerFile);
+        fread(buf, 1, fileSize, VerFile);
+        buf[fileSize - 1] = '\0';
+        settings_releasebootstrapver = buf;
+        fclose(VerFile);
+        if (logEnabled) {
+            LogFMA("download.checkBootstrapVersion()", "Reading release bootstrap ver file:", settings_releasebootstrapver.c_str());
+        }
+    }
+
+    if (res == -1) {
+        settings_releasebootstrapver = "No version available";
+    }
+
+    fclose(VerFile);
+
+    // Clean buf array
+    for (size_t i = 0; i < sizeof(buf); i++) {
+        buf[i] = '\0';
+    }
+
+    if (res == 0) {
+        if (logEnabled) {
+            LogFM("download.checkBootstrapVersion()", "Re-opening release bootstrap ver file.");
+        }
+        // Try to open again
+        VerFile = fopen("sdmc:/_nds/twloader/release-bootstrap", "r");
+        if (!VerFile) {
+            if (logEnabled) {
+                LogFM("download.checkBootstrapVersion()", "No release version file available #2.");
+            }
+            settings_releasebootstrapver = "No version available";
+        } else {
+            fseek(VerFile, 0, SEEK_END);
+            fileSize = ftell(VerFile);
+            rewind(VerFile);
+            fread(buf, 1, fileSize, VerFile);
+            buf[fileSize - 1] = '\0';
+            settings_releasebootstrapver = buf;
+            fclose(VerFile);
+            if (logEnabled) {
+                LogFMA("download.checkBootstrapVersion()", "Reading release bootstrap ver file #2:", settings_releasebootstrapver.c_str());
+            }
+        }
+    }
+
+    res = false; // Just to be sure
+
+    VerFile = fopen("sdmc:/_nds/twloader/unofficial-bootstrap", "r");
+    if (!VerFile) {
+        if (logEnabled) {
+            LogFM("download.checkBootstrapVersion()", "unofficial-bootstrap ver file not found.");
+        }
+        if (checkWifiStatus()) {
+            if (logEnabled) {
+                LogFM("download.checkBootstrapVersion()", "downloading unofficial-bootstrap ver file.");
+            }
+            res = downloadBootstrapVersion(false); // false == unofficial
+        } else {
+            if (logEnabled) {
+                LogFM("download.checkBootstrapVersion()", "No unofficial version file available.");
+            }
+            settings_unofficialbootstrapver = "No version available";
+        }
+    } else {
+        fseek(VerFile, 0, SEEK_END);
+        fileSize = ftell(VerFile);
+        rewind(VerFile);
+        fread(buf, 1, fileSize, VerFile);
+        buf[fileSize - 1] = '\0';
+        settings_unofficialbootstrapver = buf;
+        fclose(VerFile);
+        if (logEnabled) {
+            LogFMA("download.checkBootstrapVersion()", "Reading unofficial bootstrap ver file:", settings_unofficialbootstrapver.c_str());
+        }
+    }
+    if (res == -1) {
+        settings_unofficialbootstrapver = "No version available";
+    }
+
+    fclose(VerFile);
+
+    if (res == 0) {
+        if (logEnabled) {
+            LogFM("download.checkBootstrapVersion()", "Re-opening unofficial bootstrap ver file.");
+        }
+        // Try to open again
+        VerFile = fopen("sdmc:/_nds/twloader/unofficial-bootstrap", "r");
+        if (!VerFile) {
+            if (logEnabled) {
+                LogFM("download.checkBootstrapVersion()", "No unofficial version file available #2.");
+            }
+            settings_unofficialbootstrapver = "No version available";
+        } else {
+            fseek(VerFile, 0, SEEK_END);
+            fileSize = ftell(VerFile);
+            rewind(VerFile);
+            fread(buf, 1, fileSize, VerFile);
+            buf[fileSize - 1] = '\0';
+            settings_unofficialbootstrapver = buf;
+            fclose(VerFile);
+            if (logEnabled) {
+                LogFMA("download.checkBootstrapVersion()", "Reading unofficial bootstrap ver file #2:", settings_unofficialbootstrapver.c_str());
+            }
+        }
+    }
 }
- 
+
 /**
  * Download Slot-1 boxart.
  */
 void downloadSlot1BoxArt(const char* TID)
 {
-	if (logEnabled)	LogFM("Main.downloadSlot1BoxArt", "Checking box art (Slot-1 card).");
-	
-	char ba_TID[5];
-	snprintf(ba_TID, sizeof(ba_TID), "%.4s", TID);
-	ba_TID[4] = 0;
+    if (logEnabled) {
+        LogFM("Main.downloadSlot1BoxArt", "Checking box art (Slot-1 card).");
+    }
 
-	char path[256];
-	snprintf(path, sizeof(path), "/_nds/twloader/boxart/%.4s.png", ba_TID);
-	if (!access(path, F_OK)) {
-		// File already exists.
-		return;
-	}
+    char ba_TID[5];
+    snprintf(ba_TID, sizeof(ba_TID), "%.4s", TID);
+    ba_TID[4] = 0;
 
-	if (logEnabled)	LogFM("Main.downloadSlot1BoxArt", "Downloading box art (Slot-1 card)");
-	downloadBoxArt_internal(ba_TID);
+    char path[256];
+    snprintf(path, sizeof(path), "/_nds/twloader/boxart/%.4s.png", ba_TID);
+    if (!access(path, F_OK)) {
+        // File already exists.
+        return;
+    }
+
+    if (logEnabled) {
+        LogFM("Main.downloadSlot1BoxArt", "Downloading box art (Slot-1 card)");
+    }
+    downloadBoxArt_internal(ba_TID);
 }
 
 /**
@@ -663,172 +742,186 @@ void downloadSlot1BoxArt(const char* TID)
  */
 void downloadBoxArt(void)
 {
-	char path[256];
+    char path[256];
 
-	// First, check if we're missing any boxart on the SD card.
-	unordered_set<u32> boxart_all_tids;	// Title IDs of all ROM files.
-	vector<u32> boxart_dl_tids;	// Title IDs of boxart to download.
-	boxart_all_tids.reserve(files.size() + fcfiles.size());
-	boxart_dl_tids.reserve(files.size() + fcfiles.size());
-	if (logEnabled)	LogFM("Download.downloadBoxArt", "Checking missing boxart on SD card...");
+    // First, check if we're missing any boxart on the SD card.
+    unordered_set<u32> boxart_all_tids; // Title IDs of all ROM files.
+    vector<u32> boxart_dl_tids; // Title IDs of boxart to download.
+    boxart_all_tids.reserve(files.size() + fcfiles.size());
+    boxart_dl_tids.reserve(files.size() + fcfiles.size());
+    if (logEnabled) {
+        LogFM("Download.downloadBoxArt", "Checking missing boxart on SD card...");
+    }
 
-	// Check if we're missing any boxart for ROMs on the SD card.
-	for (size_t boxartnum = 0; boxartnum < files.size(); boxartnum++) {
-		// Get the title ID from the ROM image.
-		const char *tempfile = files.at(boxartnum).c_str();
-		snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), tempfile);
-		FILE *f_nds_file = fopen(path, "rb");
-		if (!f_nds_file)
-			continue;
-		
-		if (logEnabled)	LogFMA("DownloadBoxArt.SD CARD", "Path: ", path);
-		char ba_TID[5];
-		grabTID(f_nds_file, ba_TID);
-		ba_TID[4] = 0;
-		fclose(f_nds_file);
+    // Check if we're missing any boxart for ROMs on the SD card.
+    for (size_t boxartnum = 0; boxartnum < files.size(); boxartnum++) {
+        // Get the title ID from the ROM image.
+        const char* tempfile = files.at(boxartnum).c_str();
+        snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), tempfile);
+        FILE* f_nds_file = fopen(path, "rb");
+        if (!f_nds_file) {
+            continue;
+        }
 
-		// Did we already check for this boxart?
-		// NOTE: Storing byteswapped in order to sort correctly.
-		u32 tid;
-		memcpy(&tid, ba_TID, sizeof(tid));
-		tid = __builtin_bswap32(tid);
-		if (tid == 0x4E54524A) {
-			// NTRJ: Generic game code used for
-			// prototypes and some DL Play games.
-			// No boxart is available.
-			continue;
-		}
-		if (boxart_all_tids.find(tid) != boxart_all_tids.end()) {
-			// Already checked for this boxart.
-			continue;
-		}
-		boxart_all_tids.insert(tid);
+        if (logEnabled) {
+            LogFMA("DownloadBoxArt.SD CARD", "Path: ", path);
+        }
+        char ba_TID[5];
+        grabTID(f_nds_file, ba_TID);
+        ba_TID[4] = 0;
+        fclose(f_nds_file);
 
-		// Does this boxart file already exist?
-		snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%.4s.png", ba_TID);
-		if (!access(path, F_OK)) {
-			// Boxart file exists.
-			continue;
-		}else{
-			// Maybe boxart exist with fullname instead of TID
-			snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%s.png", tempfile);
-			if(!access(path, F_OK)){
-				// Boxart with fullname exist
-				continue;
-			}
-		}
+        // Did we already check for this boxart?
+        // NOTE: Storing byteswapped in order to sort correctly.
+        u32 tid;
+        memcpy(&tid, ba_TID, sizeof(tid));
+        tid = __builtin_bswap32(tid);
+        if (tid == 0x4E54524A) {
+            // NTRJ: Generic game code used for
+            // prototypes and some DL Play games.
+            // No boxart is available.
+            continue;
+        }
+        if (boxart_all_tids.find(tid) != boxart_all_tids.end()) {
+            // Already checked for this boxart.
+            continue;
+        }
+        boxart_all_tids.insert(tid);
 
-		// Boxart file does not exist. Download it.
-		boxart_dl_tids.push_back(tid);
-	}
-	
-	// Check if we're missing any boxart for ROMs on the flashcard.
-	for (size_t boxartnum = 0; boxartnum < fcfiles.size(); boxartnum++) {
-		// Get the title ID from the INI file.
-		const char *tempfile = fcfiles.at(boxartnum).c_str();
-		snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), tempfile);
-		CIniFile setfcrompathini(path);							
-		
-		std::string ba_TID = setfcrompathini.GetString("FLASHCARD-ROM", "TID", "");		
-		if (ba_TID.size() < 4) {
-			// Invalid TID.
-			continue;
-		}
-		
-		if (logEnabled)	LogFMA("DownloadBoxArt.FLASHCARD", "TID: ", ba_TID.c_str());		
-		// Did we already check for this boxart?
-		// NOTE: Storing byteswapped in order to sort correctly.
-		u32 tid;
-		memcpy(&tid, ba_TID.c_str(), sizeof(tid));
-		tid = __builtin_bswap32(tid);
-		if (tid == 0x4E54524A) {
-			// NTRJ: Generic game code used for
-			// prototypes and some DL Play games.
-			// No boxart is available.
-			continue;
-		}
-		if (boxart_all_tids.find(tid) != boxart_all_tids.end()) {
-			// Already checked for this boxart.
-			continue;
-		}
-		boxart_all_tids.insert(tid);
+        // Does this boxart file already exist?
+        snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%.4s.png", ba_TID);
+        if (!access(path, F_OK)) {
+            // Boxart file exists.
+            continue;
+        } else {
+            // Maybe boxart exist with fullname instead of TID
+            snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%s.png", tempfile);
+            if (!access(path, F_OK)) {
+                // Boxart with fullname exist
+                continue;
+            }
+        }
 
-		// Does this boxart file already exist?
-		snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%.4s.png", ba_TID.c_str());
-		if (!access(path, F_OK)) {
-			// Boxart file exists.
-			continue;
-		}else{
-			// Maybe boxart exist with fullname instead of TID
-			snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%s.png", tempfile);
-			if(!access(path, F_OK)){
-				// Boxart with fullname exist
-				continue;
-			}
-		}
+        // Boxart file does not exist. Download it.
+        boxart_dl_tids.push_back(tid);
+    }
 
-		// Boxart file does not exist. Download it.
-		boxart_dl_tids.push_back(tid);
-	}
+    // Check if we're missing any boxart for ROMs on the flashcard.
+    for (size_t boxartnum = 0; boxartnum < fcfiles.size(); boxartnum++) {
+        // Get the title ID from the INI file.
+        const char* tempfile = fcfiles.at(boxartnum).c_str();
+        snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), tempfile);
+        CIniFile setfcrompathini(path);
 
-	// Check if we're missing boxart for the Slot-1 cartridge.
-	gamecardPoll(true);
-	const char *const card_gameID = gamecardGetGameID();
-	if (card_gameID) {
-		// Did we already check for this card?
-		// NOTE: Storing byteswapped in order to sort correctly.
-		u32 tid;
-		memcpy(&tid, card_gameID, sizeof(tid));
-		tid = __builtin_bswap32(tid);
-		if (boxart_all_tids.find(tid) == boxart_all_tids.end()) {
-			// Boxart wasn't checked yet.
-			boxart_all_tids.insert(tid);
+        std::string ba_TID = setfcrompathini.GetString("FLASHCARD-ROM", "TID", "");
+        if (ba_TID.size() < 4) {
+            // Invalid TID.
+            continue;
+        }
 
-			// Does this boxart file already exist?
-			snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%.4s.png", card_gameID);
-			if (access(path, F_OK) != 0) {
-				// Boxart file does not exist. Download it.
-				boxart_dl_tids.push_back(tid);
-			}
-		}
-	}
-	
-	if (logEnabled)	LogFM("DownloadBoxArt.Read_BoxArt", "Boxart read correctly.");
-	if (boxart_dl_tids.empty()) {
-		// No boxart to download.
-		if (logEnabled)	LogFM("Download.downloadBoxArt", "No boxart to download.");
-		return;
-	}
+        if (logEnabled) {
+            LogFMA("DownloadBoxArt.FLASHCARD", "TID: ", ba_TID.c_str());
+        }
+        // Did we already check for this boxart?
+        // NOTE: Storing byteswapped in order to sort correctly.
+        u32 tid;
+        memcpy(&tid, ba_TID.c_str(), sizeof(tid));
+        tid = __builtin_bswap32(tid);
+        if (tid == 0x4E54524A) {
+            // NTRJ: Generic game code used for
+            // prototypes and some DL Play games.
+            // No boxart is available.
+            continue;
+        }
+        if (boxart_all_tids.find(tid) != boxart_all_tids.end()) {
+            // Already checked for this boxart.
+            continue;
+        }
+        boxart_all_tids.insert(tid);
 
-	// Sort the TIDs for convenience purposes.
-	std::sort(boxart_dl_tids.begin(), boxart_dl_tids.end());
+        // Does this boxart file already exist?
+        snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%.4s.png", ba_TID.c_str());
+        if (!access(path, F_OK)) {
+            // Boxart file exists.
+            continue;
+        } else {
+            // Maybe boxart exist with fullname instead of TID
+            snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%s.png", tempfile);
+            if (!access(path, F_OK)) {
+                // Boxart with fullname exist
+                continue;
+            }
+        }
 
-	// Download the boxart.
-	char s_boxart_total[12];
-	snprintf(s_boxart_total, sizeof(s_boxart_total), "%zu", boxart_dl_tids.size());
-	if (logEnabled)	LogFM("DownloadBoxArt.downloading_process", "Downloading missing boxart");
-	for (size_t boxartnum = 0; boxartnum < boxart_dl_tids.size(); boxartnum++) {
-		static const char title[] = "Downloading missing boxart...";
+        // Boxart file does not exist. Download it.
+        boxart_dl_tids.push_back(tid);
+    }
 
-		// Convert the TID back to char.
-		char ba_TID[5];
-		u32 tid = __builtin_bswap32(boxart_dl_tids[boxartnum]);
-		memcpy(ba_TID, &tid, 4);
-		ba_TID[4] = 0;
-		
-		// Show the dialog.
-		DialogBoxAppear(title, 0);
-		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-		sf2d_draw_texture(dialogboxtex, 0, 0);
-		sftd_draw_text(font, 12, 16, RGBA8(0, 0, 0, 255), 12, title);
-		sftd_draw_textf(font, 12, 32, RGBA8(0, 0, 0, 255), 12, "%zu", boxartnum);
-		sftd_draw_text(font, 39, 32, RGBA8(0, 0, 0, 255), 12, "/");
-		sftd_draw_text(font, 44, 32, RGBA8(0, 0, 0, 255), 12, s_boxart_total);
-		sftd_draw_textf(font, 12, 64, RGBA8(0, 0, 0, 255), 12, "Downloading: %.4s", ba_TID);
-		sf2d_end_frame();
-		sf2d_swapbuffers();
+    // Check if we're missing boxart for the Slot-1 cartridge.
+    gamecardPoll(true);
+    const char* const card_gameID = gamecardGetGameID();
+    if (card_gameID) {
+        // Did we already check for this card?
+        // NOTE: Storing byteswapped in order to sort correctly.
+        u32 tid;
+        memcpy(&tid, card_gameID, sizeof(tid));
+        tid = __builtin_bswap32(tid);
+        if (boxart_all_tids.find(tid) == boxart_all_tids.end()) {
+            // Boxart wasn't checked yet.
+            boxart_all_tids.insert(tid);
 
-		if (strcmp (ba_TID, "####") != 0)
-			downloadBoxArt_internal(ba_TID);
-	}
+            // Does this boxart file already exist?
+            snprintf(path, sizeof(path), "sdmc:/_nds/twloader/boxart/%.4s.png", card_gameID);
+            if (access(path, F_OK) != 0) {
+                // Boxart file does not exist. Download it.
+                boxart_dl_tids.push_back(tid);
+            }
+        }
+    }
+
+    if (logEnabled) {
+        LogFM("DownloadBoxArt.Read_BoxArt", "Boxart read correctly.");
+    }
+    if (boxart_dl_tids.empty()) {
+        // No boxart to download.
+        if (logEnabled) {
+            LogFM("Download.downloadBoxArt", "No boxart to download.");
+        }
+        return;
+    }
+
+    // Sort the TIDs for convenience purposes.
+    std::sort(boxart_dl_tids.begin(), boxart_dl_tids.end());
+
+    // Download the boxart.
+    char s_boxart_total[12];
+    snprintf(s_boxart_total, sizeof(s_boxart_total), "%zu", boxart_dl_tids.size());
+    if (logEnabled) {
+        LogFM("DownloadBoxArt.downloading_process", "Downloading missing boxart");
+    }
+    for (size_t boxartnum = 0; boxartnum < boxart_dl_tids.size(); boxartnum++) {
+        static const char title[] = "Downloading missing boxart...";
+
+        // Convert the TID back to char.
+        char ba_TID[5];
+        u32 tid = __builtin_bswap32(boxart_dl_tids[boxartnum]);
+        memcpy(ba_TID, &tid, 4);
+        ba_TID[4] = 0;
+
+        // Show the dialog.
+        DialogBoxAppear(title, 0);
+        sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+        sf2d_draw_texture(dialogboxtex, 0, 0);
+        sftd_draw_text(font, 12, 16, RGBA8(0, 0, 0, 255), 12, title);
+        sftd_draw_textf(font, 12, 32, RGBA8(0, 0, 0, 255), 12, "%zu", boxartnum);
+        sftd_draw_text(font, 39, 32, RGBA8(0, 0, 0, 255), 12, "/");
+        sftd_draw_text(font, 44, 32, RGBA8(0, 0, 0, 255), 12, s_boxart_total);
+        sftd_draw_textf(font, 12, 64, RGBA8(0, 0, 0, 255), 12, "Downloading: %.4s", ba_TID);
+        sf2d_end_frame();
+        sf2d_swapbuffers();
+
+        if (strcmp(ba_TID, "####") != 0) {
+            downloadBoxArt_internal(ba_TID);
+        }
+    }
 }

--- a/gui/source/download.h
+++ b/gui/source/download.h
@@ -8,9 +8,9 @@
 bool checkWifiStatus(void);
 
 enum MediaType {
-	MEDIA_SD_FILE = 0,	// Plain old file on the SD card.
-	MEDIA_SD_CIA = 1,	// CIA installed to the SD card.
-	MEDIA_NAND_CIA = 2,	// CIA installed to NAND.
+    MEDIA_SD_FILE = 0,  // Plain old file on the SD card.
+    MEDIA_SD_CIA = 1,   // CIA installed to the SD card.
+    MEDIA_NAND_CIA = 2, // CIA installed to NAND.
 };
 
 /**
@@ -55,7 +55,7 @@ int downloadBootstrapVersion(bool type);
  */
 
 void checkBootstrapVersion(void);
- 
+
 /**
  * Download Slot-1 boxart.
  */

--- a/gui/source/gamecard.cpp
+++ b/gui/source/gamecard.cpp
@@ -17,16 +17,16 @@ using std::wstring;
 
 // Current card information.
 static union {
-	// TODO: Use this field for CTR as well?
-	u32 d;
-	char id4[4];
-} twl_gameid;	// 4-character game ID
+    // TODO: Use this field for CTR as well?
+    u32 d;
+    char id4[4];
+} twl_gameid;   // 4-character game ID
 static bool card_inserted = false;
 static GameCardType card_type = CARD_TYPE_UNKNOWN;
 static char card_product_code[20] = { };
 static u8 card_revision = 0xFF;
 static u64 card_tid = 0;
-static sf2d_texture *card_icon = NULL;
+static sf2d_texture* card_icon = NULL;
 static vector<wstring> card_text;
 
 /**
@@ -34,15 +34,15 @@ static vector<wstring> card_text;
  */
 void gamecardClearCache(void)
 {
-	// NOTE: card_inserted is NOT reset here.
-	twl_gameid.d = 0;
-	sf2d_free_texture(card_icon);
-	card_type = CARD_TYPE_UNKNOWN;
-	card_product_code[0] = 0;
-	card_revision = 0xFF;
-	card_tid = 0;
-	card_icon = NULL;
-	card_text.clear();
+    // NOTE: card_inserted is NOT reset here.
+    twl_gameid.d = 0;
+    sf2d_free_texture(card_icon);
+    card_type = CARD_TYPE_UNKNOWN;
+    card_product_code[0] = 0;
+    card_revision = 0xFF;
+    card_tid = 0;
+    card_icon = NULL;
+    card_text.clear();
 }
 
 /**
@@ -50,66 +50,66 @@ void gamecardClearCache(void)
  */
 static void gamecardCacheTWL(void)
 {
-	// Based on FBI 2.4.7's listtitles.c, task_populate_titles_add_twl()
-	static_assert(sizeof(sNDSHeader) == 0x3B4, "sizeof(sNDSHeader) is not 0x3B4.");
+    // Based on FBI 2.4.7's listtitles.c, task_populate_titles_add_twl()
+    static_assert(sizeof(sNDSHeader) == 0x3B4, "sizeof(sNDSHeader) is not 0x3B4.");
 
-	// Get the NDS ROM header.
-	sNDSHeader header;
-	if (R_FAILED(FSUSER_GetLegacyRomHeader(MEDIATYPE_GAME_CARD, 0, (u8*)&header))) {
-		// Unable to read the ROM header.
-		gamecardClearCache();
-		return;
-	}
+    // Get the NDS ROM header.
+    sNDSHeader header;
+    if (R_FAILED(FSUSER_GetLegacyRomHeader(MEDIATYPE_GAME_CARD, 0, (u8*)&header))) {
+        // Unable to read the ROM header.
+        gamecardClearCache();
+        return;
+    }
 
-	// Get the game ID from the ROM header.
-	u32 gameid;
-	memcpy(&gameid, header.gameCode, sizeof(gameid));
-	twl_gameid.d = gameid;
+    // Get the game ID from the ROM header.
+    u32 gameid;
+    memcpy(&gameid, header.gameCode, sizeof(gameid));
+    twl_gameid.d = gameid;
 
-	// Card type.
-	const char *prefix;
-	switch (header.unitCode & 0x03) {
-		case 0x00:
-		default:
-			card_type = CARD_TYPE_NTR;
-			prefix = "NTR";
-			break;
-		case 0x02:
-			card_type = CARD_TYPE_TWL_ENH;
-			prefix = "TWL";
-			break;
-		case 0x03:
-			card_type = CARD_TYPE_TWL_ONLY;
-			prefix = "TWL";
-			break;
-	}
+    // Card type.
+    const char* prefix;
+    switch (header.unitCode & 0x03) {
+        case 0x00:
+        default:
+            card_type = CARD_TYPE_NTR;
+            prefix = "NTR";
+            break;
+        case 0x02:
+            card_type = CARD_TYPE_TWL_ENH;
+            prefix = "TWL";
+            break;
+        case 0x03:
+            card_type = CARD_TYPE_TWL_ONLY;
+            prefix = "TWL";
+            break;
+    }
 
-	// Product code. Format: NTR-P-XXXX or TWL-P-XXXX
-	snprintf(card_product_code, sizeof(card_product_code), "%s-P-%.4s", prefix, twl_gameid.id4);
+    // Product code. Format: NTR-P-XXXX or TWL-P-XXXX
+    snprintf(card_product_code, sizeof(card_product_code), "%s-P-%.4s", prefix, twl_gameid.id4);
 
-	// Revision.
-	card_revision = header.romversion;
+    // Revision.
+    card_revision = header.romversion;
 
-	// Title ID.
-	if (header.dsi_tid != 0) {
-		card_tid = (0x00030000ULL << 32) | header.dsi_tid;
-	} else {
-		// No title ID.
-		card_tid = 0;
-	}
+    // Title ID.
+    if (header.dsi_tid != 0) {
+        card_tid = (0x00030000ULL << 32) | header.dsi_tid;
+    } else {
+        // No title ID.
+        card_tid = 0;
+    }
 
-	// Get the banner.
-	sNDSBanner ndsBanner;
-	if (R_FAILED(FSUSER_GetLegacyBannerData(MEDIATYPE_GAME_CARD, 0, (u8*)&ndsBanner))) {
-		// Unable to obtain the banner.
-		gamecardClearCache();
-		return;
-	}
+    // Get the banner.
+    sNDSBanner ndsBanner;
+    if (R_FAILED(FSUSER_GetLegacyBannerData(MEDIATYPE_GAME_CARD, 0, (u8*)&ndsBanner))) {
+        // Unable to obtain the banner.
+        gamecardClearCache();
+        return;
+    }
 
-	// Store the icon and banner text.
-	sf2d_free_texture(card_icon);
-	card_icon = grabIcon(&ndsBanner);
-	card_text = grabText(&ndsBanner, language);
+    // Store the icon and banner text.
+    sf2d_free_texture(card_icon);
+    card_icon = grabIcon(&ndsBanner);
+    card_text = grabText(&ndsBanner, language);
 }
 
 /**
@@ -117,126 +117,125 @@ static void gamecardCacheTWL(void)
  */
 static void gamecardCacheCTR(void)
 {
-	// Based on FBI 2.4.7's listtitles.c, task_populate_titles_add_ctr()
-	card_type = CARD_TYPE_CTR;
+    // Based on FBI 2.4.7's listtitles.c, task_populate_titles_add_ctr()
+    card_type = CARD_TYPE_CTR;
 
-	// We need to get the title ID from the cartridge.
-	u32 titleCount = 0;
-	if (R_FAILED(AM_GetTitleCount(MEDIATYPE_GAME_CARD, &titleCount)) || titleCount == 0) {
-		return;
-	}
-	u64* titleIds = (u64*)calloc(titleCount, sizeof(u64));
-	if (!titleIds) {
-		return;
-	}
-	if (R_FAILED(AM_GetTitleList(&titleCount, MEDIATYPE_GAME_CARD, titleCount, titleIds))) {
-		free(titleIds);
-		return;
-	}
+    // We need to get the title ID from the cartridge.
+    u32 titleCount = 0;
+    if (R_FAILED(AM_GetTitleCount(MEDIATYPE_GAME_CARD, &titleCount)) || titleCount == 0) {
+        return;
+    }
+    u64* titleIds = (u64*)calloc(titleCount, sizeof(u64));
+    if (!titleIds) {
+        return;
+    }
+    if (R_FAILED(AM_GetTitleList(&titleCount, MEDIATYPE_GAME_CARD, titleCount, titleIds))) {
+        free(titleIds);
+        return;
+    }
 
-	// First entry is the correct title ID.
-	card_tid = titleIds[0];
-	free(titleIds);
+    // First entry is the correct title ID.
+    card_tid = titleIds[0];
+    free(titleIds);
 
-	// Get the title entry.
-	AM_TitleEntry entry;
-	if (R_FAILED(AM_GetTitleInfo(MEDIATYPE_GAME_CARD, 1, &card_tid, &entry))) {
-		// Unable to read the title entry.
-		return;
-	}
+    // Get the title entry.
+    AM_TitleEntry entry;
+    if (R_FAILED(AM_GetTitleInfo(MEDIATYPE_GAME_CARD, 1, &card_tid, &entry))) {
+        // Unable to read the title entry.
+        return;
+    }
 
-	// Get the product code.
-	if (R_FAILED(AM_GetTitleProductCode(MEDIATYPE_GAME_CARD, card_tid, card_product_code))) {
-		// Unable to get the product code.
-		gamecardClearCache();
-		return;
-	}
-	// Make sure it's NULL-terminated.
-	card_product_code[20-1] = 0;
+    // Get the product code.
+    if (R_FAILED(AM_GetTitleProductCode(MEDIATYPE_GAME_CARD, card_tid, card_product_code))) {
+        // Unable to get the product code.
+        gamecardClearCache();
+        return;
+    }
+    // Make sure it's NULL-terminated.
+    card_product_code[20 - 1] = 0;
 
-	// Get the SMDH, which contains the icon and banner.
-	static const u32 filePathData[] = {0x00000000, 0x00000000, 0x00000002, 0x6E6F6369, 0x00000000};
-	static const FS_Path filePath = {PATH_BINARY, sizeof(filePathData), filePathData};
-	const u32 archivePathData[4] = {
-		(u32)(card_tid & 0xFFFFFFFFU),
-		(u32)((card_tid >> 32) & 0xFFFFFFFFU),
-		MEDIATYPE_GAME_CARD,
-		0x00000000
-	};
-	const FS_Path archivePath = {PATH_BINARY, sizeof(archivePathData), archivePathData};
+    // Get the SMDH, which contains the icon and banner.
+    static const u32 filePathData[] = {0x00000000, 0x00000000, 0x00000002, 0x6E6F6369, 0x00000000};
+    static const FS_Path filePath = {PATH_BINARY, sizeof(filePathData), filePathData};
+    const u32 archivePathData[4] = {
+        (u32)(card_tid & 0xFFFFFFFFU),
+        (u32)((card_tid >> 32) & 0xFFFFFFFFU),
+        MEDIATYPE_GAME_CARD,
+        0x00000000
+    };
+    const FS_Path archivePath = {PATH_BINARY, sizeof(archivePathData), archivePathData};
 
-	Handle fileHandle;
-	if (R_FAILED(FSUSER_OpenFileDirectly(&fileHandle, ARCHIVE_SAVEDATA_AND_CONTENT,
-	    archivePath, filePath, FS_OPEN_READ, 0)))
-	{
-		// Could not open the SMDH file.
-		gamecardClearCache();
-		return;
-	}
+    Handle fileHandle;
+    if (R_FAILED(FSUSER_OpenFileDirectly(&fileHandle, ARCHIVE_SAVEDATA_AND_CONTENT,
+                                         archivePath, filePath, FS_OPEN_READ, 0))) {
+        // Could not open the SMDH file.
+        gamecardClearCache();
+        return;
+    }
 
-	static_assert(sizeof(SMDH) == 14016, "sizeof(SMDH) is not 14,016 bytes");
-	SMDH *smdh = (SMDH*)calloc(1, sizeof(SMDH));
-	if (!smdh) {
-		// calloc() failed.
-		gamecardClearCache();
-		return;
-	}
+    static_assert(sizeof(SMDH) == 14016, "sizeof(SMDH) is not 14,016 bytes");
+    SMDH* smdh = (SMDH*)calloc(1, sizeof(SMDH));
+    if (!smdh) {
+        // calloc() failed.
+        gamecardClearCache();
+        return;
+    }
 
-	u32 bytesRead = 0;
-	Result res = FSFILE_Read(fileHandle, &bytesRead, 0, smdh, sizeof(SMDH));
-	FSFILE_Close(fileHandle);
+    u32 bytesRead = 0;
+    Result res = FSFILE_Read(fileHandle, &bytesRead, 0, smdh, sizeof(SMDH));
+    FSFILE_Close(fileHandle);
 
-	if (R_FAILED(res) || bytesRead != sizeof(*smdh)) {
-		// Either the read failed, or it was a short read.
-		free(smdh);
-		gamecardClearCache();
-		return;
-	}
+    if (R_FAILED(res) || bytesRead != sizeof(*smdh)) {
+        // Either the read failed, or it was a short read.
+        free(smdh);
+        gamecardClearCache();
+        return;
+    }
 
-	// Verify the SMDH magic.
-	static const u8 smdh_magic[] = {'S','M','D','H'};
-	if (memcmp(smdh->magic, smdh_magic, sizeof(smdh_magic)) != 0) {
-		// Incorrect SMDH magic.
-		free(smdh);
-		gamecardClearCache();
-		return;
-	}
+    // Verify the SMDH magic.
+    static const u8 smdh_magic[] = {'S', 'M', 'D', 'H'};
+    if (memcmp(smdh->magic, smdh_magic, sizeof(smdh_magic)) != 0) {
+        // Incorrect SMDH magic.
+        free(smdh);
+        gamecardClearCache();
+        return;
+    }
 
-	// Check if the title for the selected language is valid.
-	u8 lang = language;
-	if (smdh->titles[lang].shortDescription[0] == 0) {
-		// Not valid. Try English.
-		lang = 1;
-		if (smdh->titles[lang].shortDescription[0] == 0) {
-			// Still not valid. Try Japanese.
-			lang = 0;
-			if (smdh->titles[lang].shortDescription[0] == 0) {
-				// Invalid banner.
-				free(smdh);
-				gamecardClearCache();
-			}
-		}
-	}
+    // Check if the title for the selected language is valid.
+    u8 lang = language;
+    if (smdh->titles[lang].shortDescription[0] == 0) {
+        // Not valid. Try English.
+        lang = 1;
+        if (smdh->titles[lang].shortDescription[0] == 0) {
+            // Still not valid. Try Japanese.
+            lang = 0;
+            if (smdh->titles[lang].shortDescription[0] == 0) {
+                // Invalid banner.
+                free(smdh);
+                gamecardClearCache();
+            }
+        }
+    }
 
-	// Check which description to use.
-	if (smdh->titles[lang].longDescription[0]) {
-		// Use the long description.
-		card_text = utf16_nl_to_vwstring(smdh->titles[lang].longDescription, 128);
-	} else {
-		// Use the short description.
-		card_text = utf16_nl_to_vwstring(smdh->titles[lang].shortDescription, 64);
-	}
+    // Check which description to use.
+    if (smdh->titles[lang].longDescription[0]) {
+        // Use the long description.
+        card_text = utf16_nl_to_vwstring(smdh->titles[lang].longDescription, 128);
+    } else {
+        // Use the short description.
+        card_text = utf16_nl_to_vwstring(smdh->titles[lang].shortDescription, 64);
+    }
 
-	// Add the publisher.
-	// TODO: Make sure we don't have more than two lines here.
-	smdh->titles[lang].publisher[0x40-1] = 0;
-	card_text.push_back(utf16_to_wstring(smdh->titles[lang].publisher));
-	free(smdh);
+    // Add the publisher.
+    // TODO: Make sure we don't have more than two lines here.
+    smdh->titles[lang].publisher[0x40 - 1] = 0;
+    card_text.push_back(utf16_to_wstring(smdh->titles[lang].publisher));
+    free(smdh);
 
-	// FIXME: Untile the large icon and load it.
-	// TODO: Add RGB565 and RGB555 loading.
-	//screen_load_texture_tiled(titleInfo->meta.texture, smdh->largeIcon, sizeof(smdh->largeIcon), 48, 48, GPU_RGB565, false);
-	return;
+    // FIXME: Untile the large icon and load it.
+    // TODO: Add RGB565 and RGB555 loading.
+    //screen_load_texture_tiled(titleInfo->meta.texture, smdh->largeIcon, sizeof(smdh->largeIcon), 48, 48, GPU_RGB565, false);
+    return;
 }
 
 /**
@@ -246,54 +245,54 @@ static void gamecardCacheCTR(void)
  */
 bool gamecardPoll(bool force)
 {
-	// Check if a TWL card is present.
-	bool inserted;
-	if (R_FAILED(FSUSER_CardSlotIsInserted(&inserted)) || !inserted) {
-		// Card is not present.
-		if (card_inserted || force) {
-			gamecardClearCache();
-			card_inserted = false;
-			return true;
-		}
-		return false;
-	}
+    // Check if a TWL card is present.
+    bool inserted;
+    if (R_FAILED(FSUSER_CardSlotIsInserted(&inserted)) || !inserted) {
+        // Card is not present.
+        if (card_inserted || force) {
+            gamecardClearCache();
+            card_inserted = false;
+            return true;
+        }
+        return false;
+    }
 
-	FS_CardType type;
-	if (R_FAILED(FSUSER_GetCardType(&type))) {
-		// Unable to get card type.
-		// This may be a blocked flashcard.
-		if (card_inserted || force) {
-			gamecardClearCache();
-			return true;
-		}
-		return false;
-	}
+    FS_CardType type;
+    if (R_FAILED(FSUSER_GetCardType(&type))) {
+        // Unable to get card type.
+        // This may be a blocked flashcard.
+        if (card_inserted || force) {
+            gamecardClearCache();
+            return true;
+        }
+        return false;
+    }
 
-	if (card_inserted && !force) {
-		// No card change.
-		return false;
-	}
+    if (card_inserted && !force) {
+        // No card change.
+        return false;
+    }
 
-	// New card detected.
-	gamecardClearCache();
-	card_inserted = true;
+    // New card detected.
+    gamecardClearCache();
+    card_inserted = true;
 
-	switch (type) {
-		case CARD_TWL:
-			// NTR/TWL game card.
-			gamecardCacheTWL();
-			break;
-		case CARD_CTR:
-			// CTR game card.
-			gamecardCacheCTR();
-			break;
-		default:
-			// Unsupported card type.
-			gamecardClearCache();
-			break;
-	}
+    switch (type) {
+        case CARD_TWL:
+            // NTR/TWL game card.
+            gamecardCacheTWL();
+            break;
+        case CARD_CTR:
+            // CTR game card.
+            gamecardCacheCTR();
+            break;
+        default:
+            // Unsupported card type.
+            gamecardClearCache();
+            break;
+    }
 
-	return true;
+    return true;
 }
 
 /**
@@ -302,7 +301,7 @@ bool gamecardPoll(bool force)
  */
 bool gamecardIsInserted(void)
 {
-	return card_inserted;
+    return card_inserted;
 }
 
 /**
@@ -311,16 +310,16 @@ bool gamecardIsInserted(void)
  */
 GameCardType gamecardGetType(void)
 {
-	return card_type;
+    return card_type;
 }
 
 /**
  * Get the game card's game ID.
  * @return Game ID, or NULL if not a TWL card.
  */
-const char *gamecardGetGameID(void)
+const char* gamecardGetGameID(void)
 {
-	return (twl_gameid.d != 0 ? twl_gameid.id4 : NULL);
+    return (twl_gameid.d != 0 ? twl_gameid.id4 : NULL);
 }
 
 /**
@@ -329,16 +328,16 @@ const char *gamecardGetGameID(void)
  */
 u32 gamecardGetGameID_u32(void)
 {
-	return twl_gameid.d;
+    return twl_gameid.d;
 }
 
 /**
  * Get the game card's product code.
  * @return Product code, or NULL if not a TWL card.
  */
-const char *gamecardGetProductCode(void)
+const char* gamecardGetProductCode(void)
 {
-	return card_product_code;
+    return card_product_code;
 }
 
 /**
@@ -347,7 +346,7 @@ const char *gamecardGetProductCode(void)
  */
 u8 gamecardGetRevision(void)
 {
-	return card_revision;
+    return card_revision;
 }
 
 /**
@@ -357,16 +356,16 @@ u8 gamecardGetRevision(void)
  */
 u64 gamecardGetTitleID(void)
 {
-	return card_tid;
+    return card_tid;
 }
 
 /**
  * Get the game card's icon.
  * @return Game card icon, or NULL if not a TWL card.
  */
-sf2d_texture *gamecardGetIcon(void)
+sf2d_texture* gamecardGetIcon(void)
 {
-	return card_icon;
+    return card_icon;
 }
 
 /**
@@ -375,5 +374,5 @@ sf2d_texture *gamecardGetIcon(void)
  */
 vector<wstring> gamecardGetText(void)
 {
-	return card_text;
+    return card_text;
 }

--- a/gui/source/gamecard.h
+++ b/gui/source/gamecard.h
@@ -20,11 +20,11 @@ bool gamecardPoll(bool force);
 void gamecardClearCache(void);
 
 enum GameCardType {
-	CARD_TYPE_UNKNOWN	= 0,	// Unknown type.
-	CARD_TYPE_NTR		= 1,	// DS
-	CARD_TYPE_TWL_ENH	= 2,	// DSi-enhanced
-	CARD_TYPE_TWL_ONLY	= 3,	// DSi only
-	CARD_TYPE_CTR		= 4,	// 3DS
+    CARD_TYPE_UNKNOWN   = 0,    // Unknown type.
+    CARD_TYPE_NTR       = 1,    // DS
+    CARD_TYPE_TWL_ENH   = 2,    // DSi-enhanced
+    CARD_TYPE_TWL_ONLY  = 3,    // DSi only
+    CARD_TYPE_CTR       = 4,    // 3DS
 };
 
 /**
@@ -43,7 +43,7 @@ GameCardType gamecardGetType(void);
  * Get the game card's game ID.
  * @return Game ID, or NULL if not a TWL card.
  */
-const char *gamecardGetGameID(void);
+const char* gamecardGetGameID(void);
 
 /**
  * Get the game card's game ID as a u32.
@@ -55,7 +55,7 @@ u32 gamecardGetGameID_u32(void);
  * Get the game card's product code.
  * @return Product code, or NULL if not a TWL card.
  */
-const char *gamecardGetProductCode(void);
+const char* gamecardGetProductCode(void);
 
 /**
  * Get the game card's Title ID.
@@ -74,7 +74,7 @@ u8 gamecardGetRevision(void);
  * Get the game card's icon.
  * @return Game card icon, or NULL if not a TWL card.
  */
-sf2d_texture *gamecardGetIcon(void);
+sf2d_texture* gamecardGetIcon(void);
 
 /**
  * Get the game card's banner text.

--- a/gui/source/img/twpng.h
+++ b/gui/source/img/twpng.h
@@ -15,7 +15,7 @@ extern "C" {
  * @param place where to allocate the texture
  * @return a pointer to the newly created texture/image
  */
-sf2d_texture *twl_load_PNG_file(const char *filename, sf2d_place place);
+sf2d_texture* twl_load_PNG_file(const char* filename, sf2d_place place);
 
 /**
  * @brief Loads a PNG image from a memory buffer
@@ -23,7 +23,7 @@ sf2d_texture *twl_load_PNG_file(const char *filename, sf2d_place place);
  * @param place where to allocate the texture
  * @return a pointer to the newly created texture/image
  */
-sf2d_texture *twl_load_PNG_buffer(const void *buffer, sf2d_place place);
+sf2d_texture* twl_load_PNG_buffer(const void* buffer, sf2d_place place);
 
 #define sfil_load_PNG_file(filename, place) twl_load_PNG_file(filename, place)
 #define sfil_load_PNG_buffer(filename, place) twl_load_PNG_buffer(filename, place)

--- a/gui/source/inifile.cpp
+++ b/gui/source/inifile.cpp
@@ -22,371 +22,365 @@
 #include <cstdlib>
 #include "inifile.h"
 
-static bool freadLine(FILE* f,std::string& str)
+static bool freadLine(FILE* f, std::string& str)
 {
-  str.clear();
+    str.clear();
 __read:
-  char p=0;
+    char p = 0;
 
-  size_t readed=fread(&p,1,1,f);
-  if(0==readed)
-  {
-    str="";
-    return false;
-  }
-  if('\n'==p||'\r'==p)
-  {
-    str="";
+    size_t readed = fread(&p, 1, 1, f);
+    if (0 == readed) {
+        str = "";
+        return false;
+    }
+    if ('\n' == p || '\r' == p) {
+        str = "";
+        return true;
+    }
+
+    while (p != '\n' && p != '\r' && readed) {
+        str += p;
+        readed = fread(&p, 1, 1, f);
+    }
+
+    if (str.empty() || "" == str) {
+        goto __read;
+    }
+
     return true;
-  }
-
-  while(p!='\n'&&p!='\r'&&readed)
-  {
-    str+=p;
-    readed=fread(&p,1,1,f);
-  }
-
-  if(str.empty()||""==str)
-  {
-    goto __read;
-  }
-
-  return true;
 }
 
 static void trimString(std::string& str)
 {
-  size_t first=str.find_first_not_of(" \t"),last;
-  if(first==str.npos)
-  {
-    str="";
-  }
-  else
-  {
-    last=str.find_last_not_of(" \t");
-    if(first>0||(last+1)<str.length()) str=str.substr(first,last-first+1);
-  }
+    size_t first = str.find_first_not_of(" \t"), last;
+    if (first == str.npos) {
+        str = "";
+    } else {
+        last = str.find_last_not_of(" \t");
+        if (first > 0 || (last + 1) < str.length()) {
+            str = str.substr(first, last - first + 1);
+        }
+    }
 }
 
 CIniFile::CIniFile()
 {
-  m_bLastResult=false;
-  m_bModified=false;
-  m_bReadOnly=false;
+    m_bLastResult = false;
+    m_bModified = false;
+    m_bReadOnly = false;
 }
 
 CIniFile::CIniFile(const std::string& filename)
 {
-  m_sFileName=filename;
-  m_bLastResult=false;
-  m_bModified=false;
-  m_bReadOnly=false;
-  LoadIniFile(m_sFileName);
+    m_sFileName = filename;
+    m_bLastResult = false;
+    m_bModified = false;
+    m_bReadOnly = false;
+    LoadIniFile(m_sFileName);
 }
 
 CIniFile::~CIniFile()
 {
-  if(m_FileContainer.size()>0)
-  {
-    m_FileContainer.clear();
-  }
-}
-
-void CIniFile::SetString(const std::string& Section,const std::string& Item,const std::string& Value)
-{
-  if(GetFileString(Section,Item)!=Value)
-  {
-    SetFileString(Section,Item,Value);
-    m_bModified=true;
-  }
-}
-
-void CIniFile::SetInt(const std::string& Section,const std::string& Item,int Value)
-{
-  char buf[16];
-  snprintf(buf, sizeof(buf), "%d", Value);
-  std::string strtemp(buf);
-
-  if(GetFileString(Section,Item)!=strtemp)
-  {
-    SetFileString(Section,Item,strtemp);
-    m_bModified=true;
-  }
-}
-
-std::string CIniFile::GetString(const std::string& Section,const std::string& Item)
-{
-  return GetFileString(Section,Item);
-}
-
-std::string CIniFile::GetString(const std::string& Section,const std::string& Item,const std::string& DefaultValue)
-{
-  std::string temp=GetString(Section,Item);
-  if(!m_bLastResult)
-  {
-    SetString(Section,Item,DefaultValue);
-    temp=DefaultValue;
-  }
-  return temp;
-}
-
-void CIniFile::GetStringVector(const std::string& Section,const std::string& Item,std::vector< std::string >& strings,char delimiter)
-{
-  std::string strValue=GetFileString(Section,Item);
-  strings.clear();
-  size_t pos;
-  while((pos=strValue.find(delimiter),strValue.npos!=pos))
-  {
-    const std::string string=strValue.substr(0,pos);
-    if(string.length())
-    {
-      strings.push_back(string);
+    if (m_FileContainer.size() > 0) {
+        m_FileContainer.clear();
     }
-    strValue=strValue.substr(pos+1,strValue.npos);
-  }
-  if(strValue.length())
-  {
-    strings.push_back(strValue);
-  }
 }
 
-void CIniFile::SetStringVector(const std::string& Section,const std::string& Item,std::vector<std::string>& strings,char delimiter)
+void CIniFile::SetString(const std::string& Section, const std::string& Item, const std::string& Value)
 {
-  std::string strValue;
-  for(size_t ii=0;ii<strings.size();++ii)
-  {
-    if(ii) strValue+=delimiter;
-    strValue+=strings[ii];
-  }
-  SetString(Section,Item,strValue);
+    if (GetFileString(Section, Item) != Value) {
+        SetFileString(Section, Item, Value);
+        m_bModified = true;
+    }
 }
 
-int CIniFile::GetInt(const std::string& Section,const std::string& Item)
+void CIniFile::SetInt(const std::string& Section, const std::string& Item, int Value)
 {
-  std::string value=GetFileString(Section,Item);
-  if(value.size()>2&&'0'==value[0]&&('x'==value[1]||'X'==value[1]))
-    return strtol(value.c_str(),NULL,16);
-  else
-    return strtol(value.c_str(),NULL,10);
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%d", Value);
+    std::string strtemp(buf);
+
+    if (GetFileString(Section, Item) != strtemp) {
+        SetFileString(Section, Item, strtemp);
+        m_bModified = true;
+    }
 }
 
-int CIniFile::GetInt(const std::string& Section,const std::string& Item,int DefaultValue)
+std::string CIniFile::GetString(const std::string& Section, const std::string& Item)
 {
-  int temp;
-  temp=GetInt(Section,Item);
-  if(!m_bLastResult)
-  {
-    SetInt(Section,Item,DefaultValue);
-    temp=DefaultValue;
-  }
-  return temp;
+    return GetFileString(Section, Item);
+}
+
+std::string CIniFile::GetString(const std::string& Section, const std::string& Item, const std::string& DefaultValue)
+{
+    std::string temp = GetString(Section, Item);
+    if (!m_bLastResult) {
+        SetString(Section, Item, DefaultValue);
+        temp = DefaultValue;
+    }
+    return temp;
+}
+
+void CIniFile::GetStringVector(const std::string& Section, const std::string& Item, std::vector< std::string >& strings, char delimiter)
+{
+    std::string strValue = GetFileString(Section, Item);
+    strings.clear();
+    size_t pos;
+    while ((pos = strValue.find(delimiter), strValue.npos != pos)) {
+        const std::string string = strValue.substr(0, pos);
+        if (string.length()) {
+            strings.push_back(string);
+        }
+        strValue = strValue.substr(pos + 1, strValue.npos);
+    }
+    if (strValue.length()) {
+        strings.push_back(strValue);
+    }
+}
+
+void CIniFile::SetStringVector(const std::string& Section, const std::string& Item, std::vector<std::string>& strings, char delimiter)
+{
+    std::string strValue;
+    for (size_t ii = 0; ii < strings.size(); ++ii) {
+        if (ii) {
+            strValue += delimiter;
+        }
+        strValue += strings[ii];
+    }
+    SetString(Section, Item, strValue);
+}
+
+int CIniFile::GetInt(const std::string& Section, const std::string& Item)
+{
+    std::string value = GetFileString(Section, Item);
+    if (value.size() > 2 && '0' == value[0] && ('x' == value[1] || 'X' == value[1])) {
+        return strtol(value.c_str(), NULL, 16);
+    } else {
+        return strtol(value.c_str(), NULL, 10);
+    }
+}
+
+int CIniFile::GetInt(const std::string& Section, const std::string& Item, int DefaultValue)
+{
+    int temp;
+    temp = GetInt(Section, Item);
+    if (!m_bLastResult) {
+        SetInt(Section, Item, DefaultValue);
+        temp = DefaultValue;
+    }
+    return temp;
 }
 
 bool CIniFile::LoadIniFile(const std::string& FileName)
 {
-  //dbg_printf("load %s\n",FileName.c_str());
-  if(FileName!="") m_sFileName=FileName;
+    //dbg_printf("load %s\n",FileName.c_str());
+    if (FileName != "") {
+        m_sFileName = FileName;
+    }
 
-  FILE* f=fopen(FileName.c_str(),"rb");
+    FILE* f = fopen(FileName.c_str(), "rb");
 
-  if(NULL==f) return false;
+    if (NULL == f) {
+        return false;
+    }
 
-  //check for utf8 bom.
-  char bom[3];
-  if(fread(bom,3,1,f)==1&&bom[0]==0xef&&bom[1]==0xbb&&bom[2]==0xbf) ;
-  else fseek(f,0,SEEK_SET);
+    //check for utf8 bom.
+    char bom[3];
+    if (fread(bom, 3, 1, f) == 1 && bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf) ;
+    else {
+        fseek(f, 0, SEEK_SET);
+    }
 
-  std::string strline("");
-  m_FileContainer.clear();
+    std::string strline("");
+    m_FileContainer.clear();
 
-  while(freadLine(f,strline))
-  {
-    trimString(strline);
-    if(strline!=""&&';'!=strline[0]&&'/'!=strline[0]&&'!'!=strline[0]) m_FileContainer.push_back(strline);
-  }
+    while (freadLine(f, strline)) {
+        trimString(strline);
+        if (strline != "" && ';' != strline[0] && '/' != strline[0] && '!' != strline[0]) {
+            m_FileContainer.push_back(strline);
+        }
+    }
 
-  fclose(f);
+    fclose(f);
 
-  m_bLastResult=false;
-  m_bModified=false;
+    m_bLastResult = false;
+    m_bModified = false;
 
-  return true;
+    return true;
 }
 
 bool CIniFile::SaveIniFileModified(const std::string& FileName)
 {
-  if(m_bModified==true)
-  {
-    return SaveIniFile(FileName);
-  }
+    if (m_bModified == true) {
+        return SaveIniFile(FileName);
+    }
 
-  return true;
+    return true;
 }
 
 bool CIniFile::SaveIniFile(const std::string& FileName)
 {
-  if(FileName!="")
-    m_sFileName=FileName;
-
-  FILE* f=fopen(m_sFileName.c_str(),"wb");
-  if(NULL==f)
-  {
-    return false;
-  }
-
-  for(size_t ii=0;ii<m_FileContainer.size();ii++)
-  {
-    std::string& strline=m_FileContainer[ii];
-    size_t notSpace=strline.find_first_not_of(' ');
-    strline=strline.substr(notSpace);
-    if(strline.find('[')==0&&ii>0)
-    {
-      if(!m_FileContainer[ii-1].empty()&&m_FileContainer[ii-1]!="")
-        fwrite("\r\n",1,2,f);
+    if (FileName != "") {
+        m_sFileName = FileName;
     }
-    if(!strline.empty()&&strline!="")
-    {
-      fwrite(strline.c_str(),1,strline.length(),f);
-      fwrite("\r\n",1,2,f);
+
+    FILE* f = fopen(m_sFileName.c_str(), "wb");
+    if (NULL == f) {
+        return false;
     }
-  }
 
-  fclose(f);
+    for (size_t ii = 0; ii < m_FileContainer.size(); ii++) {
+        std::string& strline = m_FileContainer[ii];
+        size_t notSpace = strline.find_first_not_of(' ');
+        strline = strline.substr(notSpace);
+        if (strline.find('[') == 0 && ii > 0) {
+            if (!m_FileContainer[ii - 1].empty() && m_FileContainer[ii - 1] != "") {
+                fwrite("\r\n", 1, 2, f);
+            }
+        }
+        if (!strline.empty() && strline != "") {
+            fwrite(strline.c_str(), 1, strline.length(), f);
+            fwrite("\r\n", 1, 2, f);
+        }
+    }
 
-  m_bModified=false;
+    fclose(f);
 
-  return true;
+    m_bModified = false;
+
+    return true;
 }
 
-std::string CIniFile::GetFileString(const std::string& Section,const std::string& Item)
+std::string CIniFile::GetFileString(const std::string& Section, const std::string& Item)
 {
-  std::string strline;
-  std::string strSection;
-  std::string strItem;
-  std::string strValue;
+    std::string strline;
+    std::string strSection;
+    std::string strItem;
+    std::string strValue;
 
-  size_t ii=0;
-  size_t iFileLines=m_FileContainer.size();
+    size_t ii = 0;
+    size_t iFileLines = m_FileContainer.size();
 
-  if(m_bReadOnly)
-  {
-    cSectionCache::iterator it=m_Cache.find(Section);
-    if((it!=m_Cache.end())) ii=it->second;
-  }
-
-  m_bLastResult=false;
-
-  if(iFileLines>=0)
-  {
-    while(ii<iFileLines)
-    {
-      strline=m_FileContainer[ii++];
-
-      size_t rBracketPos=0;
-      if('['==strline[0]) rBracketPos=strline.find(']');
-      if(rBracketPos>0&&rBracketPos!=std::string::npos)
-      {
-        strSection=strline.substr(1,rBracketPos-1);
-        if(m_bReadOnly) m_Cache.insert(std::make_pair(strSection,ii-1));
-        if(strSection==Section)
-        {
-          while(ii<iFileLines)
-          {
-            strline=m_FileContainer[ii++];
-            size_t equalsignPos=strline.find('=');
-            if(equalsignPos!=strline.npos)
-            {
-              size_t last=equalsignPos?strline.find_last_not_of(" \t",equalsignPos-1):strline.npos;
-              if(last==strline.npos) strItem="";
-              else strItem=strline.substr(0,last+1);
-
-              if(strItem==Item)
-              {
-                size_t first=strline.find_first_not_of(" \t",equalsignPos+1);
-                if(first==strline.npos) strValue="";
-                else strValue=strline.substr(first);
-                m_bLastResult=true;
-                return strValue;
-              }
-            }
-            else if('['==strline[0])
-            {
-              break;
-            }
-          }
-          break;
+    if (m_bReadOnly) {
+        cSectionCache::iterator it = m_Cache.find(Section);
+        if ((it != m_Cache.end())) {
+            ii = it->second;
         }
-      }
     }
-  }
-  return std::string("");
+
+    m_bLastResult = false;
+
+    if (iFileLines >= 0) {
+        while (ii < iFileLines) {
+            strline = m_FileContainer[ii++];
+
+            size_t rBracketPos = 0;
+            if ('[' == strline[0]) {
+                rBracketPos = strline.find(']');
+            }
+            if (rBracketPos > 0 && rBracketPos != std::string::npos) {
+                strSection = strline.substr(1, rBracketPos - 1);
+                if (m_bReadOnly) {
+                    m_Cache.insert(std::make_pair(strSection, ii - 1));
+                }
+                if (strSection == Section) {
+                    while (ii < iFileLines) {
+                        strline = m_FileContainer[ii++];
+                        size_t equalsignPos = strline.find('=');
+                        if (equalsignPos != strline.npos) {
+                            size_t last = equalsignPos ? strline.find_last_not_of(" \t", equalsignPos - 1) : strline.npos;
+                            if (last == strline.npos) {
+                                strItem = "";
+                            } else {
+                                strItem = strline.substr(0, last + 1);
+                            }
+
+                            if (strItem == Item) {
+                                size_t first = strline.find_first_not_of(" \t", equalsignPos + 1);
+                                if (first == strline.npos) {
+                                    strValue = "";
+                                } else {
+                                    strValue = strline.substr(first);
+                                }
+                                m_bLastResult = true;
+                                return strValue;
+                            }
+                        } else if ('[' == strline[0]) {
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    return std::string("");
 }
 
-void CIniFile::SetFileString(const std::string& Section,const std::string& Item,const std::string& Value)
+void CIniFile::SetFileString(const std::string& Section, const std::string& Item, const std::string& Value)
 {
-  std::string strline;
-  std::string strSection;
-  std::string strItem;
+    std::string strline;
+    std::string strSection;
+    std::string strItem;
 
-  if(m_bReadOnly) return;
-
-  size_t ii=0;
-  size_t iFileLines=m_FileContainer.size();
-
-  while(ii<iFileLines)
-  {
-    strline=m_FileContainer[ii++];
-
-    size_t rBracketPos=0;
-    if('['==strline[0]) rBracketPos=strline.find(']');
-    if(rBracketPos>0&&rBracketPos!=std::string::npos)
-    {
-      strSection=strline.substr(1,rBracketPos-1);
-      if(strSection==Section)
-      {
-        while(ii<iFileLines)
-        {
-          strline=m_FileContainer[ii++];
-          size_t equalsignPos=strline.find('=');
-          if(equalsignPos!=strline.npos)
-          {
-              size_t last=equalsignPos?strline.find_last_not_of(" \t",equalsignPos-1):strline.npos;
-              if(last==strline.npos) strItem="";
-              else strItem=strline.substr(0,last+1);
-
-              if(Item==strItem)
-              {
-                ReplaceLine(ii-1,Item+" = "+Value);
-                return;
-              }
-          }
-          else if('['==strline[0])
-          {
-            InsertLine(ii-1,Item+" = "+Value);
-            return;
-          }
-        }
-        InsertLine(ii,Item+" = "+Value);
+    if (m_bReadOnly) {
         return;
-      }
     }
-  }
 
-  InsertLine(ii,"["+Section+"]");
-  InsertLine(ii+1,Item+" = "+Value);
-  return;
+    size_t ii = 0;
+    size_t iFileLines = m_FileContainer.size();
+
+    while (ii < iFileLines) {
+        strline = m_FileContainer[ii++];
+
+        size_t rBracketPos = 0;
+        if ('[' == strline[0]) {
+            rBracketPos = strline.find(']');
+        }
+        if (rBracketPos > 0 && rBracketPos != std::string::npos) {
+            strSection = strline.substr(1, rBracketPos - 1);
+            if (strSection == Section) {
+                while (ii < iFileLines) {
+                    strline = m_FileContainer[ii++];
+                    size_t equalsignPos = strline.find('=');
+                    if (equalsignPos != strline.npos) {
+                        size_t last = equalsignPos ? strline.find_last_not_of(" \t", equalsignPos - 1) : strline.npos;
+                        if (last == strline.npos) {
+                            strItem = "";
+                        } else {
+                            strItem = strline.substr(0, last + 1);
+                        }
+
+                        if (Item == strItem) {
+                            ReplaceLine(ii - 1, Item + " = " + Value);
+                            return;
+                        }
+                    } else if ('[' == strline[0]) {
+                        InsertLine(ii - 1, Item + " = " + Value);
+                        return;
+                    }
+                }
+                InsertLine(ii, Item + " = " + Value);
+                return;
+            }
+        }
+    }
+
+    InsertLine(ii, "[" + Section + "]");
+    InsertLine(ii + 1, Item + " = " + Value);
+    return;
 }
 
 
 
-bool CIniFile::InsertLine(size_t line,const std::string& str)
+bool CIniFile::InsertLine(size_t line, const std::string& str)
 {
-  m_FileContainer.insert(m_FileContainer.begin()+line,str);
-  return true;
+    m_FileContainer.insert(m_FileContainer.begin() + line, str);
+    return true;
 }
 
-bool CIniFile::ReplaceLine(size_t line,const std::string& str)
+bool CIniFile::ReplaceLine(size_t line, const std::string& str)
 {
-  m_FileContainer[line]=str;
-  return true;
+    m_FileContainer[line] = str;
+    return true;
 }

--- a/gui/source/inifile.h
+++ b/gui/source/inifile.h
@@ -27,40 +27,40 @@
 
 class CIniFile
 {
-  public:
+public:
     CIniFile();
     explicit CIniFile(const std::string& filename);
     virtual ~CIniFile();
 
-  public:
+public:
     bool LoadIniFile(const std::string& FileName);
     bool SaveIniFile(const std::string& FileName);
     bool SaveIniFileModified(const std::string& FileName);
 
-    std::string GetString(const std::string& Section,const std::string& Item,const std::string& DefaultValue);
-    void SetString(const std::string& Section,const std::string& Item,const std::string& Value);
-    int GetInt(const std::string& Section,const std::string& Item,int DefaultValue);
-    void SetInt(const std::string& Section,const std::string& Item,int Value);
-    void GetStringVector(const std::string& Section,const std::string& Item,std::vector<std::string>& strings,char delimiter=',');
-    void SetStringVector(const std::string& Section,const std::string& Item,std::vector<std::string>& strings,char delimiter=',');
-  protected:
+    std::string GetString(const std::string& Section, const std::string& Item, const std::string& DefaultValue);
+    void SetString(const std::string& Section, const std::string& Item, const std::string& Value);
+    int GetInt(const std::string& Section, const std::string& Item, int DefaultValue);
+    void SetInt(const std::string& Section, const std::string& Item, int Value);
+    void GetStringVector(const std::string& Section, const std::string& Item, std::vector<std::string>& strings, char delimiter = ',');
+    void SetStringVector(const std::string& Section, const std::string& Item, std::vector<std::string>& strings, char delimiter = ',');
+protected:
     std::string m_sFileName;
     typedef std::vector<std::string> cStringArray;
     cStringArray m_FileContainer;
     bool m_bLastResult;
     bool m_bModified;
     bool m_bReadOnly;
-    typedef std::map<std::string,size_t> cSectionCache;
+    typedef std::map<std::string, size_t> cSectionCache;
     cSectionCache m_Cache;
 
-    bool InsertLine(size_t line,const std::string& str);
-    bool ReplaceLine(size_t line,const std::string& str);
+    bool InsertLine(size_t line, const std::string& str);
+    bool ReplaceLine(size_t line, const std::string& str);
 
-    void SetFileString(const std::string& Section,const std::string& Item,const std::string& Value);
-    std::string GetFileString(const std::string& Section,const std::string& Item);
+    void SetFileString(const std::string& Section, const std::string& Item, const std::string& Value);
+    std::string GetFileString(const std::string& Section, const std::string& Item);
 
-    std::string GetString(const std::string& Section,const std::string& Item);
-    int GetInt(const std::string& Section,const std::string& Item);
+    std::string GetString(const std::string& Section, const std::string& Item);
+    int GetInt(const std::string& Section, const std::string& Item);
 };
 
 #endif // _INIFILE_H_

--- a/gui/source/keyboard.cpp
+++ b/gui/source/keyboard.cpp
@@ -4,23 +4,24 @@
 #include <stdlib.h>
 
 /**
- * This method show the software original keyboard from the 3ds OS. 
+ * This method show the software original keyboard from the 3ds OS.
  * @param: const wchar_t* text to show a hint in keyboard
  * @return: std::string with user input
  */
 
-std::string keyboardInput(const wchar_t* hint) {
+std::string keyboardInput(const wchar_t* hint)
+{
     SwkbdState keyboardState;
-	char input[64];
-	char buffer[64];
-	
-	//wchart_t* to char*
-	wcstombs (buffer, hint, sizeof(buffer) );
-	buffer[63]='\0';
-	
+    char input[64];
+    char buffer[64];
+
+    //wchart_t* to char*
+    wcstombs(buffer, hint, sizeof(buffer));
+    buffer[63] = '\0';
+
     swkbdInit(&keyboardState, SWKBD_TYPE_QWERTY, 2, sizeof(input));
     swkbdSetHintText(&keyboardState, buffer);
-	swkbdSetFeatures(&keyboardState, SWKBD_DEFAULT_QWERTY);
+    swkbdSetFeatures(&keyboardState, SWKBD_DEFAULT_QWERTY);
 
     swkbdInputText(&keyboardState, input, sizeof(input));
 
@@ -28,14 +29,15 @@ std::string keyboardInput(const wchar_t* hint) {
 }
 
 /**
- * This method show the software original keyboard from the 3ds OS. 
+ * This method show the software original keyboard from the 3ds OS.
  * @param: const char* text to show a hint in keyboard
  * @return: std::string with user input
  */
 
-int keyboardInputInt(const char* hint) {
-	
-	SwkbdState keyState;
+int keyboardInputInt(const char* hint)
+{
+
+    SwkbdState keyState;
     char input[4];
 
     swkbdInit(&keyState, SWKBD_TYPE_NUMPAD, 2, 4);
@@ -43,13 +45,13 @@ int keyboardInputInt(const char* hint) {
 
     SwkbdButton pressed = swkbdInputText(&keyState, input, 4);
     int res;
-    if(pressed == SWKBD_BUTTON_LEFT)
+    if (pressed == SWKBD_BUTTON_LEFT) {
         res = 0;
-    else
-    {
+    } else {
         res = strtol(input, NULL, 10);
-        if(res > 255)
+        if (res > 255) {
             res = 255;
+        }
     }
 
     return res;

--- a/gui/source/keyboard.h
+++ b/gui/source/keyboard.h
@@ -1,12 +1,12 @@
 /**
 
-	This method is created by Jolty95 (umbjolt in gbatemp) to parse KeyBoard input to TWLoader.
-	This code is an application of libctru swkbd using native 3DS software keyboard.
-	Please, do not modify it if there is not reason to do it.
-	
-	Use:
-		#std::string keyboardInput(const wchar_t*)  return a C++ string with the input written by the user using touch screen or buttons.
-		#int keyboardInputInt(void)  return a int with the input written by the user using touch screen or buttons. If input is >255 return = 255 and if cancel, return 0
+    This method is created by Jolty95 (umbjolt in gbatemp) to parse KeyBoard input to TWLoader.
+    This code is an application of libctru swkbd using native 3DS software keyboard.
+    Please, do not modify it if there is not reason to do it.
+
+    Use:
+        #std::string keyboardInput(const wchar_t*)  return a C++ string with the input written by the user using touch screen or buttons.
+        #int keyboardInputInt(void)  return a int with the input written by the user using touch screen or buttons. If input is >255 return = 255 and if cancel, return 0
 
 */
 
@@ -16,7 +16,7 @@
 #include <string>
 
 /**
- * This method show the software original keyboard from the 3ds OS. 
+ * This method show the software original keyboard from the 3ds OS.
  * @param: const char* text to show a hint in keyboard
  * @return: std::string with user input
  */
@@ -24,7 +24,7 @@
 std::string keyboardInput(const wchar_t* hint);
 
 /**
- * This method show the software original keyboard from the 3ds OS. 
+ * This method show the software original keyboard from the 3ds OS.
  * @param: const char* text to show a hint in keyboard
  * @return: int with user input
  */

--- a/gui/source/language.cpp
+++ b/gui/source/language.cpp
@@ -20,30 +20,30 @@
 #include "languages/russian.h"
 
 // All languages.
-static const char *const *lang_all[12] = {
-	lang_JP,	// Japanese
-	lang_EN,	// English
-	lang_FR,	// French
-	lang_DE,	// German
-	lang_IT,	// Italian
-	lang_ES,	// Spanish
-	lang_EN,	// Simplified Chinese (TODO)
-	lang_KO,	// Korean
-	lang_NL,	// Dutch
-	lang_PT,	// Portuguese
-	lang_RU,	// Russian
-	lang_EN,	// Traditional Chinese (TODO)
+static const char* const* lang_all[12] = {
+    lang_JP,    // Japanese
+    lang_EN,    // English
+    lang_FR,    // French
+    lang_DE,    // German
+    lang_IT,    // Italian
+    lang_ES,    // Spanish
+    lang_EN,    // Simplified Chinese (TODO)
+    lang_KO,    // Korean
+    lang_NL,    // Dutch
+    lang_PT,    // Portuguese
+    lang_RU,    // Russian
+    lang_EN,    // Traditional Chinese (TODO)
 };
 
 /** Functions. **/
 
 // System language setting.
-u8 language = 1;	// UI language ID.
-u8 sys_language = 1;	// System language ID.
-static const char *const *lang_data = lang_all[1];
+u8 language = 1;    // UI language ID.
+u8 sys_language = 1;    // System language ID.
+static const char* const* lang_data = lang_all[1];
 
 // Translation cache.
-static wchar_t *lang_cache[STR_MAX] = { };
+static wchar_t* lang_cache[STR_MAX] = { };
 
 /**
  * Initialize translations.
@@ -51,25 +51,24 @@ static wchar_t *lang_cache[STR_MAX] = { };
  */
 void langInit(void)
 {
-	if (R_FAILED(CFGU_GetSystemLanguage(&sys_language)) ||
-	    (sys_language < 0 || sys_language >= 12))
-	{
-		// Invalid system language ID.
-		// Default to English.
-		sys_language = 1;
-	}
+    if (R_FAILED(CFGU_GetSystemLanguage(&sys_language)) ||
+            (sys_language < 0 || sys_language >= 12)) {
+        // Invalid system language ID.
+        // Default to English.
+        sys_language = 1;
+    }
 
-	language = settings.ui.language;
-	if (language < 0 || language >= 12) {
-		// Invalid language ID.
-		// Default to the system language setting.
-		language = sys_language;
-	}
+    language = settings.ui.language;
+    if (language < 0 || language >= 12) {
+        // Invalid language ID.
+        // Default to the system language setting.
+        language = sys_language;
+    }
 
-	// Clear the language cache.
-	langClear();
-	// Set the selected language.
-	lang_data = lang_all[language];
+    // Clear the language cache.
+    langClear();
+    // Set the selected language.
+    lang_data = lang_all[language];
 }
 
 /**
@@ -77,10 +76,10 @@ void langInit(void)
  */
 void langClear(void)
 {
-	for (int i = STR_MAX-1; i >= 0; i--) {
-		free(lang_cache[i]);
-		lang_cache[i] = NULL;
-	}
+    for (int i = STR_MAX - 1; i >= 0; i--) {
+        free(lang_cache[i]);
+        lang_cache[i] = NULL;
+    }
 }
 
 /**
@@ -91,19 +90,19 @@ void langClear(void)
  * @param strID String ID.
  * @return Translation, or error string if strID is invalid.
  */
-const wchar_t *TR(StrID strID)
+const wchar_t* TR(StrID strID)
 {
-	if (strID < 0 || strID >= STR_MAX) {
-		// Invalid string ID.
-		return L"STRID ERR";
-	}
+    if (strID < 0 || strID >= STR_MAX) {
+        // Invalid string ID.
+        return L"STRID ERR";
+    }
 
-	if (lang_cache[strID]) {
-		// String has already been converted to wchar_t*.
-		return lang_cache[strID];
-	}
+    if (lang_cache[strID]) {
+        // String has already been converted to wchar_t*.
+        return lang_cache[strID];
+    }
 
-	// Convert the string to wchar_t*.
-	lang_cache[strID] = utf8_to_wchar(lang_data[strID]);
-	return lang_cache[strID];
+    // Convert the string to wchar_t*.
+    lang_cache[strID] = utf8_to_wchar(lang_data[strID]);
+    return lang_cache[strID];
 }

--- a/gui/source/language.h
+++ b/gui/source/language.h
@@ -25,168 +25,168 @@ void langClear(void);
 
 // String IDs.
 typedef enum _StrID {
-	
-	/** GUI **/
-	STR_RETURN_TO_HOME_MENU = 0,								// "Return to HOME Menu"
-	STR_START,													// "START" (used on cartridge indicator)
-	STR_NO_CARTRIDGE,											// "No cartridge"
-	STR_UNKOWN,													// "Unknown Cartridge"
-	STR_SETTINGS_TEXT,											// "Settings"
-	STR_BACK,													// "B: Back"
 
-	/** Settings: GUI **/
-	STR_SETTINGS_LANGUAGE,										// "Language"
-	STR_SETTINGS_THEME,											// "Theme"
-	STR_SETTINGS_COLOR,											// "Color"
-	STR_SETTINGS_MENUCOLOR,										// "Menu Color"
-	STR_SETTINGS_FILENAME,										// "Show filename"
-	STR_SETTINGS_COUNTER,										// "Game counter"
-	STR_SETTINGS_CUSTOM_BOTTOM,									// "Custom bottom image"
-	STR_SETTINGS_AUTOUPDATE_BOOTSTRAP,							// "Auto-update bootstrap"
-	STR_SETTINGS_AUTOUPDATE_TWLOADER,							// "Auto-update to latest TWLoader"
-	
-	/** Settings: NTR/TWL_mode **/
-	STR_SETTINGS_FLASHCARD_SELECT,								// "Flashcard(s) select"
-	STR_SETTINGS_RAINBOW_LED,									// "Rainbow LED"
-	SRT_SETTINGS_ARM9_CPU_SPEED,								// "ARM9 CPU Speed"
-	STR_SETTINGS_VRAM_BOOST,									// "VRAM boost"
-	STR_SETTINGS_DS_DSi_BOOT_SCREEN,							// "DS/DSi Boot Screen"
-	STR_SETTINGS_DS_DSi_SAFETY_MESSAGE,							// "Health and Safety message"
-	STR_SETTINGS_RESET_SLOT_1,									// "Reset Slot-1"
-	STR_SETTINGS_CONSOLE_OUTPUT,								// "Console output"
-	STR_SETTINGS_LOCK_ARM9_SCFG_EXT,							// "Lock ARM9 SCFG_EXT"
-	STR_SETTINGS_BOOTSTRAP,										// "Bootstrap"
-	
-	/** Settings: Top Screen **/
-	STR_SETTINGS_XBUTTON_RELEASE,								// "X: Update bootstrap (Official release)"
-	STR_SETTINGS_YBUTTON_UNOFFICIAL,							// "Y: Update bootstrap (Unofficial release)"
-	STR_SETTINGS_SETTINGS_START_UPDATE_TWLOADER,				// "START: Update TWLoader"
-	
-	/** Settings: GUI values **/
-	
-	// Color
-	STR_SETTINGS_VALUES_GRAY,									// "Gray"
-	STR_SETTINGS_VALUES_BROWN,									// "Brown"
-	STR_SETTINGS_VALUES_RED,									// "Red"
-	STR_SETTINGS_VALUES_PINK,									// "Pink"
-	STR_SETTINGS_VALUES_ORANGE,									// "Orange"
-	STR_SETTINGS_VALUES_YELLOW,									// "Yellow"
-	STR_SETTINGS_VALUES_YELLOW_GREEN,							// "Yellow-Green"
-	STR_SETTINGS_VALUES_GREEN_1,								// "Green 1"
-	STR_SETTINGS_VALUES_GREEN_2,								// "Green 2"
-	STR_SETTINGS_VALUES_LIGHT_GREEN,							// "Light green"
-	STR_SETTINGS_VALUES_SKY_BLUE,								// "Sky blue"
-	STR_SETTINGS_VALUES_LIGHT_BLUE,								// "Light blue"
-	STR_SETTINGS_VALUES_BLUE,									// "Blue"
-	STR_SETTINGS_VALUES_VIOLET,									// "Violet"
-	STR_SETTINGS_VALUES_PURPLE,									// "Purple"
-	STR_SETTINGS_VALUES_FUCHSIA,								// "Fuchsia"
-	STR_SETTINGS_VALUES_RED_AND_BLUE,							// "Red and blue"
-	STR_SETTINGS_VALUES_GREEN_AND_YELLOW,						// "Green and yellow"
-	STR_SETTINGS_VALUES_CHRISTMAS,								// "Christmas"
+    /** GUI **/
+    STR_RETURN_TO_HOME_MENU = 0,                                // "Return to HOME Menu"
+    STR_START,                                                  // "START" (used on cartridge indicator)
+    STR_NO_CARTRIDGE,                                           // "No cartridge"
+    STR_UNKOWN,                                                 // "Unknown Cartridge"
+    STR_SETTINGS_TEXT,                                          // "Settings"
+    STR_BACK,                                                   // "B: Back"
 
-	// Menu Color
-	STR_SETTINGS_VALUES_WHITE,									// "White"
-	STR_SETTINGS_VALUES_BLACK,									// "Black"
+    /** Settings: GUI **/
+    STR_SETTINGS_LANGUAGE,                                      // "Language"
+    STR_SETTINGS_THEME,                                         // "Theme"
+    STR_SETTINGS_COLOR,                                         // "Color"
+    STR_SETTINGS_MENUCOLOR,                                     // "Menu Color"
+    STR_SETTINGS_FILENAME,                                      // "Show filename"
+    STR_SETTINGS_COUNTER,                                       // "Game counter"
+    STR_SETTINGS_CUSTOM_BOTTOM,                                 // "Custom bottom image"
+    STR_SETTINGS_AUTOUPDATE_BOOTSTRAP,                          // "Auto-update bootstrap"
+    STR_SETTINGS_AUTOUPDATE_TWLOADER,                           // "Auto-update to latest TWLoader"
 
-	/** Settings: GUI descriptions **/
-	STR_SETTINGS_DESCRIPTION_LANGUAGE_1,						// "The language to use for the UI,"
-	STR_SETTINGS_DESCRIPTION_LANGUAGE_2,						// "including game banner text."
-	
-	STR_SETTINGS_DESCRIPTION_THEME_1,							// "The theme to use in TWLoader."
-	STR_SETTINGS_DESCRIPTION_THEME_2,							// "Press A for sub-themes."
-	
-	STR_SETTINGS_DESCRIPTION_COLOR_1,							// "The color of the top background,"
-	STR_SETTINGS_DESCRIPTION_COLOR_2,							// "the START border, and the circling dots."
-	
-	STR_SETTINGS_DESCRIPTION_MENUCOLOR_1,						// "The color of the top border,"
-	STR_SETTINGS_DESCRIPTION_MENUCOLOR_2,						// "and the bottom background."
-	
-	STR_SETTINGS_DESCRIPTION_FILENAME_1,						// "Shows game filename at the top of the bubble."
-	STR_SETTINGS_DESCRIPTION_FILENAME_2,						// (empty)
-	
-	STR_SETTINGS_DESCRIPTION_COUNTER_1,							// "A number of selected game and listed games"
-	STR_SETTINGS_DESCRIPTION_COUNTER_2,							// "is shown below the text bubble."
-	
-	STR_SETTINGS_DESCRIPTION_CUSTOM_BOTTOM_1,					// "Loads a custom bottom screen image"
-	STR_SETTINGS_DESCRIPTION_CUSTOM_BOTTOM_2,					// "for the game menu."
-	
-	STR_SETTINGS_DESCRIPTION_AUTOUPDATE_BOOTSTRAP_1,			// "Auto-update nds-bootstrap at launch."
-	STR_SETTINGS_DESCRIPTION_AUTOUPDATE_BOOTSTRAP_2,			// (empty)
-	
-	STR_SETTINGS_DESCRIPTION_AUTOUPDATE_TWLOADER_1,				// "Auto-download the CIA of the latest"
-	STR_SETTINGS_DESCRIPTION_AUTOUPDATE_TWLOADER_2,				// "TWLoader version at launch."
-	
-	/** Settings: NTR/TWL_mode descriptions **/
-	STR_SETTINGS_DESCRIPTION_FLASHCARD_SELECT_1,				// "Pick a flashcard to use to"
-	STR_SETTINGS_DESCRIPTION_FLASHCARD_SELECT_2,				// "run ROMs from it."
-	
-	STR_SETTINGS_DESCRIPTION_RAINBOW_LED_1,						// "See rainbow colors glowing in"
-	STR_SETTINGS_DESCRIPTION_RAINBOW_LED_2,						// "the Notification LED."
-	
-	SRT_SETTINGS_DESCRIPTION_ARM9_CPU_SPEED_1,					// "Set to TWL to get rid of lags in some games."
-	SRT_SETTINGS_DESCRIPTION_ARM9_CPU_SPEED_2,					// (empty)
-	
-	STR_SETTINGS_DESCRIPTION_VRAM_BOOST_1,						// "Allows 8 bit VRAM writes"
-	STR_SETTINGS_DESCRIPTION_VRAM_BOOST_2,						// "and expands the bus to 32 bit."
-	
-	STR_SETTINGS_DESCRIPTION_DS_DSi_BOOT_SCREEN_1,				// "Displays the DS/DSi boot animation"
-	STR_SETTINGS_DESCRIPTION_DS_DSi_BOOT_SCREEN_2,				// "before launched game."
-	
-	STR_SETTINGS_DESCRIPTION_DS_DSi_SAFETY_MESSAGE_1,			// "Displays the Health and Safety"
-	STR_SETTINGS_DESCRIPTION_DS_DSi_SAFETY_MESSAGE_2,			// "message on the bottom screen."
-	
-	STR_SETTINGS_DESCRIPTION_RESET_SLOT_1_1,					// "Enable this if Slot-1 carts are stuck"
-	STR_SETTINGS_DESCRIPTION_RESET_SLOT_1_2,					// "on white screens."
-	
-	STR_SETTINGS_DESCRIPTION_CONSOLE_OUTPUT_1,					// "Displays some text before launched game."
-	STR_SETTINGS_DESCRIPTION_CONSOLE_OUTPUT_2,					// (empty)
-	
-	STR_SETTINGS_DESCRIPTION_LOCK_ARM9_SCFG_EXT_1,				// "Locks the ARM9 SCFG_EXT,"
-	STR_SETTINGS_DESCRIPTION_LOCK_ARM9_SCFG_EXT_2,				// "avoiding conflict with recent libnds."
-	
-	STR_SETTINGS_DESCRIPTION_BOOTSTRAP_1,						// "Change between release and"
-	STR_SETTINGS_DESCRIPTION_BOOTSTRAP_2,						// "unofficial bootstrap file."
-	
-	/** Start menu **/
-	// Options
-	STR_START_GAMELOCATION,										// "Game location"
-	STR_START_BOXART_ON,										// "Box Art: On"
-	STR_START_BOXART_OFF,										// "Box Art: OFF"
-	STR_START_START_GBARUNNER2,									// "Start GBARunner2"
-	STR_START_TOP_BORDER_ON,									// "Top border: On"
-	STR_START_TOP_BORDER_OFF,									// "Top border: Off"
-	STR_START_UNSET_DONOR,										// "Unset donor rom"
-	STR_START_SEARCH,											// "Search"
-	// Values
-	STR_START_SD_CARD,											// "SD Card"
-	STR_START_FLASHCARD,										// "Flashcard"
-	STR_START_SEARCH_HINT,										// "Use the keyboard to find roms"
-	
-	/** Select menu **/
-	// Options
-	STR_START_ARM9_CPU_SPEED,									// "ARM9 CPU Speed"
-	STR_START_VRAM_BOOST,										// "VRAM boost"
-	STR_START_LOCK_ARM9_SCFG_EXT,								// "Lock ARM9 SCFG_EXT"
-	STR_START_SET_DONOR,										// "Set as donor ROM"
-	STR_START_SET_LED,											// "Set LED color"
-	// Values
-	STR_START_DEFAULT,											// "Default"
-	
-	/** Sub-theme **/
-	STR_SETTINGS_SUBTHEME_DSi,									// "Sub-theme select: DSi Menu"
-	STR_SETTINGS_SUBTHEME_R4,									// "Sub-theme select: R4"
-	STR_SETTINGS_SUBTHEME_WOOD,									// "Sub-theme select: Wood"
-	
-	STR_SETTINGS_NO_SUB_THEMES,									// "No sub-themes exist for this theme."
-	
-	/** Settings others minor strings **/
-	STR_SETTINGS_AB_SAVE_RETURN,								// "A/B: Save and Return"
-	STR_SETTINGS_LEFTRIGHT_PICK,								// "Left/Right: Pick"
-	STR_SETTINGS_GUI,											// "Settings: GUI"
-	STR_SETTINGS_NTR_TWL,										// "Settings: NTR/TWL-mode"
-	
-	STR_MAX
+    /** Settings: NTR/TWL_mode **/
+    STR_SETTINGS_FLASHCARD_SELECT,                              // "Flashcard(s) select"
+    STR_SETTINGS_RAINBOW_LED,                                   // "Rainbow LED"
+    SRT_SETTINGS_ARM9_CPU_SPEED,                                // "ARM9 CPU Speed"
+    STR_SETTINGS_VRAM_BOOST,                                    // "VRAM boost"
+    STR_SETTINGS_DS_DSi_BOOT_SCREEN,                            // "DS/DSi Boot Screen"
+    STR_SETTINGS_DS_DSi_SAFETY_MESSAGE,                         // "Health and Safety message"
+    STR_SETTINGS_RESET_SLOT_1,                                  // "Reset Slot-1"
+    STR_SETTINGS_CONSOLE_OUTPUT,                                // "Console output"
+    STR_SETTINGS_LOCK_ARM9_SCFG_EXT,                            // "Lock ARM9 SCFG_EXT"
+    STR_SETTINGS_BOOTSTRAP,                                     // "Bootstrap"
+
+    /** Settings: Top Screen **/
+    STR_SETTINGS_XBUTTON_RELEASE,                               // "X: Update bootstrap (Official release)"
+    STR_SETTINGS_YBUTTON_UNOFFICIAL,                            // "Y: Update bootstrap (Unofficial release)"
+    STR_SETTINGS_SETTINGS_START_UPDATE_TWLOADER,                // "START: Update TWLoader"
+
+    /** Settings: GUI values **/
+
+    // Color
+    STR_SETTINGS_VALUES_GRAY,                                   // "Gray"
+    STR_SETTINGS_VALUES_BROWN,                                  // "Brown"
+    STR_SETTINGS_VALUES_RED,                                    // "Red"
+    STR_SETTINGS_VALUES_PINK,                                   // "Pink"
+    STR_SETTINGS_VALUES_ORANGE,                                 // "Orange"
+    STR_SETTINGS_VALUES_YELLOW,                                 // "Yellow"
+    STR_SETTINGS_VALUES_YELLOW_GREEN,                           // "Yellow-Green"
+    STR_SETTINGS_VALUES_GREEN_1,                                // "Green 1"
+    STR_SETTINGS_VALUES_GREEN_2,                                // "Green 2"
+    STR_SETTINGS_VALUES_LIGHT_GREEN,                            // "Light green"
+    STR_SETTINGS_VALUES_SKY_BLUE,                               // "Sky blue"
+    STR_SETTINGS_VALUES_LIGHT_BLUE,                             // "Light blue"
+    STR_SETTINGS_VALUES_BLUE,                                   // "Blue"
+    STR_SETTINGS_VALUES_VIOLET,                                 // "Violet"
+    STR_SETTINGS_VALUES_PURPLE,                                 // "Purple"
+    STR_SETTINGS_VALUES_FUCHSIA,                                // "Fuchsia"
+    STR_SETTINGS_VALUES_RED_AND_BLUE,                           // "Red and blue"
+    STR_SETTINGS_VALUES_GREEN_AND_YELLOW,                       // "Green and yellow"
+    STR_SETTINGS_VALUES_CHRISTMAS,                              // "Christmas"
+
+    // Menu Color
+    STR_SETTINGS_VALUES_WHITE,                                  // "White"
+    STR_SETTINGS_VALUES_BLACK,                                  // "Black"
+
+    /** Settings: GUI descriptions **/
+    STR_SETTINGS_DESCRIPTION_LANGUAGE_1,                        // "The language to use for the UI,"
+    STR_SETTINGS_DESCRIPTION_LANGUAGE_2,                        // "including game banner text."
+
+    STR_SETTINGS_DESCRIPTION_THEME_1,                           // "The theme to use in TWLoader."
+    STR_SETTINGS_DESCRIPTION_THEME_2,                           // "Press A for sub-themes."
+
+    STR_SETTINGS_DESCRIPTION_COLOR_1,                           // "The color of the top background,"
+    STR_SETTINGS_DESCRIPTION_COLOR_2,                           // "the START border, and the circling dots."
+
+    STR_SETTINGS_DESCRIPTION_MENUCOLOR_1,                       // "The color of the top border,"
+    STR_SETTINGS_DESCRIPTION_MENUCOLOR_2,                       // "and the bottom background."
+
+    STR_SETTINGS_DESCRIPTION_FILENAME_1,                        // "Shows game filename at the top of the bubble."
+    STR_SETTINGS_DESCRIPTION_FILENAME_2,                        // (empty)
+
+    STR_SETTINGS_DESCRIPTION_COUNTER_1,                         // "A number of selected game and listed games"
+    STR_SETTINGS_DESCRIPTION_COUNTER_2,                         // "is shown below the text bubble."
+
+    STR_SETTINGS_DESCRIPTION_CUSTOM_BOTTOM_1,                   // "Loads a custom bottom screen image"
+    STR_SETTINGS_DESCRIPTION_CUSTOM_BOTTOM_2,                   // "for the game menu."
+
+    STR_SETTINGS_DESCRIPTION_AUTOUPDATE_BOOTSTRAP_1,            // "Auto-update nds-bootstrap at launch."
+    STR_SETTINGS_DESCRIPTION_AUTOUPDATE_BOOTSTRAP_2,            // (empty)
+
+    STR_SETTINGS_DESCRIPTION_AUTOUPDATE_TWLOADER_1,             // "Auto-download the CIA of the latest"
+    STR_SETTINGS_DESCRIPTION_AUTOUPDATE_TWLOADER_2,             // "TWLoader version at launch."
+
+    /** Settings: NTR/TWL_mode descriptions **/
+    STR_SETTINGS_DESCRIPTION_FLASHCARD_SELECT_1,                // "Pick a flashcard to use to"
+    STR_SETTINGS_DESCRIPTION_FLASHCARD_SELECT_2,                // "run ROMs from it."
+
+    STR_SETTINGS_DESCRIPTION_RAINBOW_LED_1,                     // "See rainbow colors glowing in"
+    STR_SETTINGS_DESCRIPTION_RAINBOW_LED_2,                     // "the Notification LED."
+
+    SRT_SETTINGS_DESCRIPTION_ARM9_CPU_SPEED_1,                  // "Set to TWL to get rid of lags in some games."
+    SRT_SETTINGS_DESCRIPTION_ARM9_CPU_SPEED_2,                  // (empty)
+
+    STR_SETTINGS_DESCRIPTION_VRAM_BOOST_1,                      // "Allows 8 bit VRAM writes"
+    STR_SETTINGS_DESCRIPTION_VRAM_BOOST_2,                      // "and expands the bus to 32 bit."
+
+    STR_SETTINGS_DESCRIPTION_DS_DSi_BOOT_SCREEN_1,              // "Displays the DS/DSi boot animation"
+    STR_SETTINGS_DESCRIPTION_DS_DSi_BOOT_SCREEN_2,              // "before launched game."
+
+    STR_SETTINGS_DESCRIPTION_DS_DSi_SAFETY_MESSAGE_1,           // "Displays the Health and Safety"
+    STR_SETTINGS_DESCRIPTION_DS_DSi_SAFETY_MESSAGE_2,           // "message on the bottom screen."
+
+    STR_SETTINGS_DESCRIPTION_RESET_SLOT_1_1,                    // "Enable this if Slot-1 carts are stuck"
+    STR_SETTINGS_DESCRIPTION_RESET_SLOT_1_2,                    // "on white screens."
+
+    STR_SETTINGS_DESCRIPTION_CONSOLE_OUTPUT_1,                  // "Displays some text before launched game."
+    STR_SETTINGS_DESCRIPTION_CONSOLE_OUTPUT_2,                  // (empty)
+
+    STR_SETTINGS_DESCRIPTION_LOCK_ARM9_SCFG_EXT_1,              // "Locks the ARM9 SCFG_EXT,"
+    STR_SETTINGS_DESCRIPTION_LOCK_ARM9_SCFG_EXT_2,              // "avoiding conflict with recent libnds."
+
+    STR_SETTINGS_DESCRIPTION_BOOTSTRAP_1,                       // "Change between release and"
+    STR_SETTINGS_DESCRIPTION_BOOTSTRAP_2,                       // "unofficial bootstrap file."
+
+    /** Start menu **/
+    // Options
+    STR_START_GAMELOCATION,                                     // "Game location"
+    STR_START_BOXART_ON,                                        // "Box Art: On"
+    STR_START_BOXART_OFF,                                       // "Box Art: OFF"
+    STR_START_START_GBARUNNER2,                                 // "Start GBARunner2"
+    STR_START_TOP_BORDER_ON,                                    // "Top border: On"
+    STR_START_TOP_BORDER_OFF,                                   // "Top border: Off"
+    STR_START_UNSET_DONOR,                                      // "Unset donor rom"
+    STR_START_SEARCH,                                           // "Search"
+    // Values
+    STR_START_SD_CARD,                                          // "SD Card"
+    STR_START_FLASHCARD,                                        // "Flashcard"
+    STR_START_SEARCH_HINT,                                      // "Use the keyboard to find roms"
+
+    /** Select menu **/
+    // Options
+    STR_START_ARM9_CPU_SPEED,                                   // "ARM9 CPU Speed"
+    STR_START_VRAM_BOOST,                                       // "VRAM boost"
+    STR_START_LOCK_ARM9_SCFG_EXT,                               // "Lock ARM9 SCFG_EXT"
+    STR_START_SET_DONOR,                                        // "Set as donor ROM"
+    STR_START_SET_LED,                                          // "Set LED color"
+    // Values
+    STR_START_DEFAULT,                                          // "Default"
+
+    /** Sub-theme **/
+    STR_SETTINGS_SUBTHEME_DSi,                                  // "Sub-theme select: DSi Menu"
+    STR_SETTINGS_SUBTHEME_R4,                                   // "Sub-theme select: R4"
+    STR_SETTINGS_SUBTHEME_WOOD,                                 // "Sub-theme select: Wood"
+
+    STR_SETTINGS_NO_SUB_THEMES,                                 // "No sub-themes exist for this theme."
+
+    /** Settings others minor strings **/
+    STR_SETTINGS_AB_SAVE_RETURN,                                // "A/B: Save and Return"
+    STR_SETTINGS_LEFTRIGHT_PICK,                                // "Left/Right: Pick"
+    STR_SETTINGS_GUI,                                           // "Settings: GUI"
+    STR_SETTINGS_NTR_TWL,                                       // "Settings: NTR/TWL-mode"
+
+    STR_MAX
 } StrID;
 
 /**
@@ -197,6 +197,6 @@ typedef enum _StrID {
  * @param strID String ID.
  * @return Translation, or error string if strID is invalid.
  */
-const wchar_t *TR(StrID strID);
+const wchar_t* TR(StrID strID);
 
 #endif /* TWLOADER_LANGUAGE_H */

--- a/gui/source/languages/dutch.h
+++ b/gui/source/languages/dutch.h
@@ -4,168 +4,168 @@
 #include <3ds/types.h>
 
 // DUTCH
-static const char *const lang_NL[STR_MAX] = {
-	
-	/** GUI **/
-    ": Return to HOME Menu",									// "Return to HOME Menu"
-	"START",													// "START" (used on cartridge indicator)
-	"No cartridge",												// "No cartridge"
-	"Unknown Cartridge", 										// "Unknown Cartridge"
-	"Settings",													// "Settings"
-	"B: Back",													// "B: Back"	
-	
-	/** Settings: GUI **/
-	"Language",													// "Language"
-	"Theme",													// "Theme"
-	"Color",													// "Color"
-	"Menu color",												// "Menu Color"
-	"Show filename",											// "Show filename"
-	"Game counter",												// "Game counter"
-	"Custom bottom image",										// "Custom bottom image"
-	"Auto-update bootstrap",									// "Auto-update bootstrap"
-	"Auto-update to latest TWLoader",							// "Auto-update to latest TWLoader"
-	
-	/** Settings: NTR/TWL_mode **/
-	"Flashcard(s) select",										// "Flashcard(s) select"
-	"Rainbow LED",												// "Rainbow LED"
-	"ARM9 CPU Speed",											// "ARM9 CPU Speed"
-	"VRAM boost",												// "VRAM boost"
-	"DS/DSi Boot Screen",										// "DS/DSi Boot Screen"
-	"Health and Safety message",								// "Health and Safety message"
-	"Reset Slot-1",												// "Reset Slot-1"
-	"Console output",											// "Console output"
-	"Lock ARM9 SCFG_EXT",										// "Lock ARM9 SCFG_EXT"
-	"Bootstrap",												// "Bootstrap"
-	
-	/** Settings: Top Screen **/
-	"X: Update bootstrap (Official release)",					// "X: Update bootstrap (Official release)"
-	"Y: Update bootstrap (Unofficial release)",					// "Y: Update bootstrap (Unofficial release)"
-    "START: Update TWLoader",    								// "START: Update TWLoader"
-	
-	/** Settings: GUI values **/
-	
-	// Color
-	"Gray",														// "Gray"
-	"Brown",													// "Brown"
-	"Red",														// "Red"
-	"Pink",												 		// "Pink"
-	"Orange",													// "Orange"
-	"Yellow",													// "Yellow"
-	"Yellow-Green",												// "Yellow-Green"
-	"Green 1",													// "Green 1"
-	"Green 2",													// "Green 2"
-	"Light green",												// "Light green"
-	"Sky blue",													// "Sky blue"
-	"Light blue",												// "Light blue"
-	"Blue",														// "Blue"
-	"Violet",													// "Violet"
-	"Purple",													// "Purple"
-	"Fuchsia",													// "Fuchsia"
-	"Red&blue",													// "Red and blue"
-	"Green&yellow",												// "Green and yellow"
-	"Christmas",												// "Christmas"
+static const char* const lang_NL[STR_MAX] = {
 
-	// Menu Color
-	"White",													// "White"
-	"Black",													// "Black"
+    /** GUI **/
+    ": Return to HOME Menu",                                    // "Return to HOME Menu"
+    "START",                                                    // "START" (used on cartridge indicator)
+    "No cartridge",                                             // "No cartridge"
+    "Unknown Cartridge",                                        // "Unknown Cartridge"
+    "Settings",                                                 // "Settings"
+    "B: Back",                                                  // "B: Back"
 
-	/** Settings: GUI descriptions **/
-	"The language to use for the UI,",							// "The language to use for the UI,"
-	"including game banner text.",								// "including game banner text."
-	
-	"The theme to use in TWLoader.",							// "The theme to use in TWLoader."
-	"Press A for sub-themes.",									// "Press A for sub-themes."
-	
-	"The color of the top background,",							// "The color of the top background,"
-	"the START border, and the circling dots.",					// "the START border, and the circling dots."
-	
-	"The color of the top border,",								// "The color of the top border,"
-	"and the bottom background.",								// "and the bottom background."
-	
-	"Shows game filename at the top of the bubble.",			// "Shows game filename at the top of the bubble."
-	"",															// (empty)
-	
-	"A number of selected game and listed games",				// "A number of selected game and listed games"
-	"is shown below the text bubble.",							// "is shown below the text bubble."
-	
-	"Loads a custom bottom screen image",						// "Loads a custom bottom screen image"
-	"for the game menu.",										// "for the game menu."
-	
-	"Auto-update nds-bootstrap at launch.",						// "Auto-update nds-bootstrap at launch."
-	"",															// (empty)
+    /** Settings: GUI **/
+    "Language",                                                 // "Language"
+    "Theme",                                                    // "Theme"
+    "Color",                                                    // "Color"
+    "Menu color",                                               // "Menu Color"
+    "Show filename",                                            // "Show filename"
+    "Game counter",                                             // "Game counter"
+    "Custom bottom image",                                      // "Custom bottom image"
+    "Auto-update bootstrap",                                    // "Auto-update bootstrap"
+    "Auto-update to latest TWLoader",                           // "Auto-update to latest TWLoader"
 
-	"Auto-download the CIA of the latest",						// "Auto-download the CIA of the latest"
-	"TWLoader version at launch.",								// "TWLoader version at launch."
-	
-	/** Settings: NTR/TWL_mode descriptions **/
-	"Pick a flashcard to use to",								// "Pick a flashcard to use to"
-	"run ROMs from it.",										// "run ROMs from it."
-	
-	"See rainbow colors glowing in",							// "See rainbow colors glowing in"
-	"the Notification LED.",									// "the Notification LED."
-	
-	"Set to TWL to get rid of lags in some games.",				// "Set to TWL to get rid of lags in some games."
-	"",															// (empty)
-	
-	"Allows 8 bit VRAM writes",									// "Allows 8 bit VRAM writes"
-	"and expands the bus to 32 bit.",							// "and expands the bus to 32 bit."
-	
-	"Displays the DS/DSi boot animation",						// "Displays the DS/DSi boot animation"
-	"before launched game.",									// "before launched game."
-	
-	"Displays the Health and Safety",							// "Displays the Health and Safety"
-	"message on the bottom screen.",							// "message on the bottom screen."
-	
-	"Enable this if Slot-1 carts are stuck",					// "Enable this if Slot-1 carts are stuck"
-	"on white screens.",										// "on white screens."
-	
-	"Displays some text before launched game.",					// "Displays some text before launched game."
-	"",															// (empty)
-	
-	"Locks the ARM9 SCFG_EXT,",									// "Locks the ARM9 SCFG_EXT,"
-	"avoiding conflict with recent libnds.",					// "avoiding conflict with recent libnds."
-	
-	"Change between release and",								// "Change between release and"
-	"unofficial bootstrap file.",								// "unofficial bootstrap file."
-	
-	/** Start menu **/
-	// Options
-	"Game location",											// "Game location"
-	"Box Art: On",												// "Box Art: On"
-	"Box Art: Off",												// "Box Art: OFF"
-	"Start GBARunner2",											// "Start GBARunner2"
-	"Top border: On",											// "Top border: On"
-	"Top border: Off",											// "Top border: Off"
-	"Unset donor ROM",											// "Unset donor rom"
-	"Search",													// "Search"
-	// Values
-	"SD Card",													// "SD Card"
-	"Flashcard",												// "Flashcard"
-	"Use the keyboard to find roms",							// "Use the keyboard to find roms"
-	
-	/** Select menu **/
-	// Options
-	"ARM9 CPU Speed",											// "ARM9 CPU Speed"
-	"VRAM boost",												// "VRAM boost"
-	"Lock ARM9 SCFG_EXT",										// "Lock ARM9 SCFG_EXT"
-	"Set as donor ROM",											// "Set as donor ROM"
-	"Set LED color",											// "Set LED color"
-	// Values
-	"Default",													// "Default"
-	
-	/** Sub-theme **/
-	"Sub-theme select: DSi Menu",								// "Sub-theme select: DSi Menu"
-	"Sub-theme select: R4",										// "Sub-theme select: R4"
-	"Sub-theme select: akMenu/Wood",							// "Sub-theme select: Wood"
-	
-	"No sub-themes exist for this theme.",						// "No sub-themes exist for this theme."
-	
-	/** Settings others minor strings **/
-	"A/B: Save and Return",										// "A/B: Save and Return"
-	"Left/Right: Pick",											// "Left/Right: Pick"
-	"Settings: GUI",											// "Settings: GUI"
-	"Settings: NTR/TWL-mode",									// "Settings: NTR/TWL-mode"
-	
+    /** Settings: NTR/TWL_mode **/
+    "Flashcard(s) select",                                      // "Flashcard(s) select"
+    "Rainbow LED",                                              // "Rainbow LED"
+    "ARM9 CPU Speed",                                           // "ARM9 CPU Speed"
+    "VRAM boost",                                               // "VRAM boost"
+    "DS/DSi Boot Screen",                                       // "DS/DSi Boot Screen"
+    "Health and Safety message",                                // "Health and Safety message"
+    "Reset Slot-1",                                             // "Reset Slot-1"
+    "Console output",                                           // "Console output"
+    "Lock ARM9 SCFG_EXT",                                       // "Lock ARM9 SCFG_EXT"
+    "Bootstrap",                                                // "Bootstrap"
+
+    /** Settings: Top Screen **/
+    "X: Update bootstrap (Official release)",                   // "X: Update bootstrap (Official release)"
+    "Y: Update bootstrap (Unofficial release)",                 // "Y: Update bootstrap (Unofficial release)"
+    "START: Update TWLoader",                                   // "START: Update TWLoader"
+
+    /** Settings: GUI values **/
+
+    // Color
+    "Gray",                                                     // "Gray"
+    "Brown",                                                    // "Brown"
+    "Red",                                                      // "Red"
+    "Pink",                                                     // "Pink"
+    "Orange",                                                   // "Orange"
+    "Yellow",                                                   // "Yellow"
+    "Yellow-Green",                                             // "Yellow-Green"
+    "Green 1",                                                  // "Green 1"
+    "Green 2",                                                  // "Green 2"
+    "Light green",                                              // "Light green"
+    "Sky blue",                                                 // "Sky blue"
+    "Light blue",                                               // "Light blue"
+    "Blue",                                                     // "Blue"
+    "Violet",                                                   // "Violet"
+    "Purple",                                                   // "Purple"
+    "Fuchsia",                                                  // "Fuchsia"
+    "Red&blue",                                                 // "Red and blue"
+    "Green&yellow",                                             // "Green and yellow"
+    "Christmas",                                                // "Christmas"
+
+    // Menu Color
+    "White",                                                    // "White"
+    "Black",                                                    // "Black"
+
+    /** Settings: GUI descriptions **/
+    "The language to use for the UI,",                          // "The language to use for the UI,"
+    "including game banner text.",                              // "including game banner text."
+
+    "The theme to use in TWLoader.",                            // "The theme to use in TWLoader."
+    "Press A for sub-themes.",                                  // "Press A for sub-themes."
+
+    "The color of the top background,",                         // "The color of the top background,"
+    "the START border, and the circling dots.",                 // "the START border, and the circling dots."
+
+    "The color of the top border,",                             // "The color of the top border,"
+    "and the bottom background.",                               // "and the bottom background."
+
+    "Shows game filename at the top of the bubble.",            // "Shows game filename at the top of the bubble."
+    "",                                                         // (empty)
+
+    "A number of selected game and listed games",               // "A number of selected game and listed games"
+    "is shown below the text bubble.",                          // "is shown below the text bubble."
+
+    "Loads a custom bottom screen image",                       // "Loads a custom bottom screen image"
+    "for the game menu.",                                       // "for the game menu."
+
+    "Auto-update nds-bootstrap at launch.",                     // "Auto-update nds-bootstrap at launch."
+    "",                                                         // (empty)
+
+    "Auto-download the CIA of the latest",                      // "Auto-download the CIA of the latest"
+    "TWLoader version at launch.",                              // "TWLoader version at launch."
+
+    /** Settings: NTR/TWL_mode descriptions **/
+    "Pick a flashcard to use to",                               // "Pick a flashcard to use to"
+    "run ROMs from it.",                                        // "run ROMs from it."
+
+    "See rainbow colors glowing in",                            // "See rainbow colors glowing in"
+    "the Notification LED.",                                    // "the Notification LED."
+
+    "Set to TWL to get rid of lags in some games.",             // "Set to TWL to get rid of lags in some games."
+    "",                                                         // (empty)
+
+    "Allows 8 bit VRAM writes",                                 // "Allows 8 bit VRAM writes"
+    "and expands the bus to 32 bit.",                           // "and expands the bus to 32 bit."
+
+    "Displays the DS/DSi boot animation",                       // "Displays the DS/DSi boot animation"
+    "before launched game.",                                    // "before launched game."
+
+    "Displays the Health and Safety",                           // "Displays the Health and Safety"
+    "message on the bottom screen.",                            // "message on the bottom screen."
+
+    "Enable this if Slot-1 carts are stuck",                    // "Enable this if Slot-1 carts are stuck"
+    "on white screens.",                                        // "on white screens."
+
+    "Displays some text before launched game.",                 // "Displays some text before launched game."
+    "",                                                         // (empty)
+
+    "Locks the ARM9 SCFG_EXT,",                                 // "Locks the ARM9 SCFG_EXT,"
+    "avoiding conflict with recent libnds.",                    // "avoiding conflict with recent libnds."
+
+    "Change between release and",                               // "Change between release and"
+    "unofficial bootstrap file.",                               // "unofficial bootstrap file."
+
+    /** Start menu **/
+    // Options
+    "Game location",                                            // "Game location"
+    "Box Art: On",                                              // "Box Art: On"
+    "Box Art: Off",                                             // "Box Art: OFF"
+    "Start GBARunner2",                                         // "Start GBARunner2"
+    "Top border: On",                                           // "Top border: On"
+    "Top border: Off",                                          // "Top border: Off"
+    "Unset donor ROM",                                          // "Unset donor rom"
+    "Search",                                                   // "Search"
+    // Values
+    "SD Card",                                                  // "SD Card"
+    "Flashcard",                                                // "Flashcard"
+    "Use the keyboard to find roms",                            // "Use the keyboard to find roms"
+
+    /** Select menu **/
+    // Options
+    "ARM9 CPU Speed",                                           // "ARM9 CPU Speed"
+    "VRAM boost",                                               // "VRAM boost"
+    "Lock ARM9 SCFG_EXT",                                       // "Lock ARM9 SCFG_EXT"
+    "Set as donor ROM",                                         // "Set as donor ROM"
+    "Set LED color",                                            // "Set LED color"
+    // Values
+    "Default",                                                  // "Default"
+
+    /** Sub-theme **/
+    "Sub-theme select: DSi Menu",                               // "Sub-theme select: DSi Menu"
+    "Sub-theme select: R4",                                     // "Sub-theme select: R4"
+    "Sub-theme select: akMenu/Wood",                            // "Sub-theme select: Wood"
+
+    "No sub-themes exist for this theme.",                      // "No sub-themes exist for this theme."
+
+    /** Settings others minor strings **/
+    "A/B: Save and Return",                                     // "A/B: Save and Return"
+    "Left/Right: Pick",                                         // "Left/Right: Pick"
+    "Settings: GUI",                                            // "Settings: GUI"
+    "Settings: NTR/TWL-mode",                                   // "Settings: NTR/TWL-mode"
+
 };
 
 

--- a/gui/source/languages/english.h
+++ b/gui/source/languages/english.h
@@ -4,167 +4,167 @@
 #include <3ds/types.h>
 
 // ENGLISH
-static const char *const lang_EN[STR_MAX] = {
-	
-	/** GUI **/
-    ": Return to HOME Menu",									// "Return to HOME Menu"
-	"START",													// "START" (used on cartridge indicator)
-	"No cartridge",												// "No cartridge"
-	"Unknown Cartridge", 										// "Unknown Cartridge"
-	"Settings",													// "Settings"
-	"B: Back",													// "B: Back"	
-	
-	/** Settings: GUI **/
-	"Language",													// "Language"
-	"Theme",													// "Theme"
-	"Color",													// "Color"
-	"Menu color",												// "Menu Color"
-	"Show filename",											// "Show filename"
-	"Game counter",												// "Game counter"
-	"Custom bottom image",										// "Custom bottom image"
-	"Auto-update bootstrap",									// "Auto-update bootstrap"
-	"Auto-update to latest TWLoader",							// "Auto-update to latest TWLoader"
-	
-	/** Settings: NTR/TWL_mode **/
-	"Flashcard(s) select",										// "Flashcard(s) select"
-	"Rainbow LED",												// "Rainbow LED"
-	"ARM9 CPU Speed",											// "ARM9 CPU Speed"
-	"VRAM boost",												// "VRAM boost"
-	"DS/DSi Boot Screen",										// "DS/DSi Boot Screen"
-	"Health and Safety message",								// "Health and Safety message"
-	"Reset Slot-1",												// "Reset Slot-1"
-	"Console output",											// "Console output"
-	"Lock ARM9 SCFG_EXT",										// "Lock ARM9 SCFG_EXT"
-	"Bootstrap",												// "Bootstrap"
-	
-	/** Settings: Top Screen **/
-	"X: Update bootstrap (Official release)",					// "X: Update bootstrap (Official release)"
-	"Y: Update bootstrap (Unofficial release)",					// "Y: Update bootstrap (Unofficial release)"
-    "START: Update TWLoader",    								// "START: Update TWLoader"
-	
-	/** Settings: GUI values **/
-	
-	// Color
-	"Gray",														// "Gray"
-	"Brown",													// "Brown"
-	"Red",														// "Red"
-	"Pink",												 		// "Pink"
-	"Orange",													// "Orange"
-	"Yellow",													// "Yellow"
-	"Yellow-Green",												// "Yellow-Green"
-	"Green 1",													// "Green 1"
-	"Green 2",													// "Green 2"
-	"Light green",												// "Light green"
-	"Sky blue",													// "Sky blue"
-	"Light blue",												// "Light blue"
-	"Blue",														// "Blue"
-	"Violet",													// "Violet"
-	"Purple",													// "Purple"
-	"Fuchsia",													// "Fuchsia"
-	"Red&blue",													// "Red and blue"
-	"Green&yellow",												// "Green and yellow"
-	"Christmas",												// "Christmas"
+static const char* const lang_EN[STR_MAX] = {
 
-	// Menu Color
-	"White",													// "White"
-	"Black",													// "Black"
+    /** GUI **/
+    ": Return to HOME Menu",                                    // "Return to HOME Menu"
+    "START",                                                    // "START" (used on cartridge indicator)
+    "No cartridge",                                             // "No cartridge"
+    "Unknown Cartridge",                                        // "Unknown Cartridge"
+    "Settings",                                                 // "Settings"
+    "B: Back",                                                  // "B: Back"
 
-	/** Settings: GUI descriptions **/
-	"The language to use for the UI,",							// "The language to use for the UI,"
-	"including game banner text.",								// "including game banner text."
-	
-	"The theme to use in TWLoader.",							// "The theme to use in TWLoader."
-	"Press A for sub-themes.",									// "Press A for sub-themes."
-	
-	"The color of the top background,",							// "The color of the top background,"
-	"the START border, and the circling dots.",					// "the START border, and the circling dots."
-	
-	"The color of the top border,",								// "The color of the top border,"
-	"and the bottom background.",								// "and the bottom background."
-	
-	"Shows game filename at the top of the bubble.",			// "Shows game filename at the top of the bubble."
-	"",															// (empty)
-	
-	"A number of selected game and listed games",				// "A number of selected game and listed games"
-	"is shown below the text bubble.",							// "is shown below the text bubble."
-	
-	"Loads a custom bottom screen image",						// "Loads a custom bottom screen image"
-	"for the game menu.",										// "for the game menu."
-	
-	"Auto-update nds-bootstrap at launch.",						// "Auto-update nds-bootstrap at launch."
-	"",															// (empty)
+    /** Settings: GUI **/
+    "Language",                                                 // "Language"
+    "Theme",                                                    // "Theme"
+    "Color",                                                    // "Color"
+    "Menu color",                                               // "Menu Color"
+    "Show filename",                                            // "Show filename"
+    "Game counter",                                             // "Game counter"
+    "Custom bottom image",                                      // "Custom bottom image"
+    "Auto-update bootstrap",                                    // "Auto-update bootstrap"
+    "Auto-update to latest TWLoader",                           // "Auto-update to latest TWLoader"
 
-	"Auto-download the CIA of the latest",						// "Auto-download the CIA of the latest"
-	"TWLoader version at launch.",								// "TWLoader version at launch."
-	
-	/** Settings: NTR/TWL_mode descriptions **/
-	"Pick a flashcard to use to",								// "Pick a flashcard to use to"
-	"run ROMs from it.",										// "run ROMs from it."
-	
-	"See rainbow colors glowing in",							// "See rainbow colors glowing in"
-	"the Notification LED.",									// "the Notification LED."
-	
-	"Set to TWL to get rid of lags in some games.",				// "Set to TWL to get rid of lags in some games."
-	"",															// (empty)
-	
-	"Allows 8 bit VRAM writes",									// "Allows 8 bit VRAM writes"
-	"and expands the bus to 32 bit.",							// "and expands the bus to 32 bit."
-	
-	"Displays the DS/DSi boot animation",						// "Displays the DS/DSi boot animation"
-	"before launched game.",									// "before launched game."
-	
-	"Displays the Health and Safety",							// "Displays the Health and Safety"
-	"message on the bottom screen.",							// "message on the bottom screen."
-	
-	"Enable this if Slot-1 carts are stuck",					// "Enable this if Slot-1 carts are stuck"
-	"on white screens.",										// "on white screens."
-	
-	"Displays some text before launched game.",					// "Displays some text before launched game."
-	"",															// (empty)
-	
-	"Locks the ARM9 SCFG_EXT,",									// "Locks the ARM9 SCFG_EXT,"
-	"avoiding conflict with recent libnds.",					// "avoiding conflict with recent libnds."
-	
-	"Change between release and",								// "Change between release and"
-	"unofficial bootstrap file.",								// "unofficial bootstrap file."
-	
-	/** Start menu **/
-	// Options
-	"Game location",											// "Game location"
-	"Box Art: On",												// "Box Art: On"
-	"Box Art: Off",												// "Box Art: OFF"
-	"Start GBARunner2",											// "Start GBARunner2"
-	"Top border: On",											// "Top border: On"
-	"Top border: Off",											// "Top border: Off"
-	"Unset donor ROM",											// "Unset donor rom"
-	"Search",													// "Search"
-	// Values
-	"SD Card",													// "SD Card"
-	"Flashcard",												// "Flashcard"
-	"Use the keyboard to find roms",							// "Use the keyboard to find roms"
-	
-	/** Select menu **/
-	// Options
-	"ARM9 CPU Speed",											// "ARM9 CPU Speed"
-	"VRAM boost",												// "VRAM boost"
-	"Lock ARM9 SCFG_EXT",										// "Lock ARM9 SCFG_EXT"
-	"Set as donor ROM",											// "Set as donor ROM"
-	"Set LED color",											// "Set LED color"
-	// Values
-	"Default",													// "Default"
-	
-	/** Sub-theme **/
-	"Sub-theme select: DSi Menu",								// "Sub-theme select: DSi Menu"
-	"Sub-theme select: R4",										// "Sub-theme select: R4"
-	"Sub-theme select: akMenu/Wood",							// "Sub-theme select: Wood"
-	
-	"No sub-themes exist for this theme.",						// "No sub-themes exist for this theme."
-	
-	/** Settings others minor strings **/
-	"A/B: Save and Return",										// "A/B: Save and Return"
-	"Left/Right: Pick",											// "Left/Right: Pick"
-	"Settings: GUI",											// "Settings: GUI"
-	"Settings: NTR/TWL-mode",									// "Settings: NTR/TWL-mode"
+    /** Settings: NTR/TWL_mode **/
+    "Flashcard(s) select",                                      // "Flashcard(s) select"
+    "Rainbow LED",                                              // "Rainbow LED"
+    "ARM9 CPU Speed",                                           // "ARM9 CPU Speed"
+    "VRAM boost",                                               // "VRAM boost"
+    "DS/DSi Boot Screen",                                       // "DS/DSi Boot Screen"
+    "Health and Safety message",                                // "Health and Safety message"
+    "Reset Slot-1",                                             // "Reset Slot-1"
+    "Console output",                                           // "Console output"
+    "Lock ARM9 SCFG_EXT",                                       // "Lock ARM9 SCFG_EXT"
+    "Bootstrap",                                                // "Bootstrap"
+
+    /** Settings: Top Screen **/
+    "X: Update bootstrap (Official release)",                   // "X: Update bootstrap (Official release)"
+    "Y: Update bootstrap (Unofficial release)",                 // "Y: Update bootstrap (Unofficial release)"
+    "START: Update TWLoader",                                   // "START: Update TWLoader"
+
+    /** Settings: GUI values **/
+
+    // Color
+    "Gray",                                                     // "Gray"
+    "Brown",                                                    // "Brown"
+    "Red",                                                      // "Red"
+    "Pink",                                                     // "Pink"
+    "Orange",                                                   // "Orange"
+    "Yellow",                                                   // "Yellow"
+    "Yellow-Green",                                             // "Yellow-Green"
+    "Green 1",                                                  // "Green 1"
+    "Green 2",                                                  // "Green 2"
+    "Light green",                                              // "Light green"
+    "Sky blue",                                                 // "Sky blue"
+    "Light blue",                                               // "Light blue"
+    "Blue",                                                     // "Blue"
+    "Violet",                                                   // "Violet"
+    "Purple",                                                   // "Purple"
+    "Fuchsia",                                                  // "Fuchsia"
+    "Red&blue",                                                 // "Red and blue"
+    "Green&yellow",                                             // "Green and yellow"
+    "Christmas",                                                // "Christmas"
+
+    // Menu Color
+    "White",                                                    // "White"
+    "Black",                                                    // "Black"
+
+    /** Settings: GUI descriptions **/
+    "The language to use for the UI,",                          // "The language to use for the UI,"
+    "including game banner text.",                              // "including game banner text."
+
+    "The theme to use in TWLoader.",                            // "The theme to use in TWLoader."
+    "Press A for sub-themes.",                                  // "Press A for sub-themes."
+
+    "The color of the top background,",                         // "The color of the top background,"
+    "the START border, and the circling dots.",                 // "the START border, and the circling dots."
+
+    "The color of the top border,",                             // "The color of the top border,"
+    "and the bottom background.",                               // "and the bottom background."
+
+    "Shows game filename at the top of the bubble.",            // "Shows game filename at the top of the bubble."
+    "",                                                         // (empty)
+
+    "A number of selected game and listed games",               // "A number of selected game and listed games"
+    "is shown below the text bubble.",                          // "is shown below the text bubble."
+
+    "Loads a custom bottom screen image",                       // "Loads a custom bottom screen image"
+    "for the game menu.",                                       // "for the game menu."
+
+    "Auto-update nds-bootstrap at launch.",                     // "Auto-update nds-bootstrap at launch."
+    "",                                                         // (empty)
+
+    "Auto-download the CIA of the latest",                      // "Auto-download the CIA of the latest"
+    "TWLoader version at launch.",                              // "TWLoader version at launch."
+
+    /** Settings: NTR/TWL_mode descriptions **/
+    "Pick a flashcard to use to",                               // "Pick a flashcard to use to"
+    "run ROMs from it.",                                        // "run ROMs from it."
+
+    "See rainbow colors glowing in",                            // "See rainbow colors glowing in"
+    "the Notification LED.",                                    // "the Notification LED."
+
+    "Set to TWL to get rid of lags in some games.",             // "Set to TWL to get rid of lags in some games."
+    "",                                                         // (empty)
+
+    "Allows 8 bit VRAM writes",                                 // "Allows 8 bit VRAM writes"
+    "and expands the bus to 32 bit.",                           // "and expands the bus to 32 bit."
+
+    "Displays the DS/DSi boot animation",                       // "Displays the DS/DSi boot animation"
+    "before launched game.",                                    // "before launched game."
+
+    "Displays the Health and Safety",                           // "Displays the Health and Safety"
+    "message on the bottom screen.",                            // "message on the bottom screen."
+
+    "Enable this if Slot-1 carts are stuck",                    // "Enable this if Slot-1 carts are stuck"
+    "on white screens.",                                        // "on white screens."
+
+    "Displays some text before launched game.",                 // "Displays some text before launched game."
+    "",                                                         // (empty)
+
+    "Locks the ARM9 SCFG_EXT,",                                 // "Locks the ARM9 SCFG_EXT,"
+    "avoiding conflict with recent libnds.",                    // "avoiding conflict with recent libnds."
+
+    "Change between release and",                               // "Change between release and"
+    "unofficial bootstrap file.",                               // "unofficial bootstrap file."
+
+    /** Start menu **/
+    // Options
+    "Game location",                                            // "Game location"
+    "Box Art: On",                                              // "Box Art: On"
+    "Box Art: Off",                                             // "Box Art: OFF"
+    "Start GBARunner2",                                         // "Start GBARunner2"
+    "Top border: On",                                           // "Top border: On"
+    "Top border: Off",                                          // "Top border: Off"
+    "Unset donor ROM",                                          // "Unset donor rom"
+    "Search",                                                   // "Search"
+    // Values
+    "SD Card",                                                  // "SD Card"
+    "Flashcard",                                                // "Flashcard"
+    "Use the keyboard to find roms",                            // "Use the keyboard to find roms"
+
+    /** Select menu **/
+    // Options
+    "ARM9 CPU Speed",                                           // "ARM9 CPU Speed"
+    "VRAM boost",                                               // "VRAM boost"
+    "Lock ARM9 SCFG_EXT",                                       // "Lock ARM9 SCFG_EXT"
+    "Set as donor ROM",                                         // "Set as donor ROM"
+    "Set LED color",                                            // "Set LED color"
+    // Values
+    "Default",                                                  // "Default"
+
+    /** Sub-theme **/
+    "Sub-theme select: DSi Menu",                               // "Sub-theme select: DSi Menu"
+    "Sub-theme select: R4",                                     // "Sub-theme select: R4"
+    "Sub-theme select: akMenu/Wood",                            // "Sub-theme select: Wood"
+
+    "No sub-themes exist for this theme.",                      // "No sub-themes exist for this theme."
+
+    /** Settings others minor strings **/
+    "A/B: Save and Return",                                     // "A/B: Save and Return"
+    "Left/Right: Pick",                                         // "Left/Right: Pick"
+    "Settings: GUI",                                            // "Settings: GUI"
+    "Settings: NTR/TWL-mode",                                   // "Settings: NTR/TWL-mode"
 
 };
 

--- a/gui/source/languages/french.h
+++ b/gui/source/languages/french.h
@@ -1,20 +1,20 @@
- 
+
 #ifndef FRENCH_H
 #define FRENCH_H
- 
+
 #include <3ds/types.h>
- 
+
 // FRENCH
-static const char *const lang_FR[STR_MAX] = {
-     
-/** GUI **/
+static const char* const lang_FR[STR_MAX] = {
+
+    /** GUI **/
     ": Retourner vers le Menu HOME",                                    // "Return to HOME Menu"
     "START",                                                    // "START" (used on cartridge indicator)
     "Pas de cartouche",                                             // "No cartridge"
     "Paramètres",                                                 // "Settings"
     "Cartouche inconnue",                                         // "Unknown Cartridge"
-    "B: Retour",                                                  // "B: Back"    
-     
+    "B: Retour",                                                  // "B: Back"
+
     /** Settings: GUI **/
     "Langue",                                                 // "Language"
     "Thème",                                                    // "Theme"
@@ -25,7 +25,7 @@ static const char *const lang_FR[STR_MAX] = {
     "Image du bas personnalisée",                                      // "Custom bottom image"
     "Mise à jour auto. de la bootstrap",                                    // "Auto-update bootstrap"
     "Mise à jour auto. de TWLoader",                           // "Auto-update to latest TWLoader"
-     
+
     /** Settings: NTR/TWL_mode **/
     "Sélection du linker(s)",                                      // "Flashcard(s) select"
     "LED arc-en-ciel",                                              // "Rainbow LED"
@@ -37,14 +37,14 @@ static const char *const lang_FR[STR_MAX] = {
     "Affichage",                                           // "Console output"
     "Vérouiller SCFG_EXT ARM9",                                       // "Lock ARM9 SCFG_EXT"
     "Bootstrap",                                                // "Bootstrap"
-     
+
     /** Settings: Top Screen **/
     "X: Mise à jour de la bootstrap (Release officiel)",                   // "X: Update bootstrap (Official release)"
     "Y: Mise à jour de la bootstrap (Release non-officiel)",                 // "Y: Update bootstrap (Unofficial release)"
     "START: Mettre à jour TWLoader",                                   // "START: Update TWLoader"
-     
+
     /** Settings: GUI values **/
-     
+
     // Color
     "Gris",                                                     // "Gray"
     "Brun",                                                    // "Brown"
@@ -65,70 +65,70 @@ static const char *const lang_FR[STR_MAX] = {
     "Rouge&Bleu",                                                 // "Red and blue"
     "Jaune&Vert",                                             // "Green and yellow"
     "Noel",                                                // "Christmas"
- 
+
     // Menu Color
     "Blanc",                                                    // "White"
     "Noir",                                                    // "Black"
- 
+
     /** Settings: GUI descriptions **/
     "La langue à utiliser pour l'UI,",                          // "The language to use for the UI,"
     "incluant le texte des bannières des jeux.",                              // "including game banner text."
-     
+
     "Le thème à utiliser dans TWLoader.",                            // "The theme to use in TWLoader."
     "Appuyez sur A pour les sous-thèmes.",                                  // "Press A for sub-themes."
-     
+
     "La couleur de l'arrière plan du haut,",                         // "The color of the top background,"
     "de la bordure START et du contour des points.",                 // "the START border, and the circling dots."
-     
+
     "La couleur de la bordure du haut,",                             // "The color of the top border,"
     "et de l'arrière plan du bas.",                               // "and the bottom background."
-     
+
     "Afficher le nom du fichier du jeu dans le bas de la bulle.",            // "Shows game filename at the top of the bubble."
     "",                                                         // (empty)
-     
+
     "Un numéro de jeux sélectionner et lister",               // "A number of selected game and listed games"
     "est afficher au dessous de la bulle de texte.",                          // "is shown below the text bubble."
-     
+
     "Charge une image personnalisée sur l'écran du bas",                       // "Loads a custom bottom screen image"
     "dans le menu des jeux.",                                       // "for the game menu."
-     
+
     "Mise à jour auto. de nds-bootstrap au démarrage.",                     // "Auto-update nds-bootstrap at launch."
     "",                                                         // (empty)
- 
+
     "Téléchargez automatiquement le dernier CIA ",                      // "Auto-download the CIA of the latest"
     "de TWLoader au démarrage.",                              // "TWLoader version at launch."
-     
+
     /** Settings: NTR/TWL_mode descriptions **/
     "Sélectionnez un linker à utiliser pour",                               // "Pick a flashcard to use to"
     "lancer les ROMs.",                                        // "run ROMs from it."
-     
+
     "Afficher les couleurs de l'arc-en-ciel clignotante dans",                            // "See rainbow colors glowing in"
     "la LED de notification.",                                    // "the Notification LED."
-     
+
     "Définis à TWL pour se débarrasser de lags dans certains jeux.",             // "Set to TWL to get rid of lags in some games."
     "",                                                         // (empty)
-     
+
     "Permet l'écriture VRAM 8 bit",                                 // "Allows 8 bit VRAM writes"
     "et étandre le bus de 32 bit.",                           // "and expands the bus to 32 bit."
-     
+
     "Afficher l'animation de démarrage de la DS/DSi",                       // "Displays the DS/DSi boot animation"
     "avant le jeu lancé.",                                    // "before launched game."
-     
+
     "Afficher le message de Santé et Sécurité",                           // "Displays the Health and Safety"
     "sur l'écran du bas.",                            // "message on the bottom screen."
-     
+
     "Activer ceci si les cartouches Slot-1 sont coincé",                    // "Enable this if Slot-1 carts are stuck"
     "sur des écrans blancs.",                                        // "on white screens."
-     
+
     "Aficher du texte avant de lancer un jeu.",                 // "Displays some text before launched game."
     "",                                                         // (empty)
-     
+
     "Verouille le SCFG_EXT de l'ARM9,",                                 // "Locks the ARM9 SCFG_EXT,"
     "évitant les conflits avec la libnds récente libnds.",                    // "avoiding conflict with recent libnds."
-     
+
     "Changer de fichier de bootstrap (release et",                               // "Change between release and"
     "non-officiel).",                               // "unofficial bootstrap file."
-     
+
     /** Start menu **/
     // Options
     "Localisation des jeux",                                            // "Game location"
@@ -143,7 +143,7 @@ static const char *const lang_FR[STR_MAX] = {
     "Carte SD",                                                  // "SD Card"
     "Linker",                                                // "Flashcard"
     "Utiliser le clavier pour trouver des roms",                            // "Use the keyboard to find roms"
-     
+
     /** Select menu **/
     // Options
     "Vitesse du CPU ARM9",                                           // "ARM9 CPU Speed"
@@ -153,21 +153,21 @@ static const char *const lang_FR[STR_MAX] = {
     "Définir la couleur de la LED",                                            // "Set LED color"
     // Values
     "Par défaut",                                                  // "Default"
-     
+
     /** Sub-theme **/
     "Sélection du sous-thème: DSi Menu",                               // "Sub-theme select: DSi Menu"
     "Sélection du sous-thème: R4",                                     // "Sub-theme select: R4"
     "Sélection du sous-thème: akMenu/Wood",                                   // "Sub-theme select: Wood"
-     
+
     "Aucune autre sous-thèmes pour ce thème.",                      // "No sub-themes exist for this theme."
-     
+
     /** Settings others minor strings **/
     "A/B: Sauvegarder and Retourner",                                     // "A/B: Save and Return"
     "Gauche/Droite: Choisir",                                         // "Left/Right: Pick"
     "Paramètres: GUI",                                            // "Settings: GUI"
     "Paramètres: NTR/TWL-mode",                                   // "Settings: NTR/TWL-mode"
- 
+
 };
- 
- 
+
+
 #endif /* FRENCH_H */

--- a/gui/source/languages/german.h
+++ b/gui/source/languages/german.h
@@ -4,167 +4,167 @@
 #include <3ds/types.h>
 
 // GERMAN
-static const char *const lang_DE[STR_MAX] = {
-	
-	/** GUI **/
-    ": Zurück zum HOME-Menü",									// "Return to HOME Menu"
-	"START",													// "START" (used on cartridge indicator)
-	"Keine Karte",												// "No cartridge"
-	"Unbekannte Karte",											// "Unknown Cartridge"
-	"Einstellungen",											// "Settings"
-	"B: Zurück",												// "B: Back"	
-	
-	/** Settings: GUI **/
-	"Sprache",													// "Language"
-	"Design",													// "Theme"
-	"Farbe",													// "Color"
-	"Menüfarbe",												// "Menu Color"
-	"Dateiname anzeigen",										// "Show filename"
-	"Spielzähler",												// "Game counter"
-	"Benutzerdefiniertes unteres Bild",							// "Custom bottom image"
-	"Bootstrap automatisch updaten",							// "Auto-update bootstrap"
-	"TWLoader automatisch updaten",								// "Auto-update to latest TWLoader"
-	
-	/** Settings: NTR/TWL_mode **/
-	"Flashkart(en) auswählen",									// "Flashcard(s) select"
-	"Regenbogen LED",											// "Rainbow LED"
-	"ARM9 CPU Geschwindigkeit",									// "ARM9 CPU Speed"
-	"VRAM Beschleunigung",										// "VRAM boost"
-	"DS/DSi Startbildschirm",									// "DS/DSi Boot Screen"
-	"Gesundheits- und Sicherheitsinformationen",				// "Health and Safety message"
-	"Slot-1 zurücksetzen",										// "Reset Slot-1"
-	"Konsolenausgabe",											// "Console output"
-	"ARM9 SCFG_EXT feststellen",								// "Lock ARM9 SCFG_EXT"
-	"Bootstrap",												// "Bootstrap"
-	
-	/** Settings: Top Screen **/
-	"X: Bootstrap updaten (Offizielle Version)",				// "X: Update bootstrap (Official release)"
-	"Y: Bootstrap updaten (Inoffizielle Version)",				// "Y: Update bootstrap (Unofficial release)"
-    "START: TWLoader aktualisieren",							// "START: Update TWLoader"
-	
-	/** Settings: GUI values **/
-	
-	// Color
-	"Grau",														// "Gray"
-	"Braun",													// "Brown"
-	"Rot",														// "Red"
-	"Pink",												 		// "Pink"
-	"Orange",													// "Orange"
-	"Gelb",														// "Yellow"
-	"Gelb-Grün",												// "Yellow-Green"
-	"Grün 1",													// "Green 1"
-	"Grün 2",													// "Green 2"
-	"Hellgrün",													// "Light green"
-	"Himmelblau",												// "Sky blue"
-	"Hellblau",													// "Light blue"
-	"Blau",														// "Blue"
-	"Violett",													// "Violet"
-	"Lila",														// "Purple"
-	"Fuchsia",													// "Fuchsia"
-	"Rot und blau",												// "Red and blue"
-	"Grün und gelb",											// "Green and yellow"
-	"Weihnachten",												// "Christmas"
+static const char* const lang_DE[STR_MAX] = {
 
-	// Menu Color
-	"Weiß",														// "White"
-	"Schwarz",													// "Black"
+    /** GUI **/
+    ": Zurück zum HOME-Menü",                                 // "Return to HOME Menu"
+    "START",                                                    // "START" (used on cartridge indicator)
+    "Keine Karte",                                              // "No cartridge"
+    "Unbekannte Karte",                                         // "Unknown Cartridge"
+    "Einstellungen",                                            // "Settings"
+    "B: Zurück",                                               // "B: Back"
 
-	/** Settings: GUI descriptions **/
-	"Die Sprache der Benutzeroberfläche",						// "The language to use for the UI,"
-	"und der Spielenamen.",										// "including game banner text."
-	
-	"Das benutzte Design für TWLoader.",						// "The theme to use in TWLoader."
-	"Drücke A für Unterdesigns.",								// "Press A for sub-themes."
-	
-	"Die Farbe des oberen Hintergrunds,",						// "The color of the top background,"
-	"der START Umrandung und der kreisenden Punkte.",			// "the START border, and the circling dots."
-	
-	"Die Farbe des oberen Randes",								// "The color of the top border,"
-	"und des unteren Hintergrundes.",							// "and the bottom background."
-	
-	"Zeigt den Dateinamen des Spiels oben in der Blase.",		// "Shows game filename at the top of the bubble."
-	"",															// (empty)
+    /** Settings: GUI **/
+    "Sprache",                                                  // "Language"
+    "Design",                                                   // "Theme"
+    "Farbe",                                                    // "Color"
+    "Menüfarbe",                                               // "Menu Color"
+    "Dateiname anzeigen",                                       // "Show filename"
+    "Spielzähler",                                             // "Game counter"
+    "Benutzerdefiniertes unteres Bild",                         // "Custom bottom image"
+    "Bootstrap automatisch updaten",                            // "Auto-update bootstrap"
+    "TWLoader automatisch updaten",                             // "Auto-update to latest TWLoader"
 
-	"Die Nummer des ausgewählten Spiels und die",				// "A number of selected game and listed games"
-	"Anzahl der Spiele wird unter der Textblase angezeigt.",	// "is shown below the text bubble."
-	
-	"Läd ein benutzerdefiniertes Bild für den unteren",			// "Loads a custom bottom screen image"
-	"Bildschirm im Spiele-Menü.",								// "for the game menu."
-	
-	"nds-bootstrap beim Start automatisch updaten.",			// "Auto-update nds-bootstrap at launch."
-	"",															// (empty)
+    /** Settings: NTR/TWL_mode **/
+    "Flashkart(en) auswählen",                                 // "Flashcard(s) select"
+    "Regenbogen LED",                                           // "Rainbow LED"
+    "ARM9 CPU Geschwindigkeit",                                 // "ARM9 CPU Speed"
+    "VRAM Beschleunigung",                                      // "VRAM boost"
+    "DS/DSi Startbildschirm",                                   // "DS/DSi Boot Screen"
+    "Gesundheits- und Sicherheitsinformationen",                // "Health and Safety message"
+    "Slot-1 zurücksetzen",                                     // "Reset Slot-1"
+    "Konsolenausgabe",                                          // "Console output"
+    "ARM9 SCFG_EXT feststellen",                                // "Lock ARM9 SCFG_EXT"
+    "Bootstrap",                                                // "Bootstrap"
 
-	"Die neuste TWLoader Version beim Start",					// "Auto-download the CIA of the latest"
-	"automatisch herunterladen.",								// "TWLoader version at launch."
-	
-	/** Settings: NTR/TWL_mode descriptions **/
-	"Wähle die Flashkarte, die du zum",							// "Pick a flashcard to use to"
-	"ausführen von ROMs benutzen willst.",						// "run ROMs from it."
-	
-	"Aktiviere Regenbogen Farben für",							// "See rainbow colors glowing in"
-	"die Benachrichtigungs-LED.",								// "the Notification LED."
-	
-	"Stelle auf TWL, um Lags in manchen",						// "Set to TWL to get rid of lags in some games."
-	"Spielen zu vermeiden.",									// (empty)
+    /** Settings: Top Screen **/
+    "X: Bootstrap updaten (Offizielle Version)",                // "X: Update bootstrap (Official release)"
+    "Y: Bootstrap updaten (Inoffizielle Version)",              // "Y: Update bootstrap (Unofficial release)"
+    "START: TWLoader aktualisieren",                            // "START: Update TWLoader"
 
-	"Erlaubt 8 bit VRAM Schreibevorgänge",						// "Allows 8 bit VRAM writes"
-	"und erweitert den Bus auf 32 bit.",						// "and expands the bus to 32 bit."
-	
-	"Zeigt die DS/DSi Boot-Animation",							// "Displays the DS/DSi boot animation"
-	"vor dem Spielstart an.",									// "before launched game."
-	
-	"Zeigt die Gesundheits- und Sicherheits-",					// "Displays the Health and Safety"
-	"warnung auf dem unteren Bildschirm an.",					// "message on the bottom screen."
-	
-	"Aktivieren, wenn Slot-1 Karten auf",						// "Enable this if Slot-1 carts are stuck"
-	"einem weißen Bildschirm hängen bleiben.",					// "on white screens."
-	
-	"Zeigt etwas Text vor dem Spielstart an.",					// "Displays some text before launched game."
-	"",															// (empty)
+    /** Settings: GUI values **/
 
-	"Stellt den ARM9 SCFG_EXT fest,",							// "Locks the ARM9 SCFG_EXT,"
-	"vermeidet Konflikt mit aktuellem libnds",					// "avoiding conflict with recent libnds."
-	
-	"Wechsele zwischen offizieller",							// "Change between release and"
-	"und inoffizieller Bootstrap Version",						// "unofficial bootstrap file."
-	
-	/** Start menu **/
-	// Options
-	"Spielort",													// "Game location"
-	"Box-Art: An",												// "Box Art: On"
-	"Box-Art: Aus",												// "Box Art: OFF"
-	"GBARunner2 starten",										// "Start GBARunner2"
-	"Oberer Rand: On",											// "Top border: On"
-	"Oberer Rand: Off",											// "Top border: Off"	
-	"Entferne Donor ROM",										// "Unset donor rom"	
-	"Suche",													// "Search"
-	// Values
-	"SD Karte",													// "SD Card"
-	"Flashkarte",												// "Flashcard"
-	"Benutze die Tastatur, um ROMs zu finden",					// "Use the keyboard to find roms"
-	
-	/** Select menu **/
-	// Options
-	"ARM9 CPU Geschwindigkeit",									// "ARM9 CPU Speed"
-	"VRAM Beschleunigung",										// "VRAM boost"
-	"ARM9 SCFG_EXT feststellen",								// "Lock ARM9 SCFG_EXT"
-	"Setze als Donor ROM",									// "Set as donor ROM"
-	"Setze LED Farbe",											// "Set LED color"
-	// Values
-	"Standart",													// "Default"
-	
-	/** Sub-theme **/
-	"Unterdesignauswahl: DSi Menu",								// "Sub-theme select: DSi Menu"
-	"Unterdesignauswahl: R4",									// "Sub-theme select: R4"
-	"Unterdesignauswahl: akMenu/Wood",									// "Sub-theme select: Wood"
-	
-	"Für dieses Design existiert kein Unterdesign.",			// "No sub-themes exist for this theme."
-	
-	/** Settings others minor strings **/
-	"A/B: Speichern und Zurück",								// "A/B: Save and Return"
-	"Links/Rechts: Auswählen",									// "Left/Right: Pick"
-	"Einstellungen: GUI",										// "Settings: GUI"
-	"Einstellungen: NTR/TWL-mode",								// "Settings: NTR/TWL-mode"
+    // Color
+    "Grau",                                                     // "Gray"
+    "Braun",                                                    // "Brown"
+    "Rot",                                                      // "Red"
+    "Pink",                                                     // "Pink"
+    "Orange",                                                   // "Orange"
+    "Gelb",                                                     // "Yellow"
+    "Gelb-Grün",                                               // "Yellow-Green"
+    "Grün 1",                                                  // "Green 1"
+    "Grün 2",                                                  // "Green 2"
+    "Hellgrün",                                                    // "Light green"
+    "Himmelblau",                                               // "Sky blue"
+    "Hellblau",                                                 // "Light blue"
+    "Blau",                                                     // "Blue"
+    "Violett",                                                  // "Violet"
+    "Lila",                                                     // "Purple"
+    "Fuchsia",                                                  // "Fuchsia"
+    "Rot und blau",                                             // "Red and blue"
+    "Grün und gelb",                                           // "Green and yellow"
+    "Weihnachten",                                              // "Christmas"
+
+    // Menu Color
+    "Weiß",                                                        // "White"
+    "Schwarz",                                                  // "Black"
+
+    /** Settings: GUI descriptions **/
+    "Die Sprache der Benutzeroberfläche",                      // "The language to use for the UI,"
+    "und der Spielenamen.",                                     // "including game banner text."
+
+    "Das benutzte Design für TWLoader.",                       // "The theme to use in TWLoader."
+    "Drücke A für Unterdesigns.",                             // "Press A for sub-themes."
+
+    "Die Farbe des oberen Hintergrunds,",                       // "The color of the top background,"
+    "der START Umrandung und der kreisenden Punkte.",           // "the START border, and the circling dots."
+
+    "Die Farbe des oberen Randes",                              // "The color of the top border,"
+    "und des unteren Hintergrundes.",                           // "and the bottom background."
+
+    "Zeigt den Dateinamen des Spiels oben in der Blase.",       // "Shows game filename at the top of the bubble."
+    "",                                                         // (empty)
+
+    "Die Nummer des ausgewählten Spiels und die",              // "A number of selected game and listed games"
+    "Anzahl der Spiele wird unter der Textblase angezeigt.",    // "is shown below the text bubble."
+
+    "Läd ein benutzerdefiniertes Bild für den unteren",           // "Loads a custom bottom screen image"
+    "Bildschirm im Spiele-Menü.",                              // "for the game menu."
+
+    "nds-bootstrap beim Start automatisch updaten.",            // "Auto-update nds-bootstrap at launch."
+    "",                                                         // (empty)
+
+    "Die neuste TWLoader Version beim Start",                   // "Auto-download the CIA of the latest"
+    "automatisch herunterladen.",                               // "TWLoader version at launch."
+
+    /** Settings: NTR/TWL_mode descriptions **/
+    "Wähle die Flashkarte, die du zum",                            // "Pick a flashcard to use to"
+    "ausführen von ROMs benutzen willst.",                     // "run ROMs from it."
+
+    "Aktiviere Regenbogen Farben für",                         // "See rainbow colors glowing in"
+    "die Benachrichtigungs-LED.",                               // "the Notification LED."
+
+    "Stelle auf TWL, um Lags in manchen",                       // "Set to TWL to get rid of lags in some games."
+    "Spielen zu vermeiden.",                                    // (empty)
+
+    "Erlaubt 8 bit VRAM Schreibevorgänge",                     // "Allows 8 bit VRAM writes"
+    "und erweitert den Bus auf 32 bit.",                        // "and expands the bus to 32 bit."
+
+    "Zeigt die DS/DSi Boot-Animation",                          // "Displays the DS/DSi boot animation"
+    "vor dem Spielstart an.",                                   // "before launched game."
+
+    "Zeigt die Gesundheits- und Sicherheits-",                  // "Displays the Health and Safety"
+    "warnung auf dem unteren Bildschirm an.",                   // "message on the bottom screen."
+
+    "Aktivieren, wenn Slot-1 Karten auf",                       // "Enable this if Slot-1 carts are stuck"
+    "einem weißen Bildschirm hängen bleiben.",                    // "on white screens."
+
+    "Zeigt etwas Text vor dem Spielstart an.",                  // "Displays some text before launched game."
+    "",                                                         // (empty)
+
+    "Stellt den ARM9 SCFG_EXT fest,",                           // "Locks the ARM9 SCFG_EXT,"
+    "vermeidet Konflikt mit aktuellem libnds",                  // "avoiding conflict with recent libnds."
+
+    "Wechsele zwischen offizieller",                            // "Change between release and"
+    "und inoffizieller Bootstrap Version",                      // "unofficial bootstrap file."
+
+    /** Start menu **/
+    // Options
+    "Spielort",                                                 // "Game location"
+    "Box-Art: An",                                              // "Box Art: On"
+    "Box-Art: Aus",                                             // "Box Art: OFF"
+    "GBARunner2 starten",                                       // "Start GBARunner2"
+    "Oberer Rand: On",                                          // "Top border: On"
+    "Oberer Rand: Off",                                         // "Top border: Off"
+    "Entferne Donor ROM",                                       // "Unset donor rom"
+    "Suche",                                                    // "Search"
+    // Values
+    "SD Karte",                                                 // "SD Card"
+    "Flashkarte",                                               // "Flashcard"
+    "Benutze die Tastatur, um ROMs zu finden",                  // "Use the keyboard to find roms"
+
+    /** Select menu **/
+    // Options
+    "ARM9 CPU Geschwindigkeit",                                 // "ARM9 CPU Speed"
+    "VRAM Beschleunigung",                                      // "VRAM boost"
+    "ARM9 SCFG_EXT feststellen",                                // "Lock ARM9 SCFG_EXT"
+    "Setze als Donor ROM",                                  // "Set as donor ROM"
+    "Setze LED Farbe",                                          // "Set LED color"
+    // Values
+    "Standart",                                                 // "Default"
+
+    /** Sub-theme **/
+    "Unterdesignauswahl: DSi Menu",                             // "Sub-theme select: DSi Menu"
+    "Unterdesignauswahl: R4",                                   // "Sub-theme select: R4"
+    "Unterdesignauswahl: akMenu/Wood",                                  // "Sub-theme select: Wood"
+
+    "Für dieses Design existiert kein Unterdesign.",           // "No sub-themes exist for this theme."
+
+    /** Settings others minor strings **/
+    "A/B: Speichern und Zurück",                               // "A/B: Save and Return"
+    "Links/Rechts: Auswählen",                                 // "Left/Right: Pick"
+    "Einstellungen: GUI",                                       // "Settings: GUI"
+    "Einstellungen: NTR/TWL-mode",                              // "Settings: NTR/TWL-mode"
 
 };
 

--- a/gui/source/languages/italian.h
+++ b/gui/source/languages/italian.h
@@ -4,16 +4,16 @@
 #include <3ds/types.h>
 
 // ITALIAN
-static const char *const lang_IT[STR_MAX] = {
-	
+static const char* const lang_IT[STR_MAX] = {
+
     /** GUI **/
     "Ritorna al menu HOME",                                       // "Return to HOME Menu"
     "AVVIA",                                                   // "START" (used on cartridge indicator)
     "Nessuna scheda",                                       // "No cartridge"
     "Scheda sconosciuta",                                    // "Unknown Cartridge"
     "Impostazioni",                                               // "Settings"
-    "B： Indietro",                                               // "B: Back"   
-   
+    "B： Indietro",                                               // "B: Back"
+
     /** Settings: GUI **/
     "Lingua",                                                   // "Language"
     "Tema",                                                       // "Theme"
@@ -24,7 +24,7 @@ static const char *const lang_IT[STR_MAX] = {
     "Sfondo inferiore personalizzato",                       // "Custom bottom image"
     "Aggiorna automaticamente bootstrap",                               // "Auto-update bootstrap"
     "Aggiorna automaticamente TWLoader",                           // "Auto-update to latest TWLoader"
-	
+
     /** Settings: NTR/TWL_mode **/
     "Seleziona la Flashcard",                                   // "Flashcard(s) select"
     "LED arcobaleno",                                           // "Rainbow LED"
@@ -36,12 +36,12 @@ static const char *const lang_IT[STR_MAX] = {
     "Console output",                                           // "Console output"
     "Blocca ARM9 SCFG_EXT",                                       // "Lock ARM9 SCFG_EXT"
     "Bootstrap",                                               // "Bootstrap"
-	
+
     /** Settings: Top Screen **/
     "X: Aggiorna il bootstrap (Versione ufficiale)",           // "X: Update bootstrap (Official release)"
     "Y: Aggiorna il bootstrap (Versione non ufficiale)",       // "Y: Update bootstrap (Unofficial release)"
     "START: Aggiorna il TWLoader",                               // "START: Update TWLoader"
-	
+
     /** Settings: GUI values **/
     // Color
     "Grigio",                                                   // "Gray"
@@ -63,14 +63,14 @@ static const char *const lang_IT[STR_MAX] = {
     "Rosso e blu",                                               // "Red and blue"
     "Verde e giallo",                                           // "Green and yellow"
     "Natale",                                                   // "Christmas"
-	
+
     // Menu Color
     "Bianco",                                                   // "White"
     "Nero",                                                       // "Black"
-	
+
     /** Settings: GUI descriptions **/
     "La lingua usata per la UI,",                               // "The language to use for the UI,"
-    "incluso il testo dei banner dei giochi.",                   // "including game banner text."	
+    "incluso il testo dei banner dei giochi.",                   // "including game banner text."
     "Il tema usato con il TWLoader.",                               // "The theme to use in TWLoader."
     "Premi A per i sotto-temi.",                               // "Press A for sub-themes."
     "Il colore dello sfondo superiore, del bordo",                       // "The color of the top background,"
@@ -87,7 +87,7 @@ static const char *const lang_IT[STR_MAX] = {
     "all'avvio.",                                                         // (empty)
     "Scarica automaticamente l'ultima",                           // "Auto-download the CIA of the latest"
     "versione del CIA TWLoader  all'avvio.",                               // "TWLoader version at launch."
-	
+
     /** Settings: NTR/TWL_mode descriptions **/
     "Seleziona una flashcard da usare",                           // "Pick a flashcard to use to"
     "per avviare le ROM.",                                       // "run ROMs from it."
@@ -95,7 +95,7 @@ static const char *const lang_IT[STR_MAX] = {
     "LED di notifica.",                                           // "the Notification LED."
     "Imposta su TWL per eliminare",                       // "Set to TWL to get rid of lags in some games."
     "il lag in alcuni giochi.",                                 // (empty)
-     
+
     "Abilita la scrittura della VRAM a 8 bit",                   // "Allows 8 bit VRAM writes"
     "ed espande il bus a 32 bit.",                               // "and expands the bus to 32 bit."
     "Mostra la schermata di avvio del DS/DSi",                   // "Displays the DS/DSi boot animation"
@@ -110,7 +110,7 @@ static const char *const lang_IT[STR_MAX] = {
     "evitando conflitti con le recenti libnds.",               // "avoiding conflict with recent libnds."
     "Cabia tra versione ufficiale e",                           // "Change between release and"
     "non ufficiale del file di bootstrap.",                       // "unofficial bootstrap file."
-	
+
     /** Start menu **/
     // Options
     "Cartella giochi",                                           // "Game location"
@@ -125,7 +125,7 @@ static const char *const lang_IT[STR_MAX] = {
     "Scheda SD",                                               // "SD Card"
     "Flashcard",                                               // "Flashcard"
     "Usa la tastiera per trovare le rom",                       // "Use the keyboard to find roms"
-	
+
     /** Select menu **/
     // Options
     "Velocità CPU ARM9",                                       // "ARM9 CPU Speed"
@@ -135,19 +135,19 @@ static const char *const lang_IT[STR_MAX] = {
     "Imposta il colore del LED",                                   // "Set LED color"
     // Values
     "Predefinito",                                               // "Default"
-	
+
     /** Sub-theme **/
     "Seleziona sotto-tema: DSi Menu",                           // "Sub-theme select: DSi Menu"
     "Seleziona sotto-tema: R4",                                   // "Sub-theme select: R4"
     "Seleziona sotto-tema: akMenu/Wood",                               // "Sub-theme select: Wood"
     "Non esistono sotto-temi per questo tema.",                   // "No sub-themes exist for this theme."
-	
+
     /** Settings others minor strings **/
     "A/B: Salva e torna a precedente",                           // "A/B: Save and Return"
     "Left/Right: Seleziona",                                   // "Left/Right: Pick"
     "Impostazioni: GUI",                                            // "Settings: GUI"
     "Impostazioni: NTR/TWL-mode",                                   // "Settings: NTR/TWL-mode"
-	
+
 };
 
 

--- a/gui/source/languages/japanese.h
+++ b/gui/source/languages/japanese.h
@@ -4,168 +4,168 @@
 #include <3ds/types.h>
 
 // JAPANESE
-static const char *const lang_JP[STR_MAX] = {
-	
-	/** GUI **/
-    ": Return to HOME Menu",									// "Return to HOME Menu"
-	"START",													// "START" (used on cartridge indicator)
-	"No cartridge",												// "No cartridge"
-	"Unknown Cartridge",										// "Unknown Cartridge"
-	"Settings",													// "Settings"
-	"B: Back",													// "B: Back"	
-	
-	/** Settings: GUI **/
-	"Language",													// "Language"
-	"Theme",													// "Theme"
-	"Color",													// "Color"
-	"Menu color",												// "Menu Color"
-	"Show filename",											// "Show filename"
-	"Game counter",												// "Game counter"
-	"Custom bottom image",										// "Custom bottom image"
-	"Auto-update bootstrap",									// "Auto-update bootstrap"
-	"Auto-update to latest TWLoader",							// "Auto-update to latest TWLoader"
-	
-	/** Settings: NTR/TWL_mode **/
-	"Flashcard(s) select",										// "Flashcard(s) select"
-	"Rainbow LED",												// "Rainbow LED"
-	"ARM9 CPU Speed",											// "ARM9 CPU Speed"
-	"VRAM boost",												// "VRAM boost"
-	"DS/DSi Boot Screen",										// "DS/DSi Boot Screen"
-	"Health and Safety message",								// "Health and Safety message"
-	"Reset Slot-1",												// "Reset Slot-1"
-	"Console output",											// "Console output"
-	"Lock ARM9 SCFG_EXT",										// "Lock ARM9 SCFG_EXT"
-	"Bootstrap",												// "Bootstrap"
-	
-	/** Settings: Top Screen **/
-	"X: Update bootstrap (Official release)",					// "X: Update bootstrap (Official release)"
-	"Y: Update bootstrap (Unofficial release)",					// "Y: Update bootstrap (Unofficial release)"
-    "START: Update TWLoader",    								// "START: Update TWLoader"
-	
-	/** Settings: GUI values **/
-	
-	// Color
-	"Gray",														// "Gray"
-	"Brown",													// "Brown"
-	"Red",														// "Red"
-	"Pink",												 		// "Pink"
-	"Orange",													// "Orange"
-	"Yellow",													// "Yellow"
-	"Yellow-Green",												// "Yellow-Green"
-	"Green 1",													// "Green 1"
-	"Green 2",													// "Green 2"
-	"Light green",												// "Light green"
-	"Sky blue",													// "Sky blue"
-	"Light blue",												// "Light blue"
-	"Blue",														// "Blue"
-	"Violet",													// "Violet"
-	"Purple",													// "Purple"
-	"Fuchsia",													// "Fuchsia"
-	"Red&blue",													// "Red and blue"
-	"Green&yellow",												// "Green and yellow"
-	"Christmas",												// "Christmas"
+static const char* const lang_JP[STR_MAX] = {
 
-	// Menu Color
-	"White",													// "White"
-	"Black",													// "Black"
+    /** GUI **/
+    ": Return to HOME Menu",                                    // "Return to HOME Menu"
+    "START",                                                    // "START" (used on cartridge indicator)
+    "No cartridge",                                             // "No cartridge"
+    "Unknown Cartridge",                                        // "Unknown Cartridge"
+    "Settings",                                                 // "Settings"
+    "B: Back",                                                  // "B: Back"
 
-	/** Settings: GUI descriptions **/
-	"The language to use for the UI,",							// "The language to use for the UI,"
-	"including game banner text.",								// "including game banner text."
-	
-	"The theme to use in TWLoader.",							// "The theme to use in TWLoader."
-	"Press A for sub-themes.",									// "Press A for sub-themes."
-	
-	"The color of the top background,",							// "The color of the top background,"
-	"the START border, and the circling dots.",					// "the START border, and the circling dots."
-	
-	"The color of the top border,",								// "The color of the top border,"
-	"and the bottom background.",								// "and the bottom background."
-	
-	"Shows game filename at the top of the bubble.",			// "Shows game filename at the top of the bubble."
-	"",															// (empty)
-	
-	"A number of selected game and listed games",				// "A number of selected game and listed games"
-	"is shown below the text bubble.",							// "is shown below the text bubble."
-	
-	"Loads a custom bottom screen image",						// "Loads a custom bottom screen image"
-	"for the game menu.",										// "for the game menu."
-	
-	"Auto-update nds-bootstrap at launch.",						// "Auto-update nds-bootstrap at launch."
-	"",															// (empty)
+    /** Settings: GUI **/
+    "Language",                                                 // "Language"
+    "Theme",                                                    // "Theme"
+    "Color",                                                    // "Color"
+    "Menu color",                                               // "Menu Color"
+    "Show filename",                                            // "Show filename"
+    "Game counter",                                             // "Game counter"
+    "Custom bottom image",                                      // "Custom bottom image"
+    "Auto-update bootstrap",                                    // "Auto-update bootstrap"
+    "Auto-update to latest TWLoader",                           // "Auto-update to latest TWLoader"
 
-	"Auto-download the CIA of the latest",						// "Auto-download the CIA of the latest"
-	"TWLoader version at launch.",								// "TWLoader version at launch."
-	
-	/** Settings: NTR/TWL_mode descriptions **/
-	"Pick a flashcard to use to",								// "Pick a flashcard to use to"
-	"run ROMs from it.",										// "run ROMs from it."
-	
-	"See rainbow colors glowing in",							// "See rainbow colors glowing in"
-	"the Notification LED.",									// "the Notification LED."
-	
-	"Set to TWL to get rid of lags in some games.",				// "Set to TWL to get rid of lags in some games."
-	"",															// (empty)
-	
-	"Allows 8 bit VRAM writes",									// "Allows 8 bit VRAM writes"
-	"and expands the bus to 32 bit.",							// "and expands the bus to 32 bit."
-	
-	"Displays the DS/DSi boot animation",						// "Displays the DS/DSi boot animation"
-	"before launched game.",									// "before launched game."
-	
-	"Displays the Health and Safety",							// "Displays the Health and Safety"
-	"message on the bottom screen.",							// "message on the bottom screen."
-	
-	"Enable this if Slot-1 carts are stuck",					// "Enable this if Slot-1 carts are stuck"
-	"on white screens.",										// "on white screens."
-	
-	"Displays some text before launched game.",					// "Displays some text before launched game."
-	"",															// (empty)
-	
-	"Locks the ARM9 SCFG_EXT,",									// "Locks the ARM9 SCFG_EXT,"
-	"avoiding conflict with recent libnds.",					// "avoiding conflict with recent libnds."
-	
-	"Change between release and",								// "Change between release and"
-	"unofficial bootstrap file.",								// "unofficial bootstrap file."
-	
-	/** Start menu **/
-	// Options
-	"Game location",											// "Game location"
-	"Box Art: On",												// "Box Art: On"
-	"Box Art: Off",												// "Box Art: OFF"
-	"Start GBARunner2",											// "Start GBARunner2"
-	"Top border: On",											// "Top border: On"
-	"Top border: Off",											// "Top border: Off"
-	"Unset donor ROM",											// "Unset donor rom"	
-	"Search",													// "Search"
-	// Values
-	"SD Card",													// "SD Card"
-	"Flashcard",												// "Flashcard"
-	"Use the keyboard to find roms",							// "Use the keyboard to find roms"
-	
-	/** Select menu **/
-	// Options
-	"ARM9 CPU Speed",											// "ARM9 CPU Speed"
-	"VRAM boost",												// "VRAM boost"
-	"Lock ARM9 SCFG_EXT",										// "Lock ARM9 SCFG_EXT"
-	"Set as donor ROM",											// "Set as donor ROM"
-	"Set LED color",											// "Set LED color"
-	// Values
-	"Default",													// "Default"
-	
-	/** Sub-theme **/
-	"Sub-theme select: DSi Menu",								// "Sub-theme select: DSi Menu"
-	"Sub-theme select: R4",										// "Sub-theme select: R4"
-	"Sub-theme select: akMenu/Wood",									// "Sub-theme select: Wood"
-	
-	"No sub-themes exist for this theme.",						// "No sub-themes exist for this theme."
-	
-	/** Settings others minor strings **/
-	"A/B: Save and Return",										// "A/B: Save and Return"
-	"Left/Right: Pick",											// "Left/Right: Pick"
-	"Settings: GUI",											// "Settings: GUI"
-	"Settings: NTR/TWL-mode",									// "Settings: NTR/TWL-mode"
-	
+    /** Settings: NTR/TWL_mode **/
+    "Flashcard(s) select",                                      // "Flashcard(s) select"
+    "Rainbow LED",                                              // "Rainbow LED"
+    "ARM9 CPU Speed",                                           // "ARM9 CPU Speed"
+    "VRAM boost",                                               // "VRAM boost"
+    "DS/DSi Boot Screen",                                       // "DS/DSi Boot Screen"
+    "Health and Safety message",                                // "Health and Safety message"
+    "Reset Slot-1",                                             // "Reset Slot-1"
+    "Console output",                                           // "Console output"
+    "Lock ARM9 SCFG_EXT",                                       // "Lock ARM9 SCFG_EXT"
+    "Bootstrap",                                                // "Bootstrap"
+
+    /** Settings: Top Screen **/
+    "X: Update bootstrap (Official release)",                   // "X: Update bootstrap (Official release)"
+    "Y: Update bootstrap (Unofficial release)",                 // "Y: Update bootstrap (Unofficial release)"
+    "START: Update TWLoader",                                   // "START: Update TWLoader"
+
+    /** Settings: GUI values **/
+
+    // Color
+    "Gray",                                                     // "Gray"
+    "Brown",                                                    // "Brown"
+    "Red",                                                      // "Red"
+    "Pink",                                                     // "Pink"
+    "Orange",                                                   // "Orange"
+    "Yellow",                                                   // "Yellow"
+    "Yellow-Green",                                             // "Yellow-Green"
+    "Green 1",                                                  // "Green 1"
+    "Green 2",                                                  // "Green 2"
+    "Light green",                                              // "Light green"
+    "Sky blue",                                                 // "Sky blue"
+    "Light blue",                                               // "Light blue"
+    "Blue",                                                     // "Blue"
+    "Violet",                                                   // "Violet"
+    "Purple",                                                   // "Purple"
+    "Fuchsia",                                                  // "Fuchsia"
+    "Red&blue",                                                 // "Red and blue"
+    "Green&yellow",                                             // "Green and yellow"
+    "Christmas",                                                // "Christmas"
+
+    // Menu Color
+    "White",                                                    // "White"
+    "Black",                                                    // "Black"
+
+    /** Settings: GUI descriptions **/
+    "The language to use for the UI,",                          // "The language to use for the UI,"
+    "including game banner text.",                              // "including game banner text."
+
+    "The theme to use in TWLoader.",                            // "The theme to use in TWLoader."
+    "Press A for sub-themes.",                                  // "Press A for sub-themes."
+
+    "The color of the top background,",                         // "The color of the top background,"
+    "the START border, and the circling dots.",                 // "the START border, and the circling dots."
+
+    "The color of the top border,",                             // "The color of the top border,"
+    "and the bottom background.",                               // "and the bottom background."
+
+    "Shows game filename at the top of the bubble.",            // "Shows game filename at the top of the bubble."
+    "",                                                         // (empty)
+
+    "A number of selected game and listed games",               // "A number of selected game and listed games"
+    "is shown below the text bubble.",                          // "is shown below the text bubble."
+
+    "Loads a custom bottom screen image",                       // "Loads a custom bottom screen image"
+    "for the game menu.",                                       // "for the game menu."
+
+    "Auto-update nds-bootstrap at launch.",                     // "Auto-update nds-bootstrap at launch."
+    "",                                                         // (empty)
+
+    "Auto-download the CIA of the latest",                      // "Auto-download the CIA of the latest"
+    "TWLoader version at launch.",                              // "TWLoader version at launch."
+
+    /** Settings: NTR/TWL_mode descriptions **/
+    "Pick a flashcard to use to",                               // "Pick a flashcard to use to"
+    "run ROMs from it.",                                        // "run ROMs from it."
+
+    "See rainbow colors glowing in",                            // "See rainbow colors glowing in"
+    "the Notification LED.",                                    // "the Notification LED."
+
+    "Set to TWL to get rid of lags in some games.",             // "Set to TWL to get rid of lags in some games."
+    "",                                                         // (empty)
+
+    "Allows 8 bit VRAM writes",                                 // "Allows 8 bit VRAM writes"
+    "and expands the bus to 32 bit.",                           // "and expands the bus to 32 bit."
+
+    "Displays the DS/DSi boot animation",                       // "Displays the DS/DSi boot animation"
+    "before launched game.",                                    // "before launched game."
+
+    "Displays the Health and Safety",                           // "Displays the Health and Safety"
+    "message on the bottom screen.",                            // "message on the bottom screen."
+
+    "Enable this if Slot-1 carts are stuck",                    // "Enable this if Slot-1 carts are stuck"
+    "on white screens.",                                        // "on white screens."
+
+    "Displays some text before launched game.",                 // "Displays some text before launched game."
+    "",                                                         // (empty)
+
+    "Locks the ARM9 SCFG_EXT,",                                 // "Locks the ARM9 SCFG_EXT,"
+    "avoiding conflict with recent libnds.",                    // "avoiding conflict with recent libnds."
+
+    "Change between release and",                               // "Change between release and"
+    "unofficial bootstrap file.",                               // "unofficial bootstrap file."
+
+    /** Start menu **/
+    // Options
+    "Game location",                                            // "Game location"
+    "Box Art: On",                                              // "Box Art: On"
+    "Box Art: Off",                                             // "Box Art: OFF"
+    "Start GBARunner2",                                         // "Start GBARunner2"
+    "Top border: On",                                           // "Top border: On"
+    "Top border: Off",                                          // "Top border: Off"
+    "Unset donor ROM",                                          // "Unset donor rom"
+    "Search",                                                   // "Search"
+    // Values
+    "SD Card",                                                  // "SD Card"
+    "Flashcard",                                                // "Flashcard"
+    "Use the keyboard to find roms",                            // "Use the keyboard to find roms"
+
+    /** Select menu **/
+    // Options
+    "ARM9 CPU Speed",                                           // "ARM9 CPU Speed"
+    "VRAM boost",                                               // "VRAM boost"
+    "Lock ARM9 SCFG_EXT",                                       // "Lock ARM9 SCFG_EXT"
+    "Set as donor ROM",                                         // "Set as donor ROM"
+    "Set LED color",                                            // "Set LED color"
+    // Values
+    "Default",                                                  // "Default"
+
+    /** Sub-theme **/
+    "Sub-theme select: DSi Menu",                               // "Sub-theme select: DSi Menu"
+    "Sub-theme select: R4",                                     // "Sub-theme select: R4"
+    "Sub-theme select: akMenu/Wood",                                    // "Sub-theme select: Wood"
+
+    "No sub-themes exist for this theme.",                      // "No sub-themes exist for this theme."
+
+    /** Settings others minor strings **/
+    "A/B: Save and Return",                                     // "A/B: Save and Return"
+    "Left/Right: Pick",                                         // "Left/Right: Pick"
+    "Settings: GUI",                                            // "Settings: GUI"
+    "Settings: NTR/TWL-mode",                                   // "Settings: NTR/TWL-mode"
+
 };
 
 

--- a/gui/source/languages/korean.h
+++ b/gui/source/languages/korean.h
@@ -4,167 +4,167 @@
 #include <3ds/types.h>
 
 // KOREAN
-static const char *const lang_KO[STR_MAX] = {
-	
-	/** GUI **/
-    ": 홈 메뉴로 돌아가",									// "Return to HOME Menu"
-	"시작",													// "START" (used on cartridge indicator)
-	"카트리지가 없습니다.",												// "No cartridge"
-	"카트리지가 올바르지 않습니다.", 										// "Unknown Cartridge"
-	"설정",													// "Settings"
-	"B: 뒤로",													// "B: Back"	
-	
-	/** Settings: GUI **/
-	"언어",													// "Language"
-	"테마",													// "Theme"
-	"색상",													// "Color"
-	"메뉴 색상",												// "Menu Color"
-	"파일이름 보기",											// "Show filename"
-	"기게임 카운터",												// "Game counter"
-	"커스텀 하단 이미지",										// "Custom bottom image"
-	"부트스트랩 자동 업데이트",									// "Auto-update bootstrap"
-	"TWLoader 자동 업데이트",							// "Auto-update to latest TWLoader"
-	
-	/** Settings: NTR/TWL_mode **/
-	"플래시카드 선택",										// "Flashcard(s) select"
-	"무지개색 LED",												// "Rainbow LED"
-	"ARM9 CPU 속도",											// "ARM9 CPU Speed"
-	"VRAM 부스트",												// "VRAM boost"
-	"DS/DSi 부트 스크린",										// "DS/DSi Boot Screen"
-	"안전 및 주의사항 메세지",								// "Health and Safety message"
-	"리셋 슬롯-1",												// "Reset Slot-1"
-	"콘솔 출력",											// "Console output"
-	"ARM9 SCFG_EXT 잠금",										// "Lock ARM9 SCFG_EXT"
-	"부트스트랩",												// "Bootstrap"
-	
-	/** Settings: Top Screen **/
-	"X: 부트스트랩 업데이트 (공식 릴리즈)",					// "X: Update bootstrap (Official release)"
-	"Y: 부트스트랩 업데이트 (비공식 릴리즈)",					// "Y: Update bootstrap (Unofficial release)"
-    "START: TWLoader 업데이트",    								// "START: Update TWLoader"
-	
-	/** Settings: GUI values **/
-	
-	// Color
-	"회색",														// "Gray"
-	"갈색",													// "Brown"
-	"빨간색",														// "Red"
-	"분홍색",												 		// "Pink"
-	"주황색",													// "Orange"
-	"노란색",													// "Yellow"
-	"초록-노란색",												// "Yellow-Green"
-	"초록색 1",													// "Green 1"
-	"초록색 2",													// "Green 2"
-	"연두색",												// "Light green"
-	"하늘색",													// "Sky blue"
-	"밝은 파란색",												// "Light blue"
-	"파란색",														// "Blue"
-	"보라색",													// "Violet"
-	"자주색",													// "Purple"
-	"진홍색",													// "Fuchsia"
-	"빨간색/파란색",													// "Red and blue"
-	"초록색/노란색",												// "Green and yellow"
-	"크리스마스",												// "Christmas"
+static const char* const lang_KO[STR_MAX] = {
 
-	// Menu Color
-	"흰색",													// "White"
-	"검정색",													// "Black"
+    /** GUI **/
+    ": 홈 메뉴로 돌아가",                                    // "Return to HOME Menu"
+    "시작",                                                   // "START" (used on cartridge indicator)
+    "카트리지가 없습니다.",                                                // "No cartridge"
+    "카트리지가 올바르지 않습니다.",                                       // "Unknown Cartridge"
+    "설정",                                                   // "Settings"
+    "B: 뒤로",                                                    // "B: Back"
 
-	/** Settings: GUI descriptions **/
-	"게임 배너를 포함해 ",							// "The language to use for the UI,"
-	"UI에서 사용할 언어",								// "including game banner text."
-	
-	"TWLoader 테마",							// "The theme to use in TWLoader."
-	"서브테마를 설정하려면 A 를 누르세요",									// "Press A for sub-themes."
-	
-	"위쪽 바탕화면 색상",							// "The color of the top background,"
-	"시작 테두리 포함",					// "the START border, and the circling dots."
-	
-	"위쪽 테두리 색상",								// "The color of the top border,"
-	"아래쪽 바탕화면 색상 포함",								// "and the bottom background."
-	
-	"상단 버블메뉴에 게임 파일이름 보이기",			// "Shows game filename at the top of the bubble."
-	"",															// (empty)
-	
-	"선택한 게임/게임 리스트 갯수",				// "A number of selected game and listed games"
-	"는 하단 텍스트 버블에 나옵니다.",							// "is shown below the text bubble."
-	
-	"게임 메뉴에",						// "Loads a custom bottom screen image"
-	"사용자 설정 스크린 이미지 띄우기.",										// "for the game menu."
-	
-	"시작 시 nds-부트스트랩 업데이트",						// "Auto-update nds-bootstrap at launch."
-	"",															// (empty)
+    /** Settings: GUI **/
+    "언어",                                                   // "Language"
+    "테마",                                                   // "Theme"
+    "색상",                                                   // "Color"
+    "메뉴 색상",                                                // "Menu Color"
+    "파일이름 보기",                                          // "Show filename"
+    "기게임 카운터",                                              // "Game counter"
+    "커스텀 하단 이미지",                                       // "Custom bottom image"
+    "부트스트랩 자동 업데이트",                                  // "Auto-update bootstrap"
+    "TWLoader 자동 업데이트",                         // "Auto-update to latest TWLoader"
 
-	"시작 시",						// "Auto-download the CIA of the latest"
-	"TWLoader 최신 CIA 자동 다운로드",								// "TWLoader version at launch."
-	
-	/** Settings: NTR/TWL_mode descriptions **/
-	"ROM 파일이 있는",								// "Pick a flashcard to use to"
-	"플래시카드 선택",										// "run ROMs from it."
-	
-	"알림 LED에",							// "See rainbow colors glowing in"
-	"무지개색 LED 적용",									// "the Notification LED."
-	
-	"몇몇 게임에서 렉을 없애기 위해 TWL으로 설정",				// "Set to TWL to get rid of lags in some games."
-	"",															// (empty)
-	
-	"8 bit VRAM 쓰기 허용",									// "Allows 8 bit VRAM writes"
-	"및 버스 크기 32bit으로 확장",							// "and expands the bus to 32 bit."
-	
-	"게임 시작 전",						// "Displays the DS/DSi boot animation"
-	"DS/DSi 부팅애니메이션 보이기",									// "before launched game."
-	
-	"안전 및 주의사항 메세지를",							// "Displays the Health and Safety"
-	"하단 화면에 출력",							// "message on the bottom screen."
-	
-	"Slot-1 carts가 화이트스크린에서 멈추면 ",					// "Enable this if Slot-1 carts are stuck"
-	"이 옵션 설정",										// "on white screens."
-	
-	"게임구동 전 텍스트 출력",					// "Displays some text before launched game."
-	"",															// (empty)
-	
-	"최신 nds 라이브러리와 충돌 회피를 피하기 위해 ",									// "Locks the ARM9 SCFG_EXT,"
-	"ARM9 SCFG_EXT 잠금",					// "avoiding conflict with recent libnds."
-	
-	"부트스트랩 파일을 ",								// "Change between release and"
-	"공식/비공식으로 변경.",								// "unofficial bootstrap file."
-	
-	/** Start menu **/
-	// Options
-	"게임 위치",											// "Game location"
-	"박스아트: 켜짐",												// "Box Art: On"
-	"박스아트: 꺼짐",												// "Box Art: OFF"
-	"GBARunner2 구동",											// "Start GBARunner2"
-	"상단 테두리: 켜짐",											// "Top border: On"
-	"상단 테두리: 꺼짐",											// "Top border: Off"
-	"donor rom 해제",											// "Unset donor rom"
-	"검색",													// "Search"
-	// Values
-	"SD 카드",													// "SD Card"
-	"플래시카드",												// "Flashcard"
-	"롬 검색 시 키보드 사용",							// "Use the keyboard to find roms"
-	
-	/** Select menu **/
-	// Options
-	"ARM9 CPU 속도",											// "ARM9 CPU Speed"
-	"VRAM 부스트",												// "VRAM boost"
-	"ARM9 SCFG_EXT 고정",										// "Lock ARM9 SCFG_EXT"
-	"donor ROM으로 설정",											// "Set as donor ROM"
-	"LED 색상",											// "Set LED color"
-	// Values
-	"기본값",													// "Default"
-	
-	/** Sub-theme **/
-	"하위 테마 선택: DSi 메뉴",								// "Sub-theme select: DSi Menu"
-	"하위 테마 선택: R4",										// "Sub-theme select: R4"
-	"하위 테마 선택: akMenu/Wood",							// "Sub-theme select: Wood"
-	
-	"하위 테마가 없습니다.",						// "No sub-themes exist for this theme."
-	
-	/** Settings others minor strings **/
-	"A/B: 저장 후 되돌아가기",										// "A/B: Save and Return"
-	"</>: 선택",											// "Left/Right: Pick"
-	"GUI 설정",											// "Settings: GUI"
-	"NTR/TWL-mode 설정",									// "Settings: NTR/TWL-mode"
+    /** Settings: NTR/TWL_mode **/
+    "플래시카드 선택",                                       // "Flashcard(s) select"
+    "무지개색 LED",                                             // "Rainbow LED"
+    "ARM9 CPU 속도",                                          // "ARM9 CPU Speed"
+    "VRAM 부스트",                                               // "VRAM boost"
+    "DS/DSi 부트 스크린",                                      // "DS/DSi Boot Screen"
+    "안전 및 주의사항 메세지",                                // "Health and Safety message"
+    "리셋 슬롯-1",                                              // "Reset Slot-1"
+    "콘솔 출력",                                            // "Console output"
+    "ARM9 SCFG_EXT 잠금",                                     // "Lock ARM9 SCFG_EXT"
+    "부트스트랩",                                              // "Bootstrap"
+
+    /** Settings: Top Screen **/
+    "X: 부트스트랩 업데이트 (공식 릴리즈)",                   // "X: Update bootstrap (Official release)"
+    "Y: 부트스트랩 업데이트 (비공식 릴리즈)",                    // "Y: Update bootstrap (Unofficial release)"
+    "START: TWLoader 업데이트",                                 // "START: Update TWLoader"
+
+    /** Settings: GUI values **/
+
+    // Color
+    "회색",                                                       // "Gray"
+    "갈색",                                                   // "Brown"
+    "빨간색",                                                        // "Red"
+    "분홍색",                                                        // "Pink"
+    "주황색",                                                    // "Orange"
+    "노란색",                                                    // "Yellow"
+    "초록-노란색",                                             // "Yellow-Green"
+    "초록색 1",                                                  // "Green 1"
+    "초록색 2",                                                  // "Green 2"
+    "연두색",                                                // "Light green"
+    "하늘색",                                                    // "Sky blue"
+    "밝은 파란색",                                             // "Light blue"
+    "파란색",                                                        // "Blue"
+    "보라색",                                                    // "Violet"
+    "자주색",                                                    // "Purple"
+    "진홍색",                                                    // "Fuchsia"
+    "빨간색/파란색",                                                  // "Red and blue"
+    "초록색/노란색",                                              // "Green and yellow"
+    "크리스마스",                                              // "Christmas"
+
+    // Menu Color
+    "흰색",                                                   // "White"
+    "검정색",                                                    // "Black"
+
+    /** Settings: GUI descriptions **/
+    "게임 배너를 포함해 ",                          // "The language to use for the UI,"
+    "UI에서 사용할 언어",                                // "including game banner text."
+
+    "TWLoader 테마",                          // "The theme to use in TWLoader."
+    "서브테마를 설정하려면 A 를 누르세요",                                   // "Press A for sub-themes."
+
+    "위쪽 바탕화면 색상",                           // "The color of the top background,"
+    "시작 테두리 포함",                  // "the START border, and the circling dots."
+
+    "위쪽 테두리 색상",                              // "The color of the top border,"
+    "아래쪽 바탕화면 색상 포함",                             // "and the bottom background."
+
+    "상단 버블메뉴에 게임 파일이름 보이기",         // "Shows game filename at the top of the bubble."
+    "",                                                         // (empty)
+
+    "선택한 게임/게임 리스트 갯수",             // "A number of selected game and listed games"
+    "는 하단 텍스트 버블에 나옵니다.",                         // "is shown below the text bubble."
+
+    "게임 메뉴에",                     // "Loads a custom bottom screen image"
+    "사용자 설정 스크린 이미지 띄우기.",                                      // "for the game menu."
+
+    "시작 시 nds-부트스트랩 업데이트",                      // "Auto-update nds-bootstrap at launch."
+    "",                                                         // (empty)
+
+    "시작 시",                       // "Auto-download the CIA of the latest"
+    "TWLoader 최신 CIA 자동 다운로드",                              // "TWLoader version at launch."
+
+    /** Settings: NTR/TWL_mode descriptions **/
+    "ROM 파일이 있는",                             // "Pick a flashcard to use to"
+    "플래시카드 선택",                                       // "run ROMs from it."
+
+    "알림 LED에",                            // "See rainbow colors glowing in"
+    "무지개색 LED 적용",                                  // "the Notification LED."
+
+    "몇몇 게임에서 렉을 없애기 위해 TWL으로 설정",             // "Set to TWL to get rid of lags in some games."
+    "",                                                         // (empty)
+
+    "8 bit VRAM 쓰기 허용",                                 // "Allows 8 bit VRAM writes"
+    "및 버스 크기 32bit으로 확장",                         // "and expands the bus to 32 bit."
+
+    "게임 시작 전",                        // "Displays the DS/DSi boot animation"
+    "DS/DSi 부팅애니메이션 보이기",                                   // "before launched game."
+
+    "안전 및 주의사항 메세지를",                         // "Displays the Health and Safety"
+    "하단 화면에 출력",                          // "message on the bottom screen."
+
+    "Slot-1 carts가 화이트스크린에서 멈추면 ",                  // "Enable this if Slot-1 carts are stuck"
+    "이 옵션 설정",                                        // "on white screens."
+
+    "게임구동 전 텍스트 출력",                    // "Displays some text before launched game."
+    "",                                                         // (empty)
+
+    "최신 nds 라이브러리와 충돌 회피를 피하기 위해 ",                                 // "Locks the ARM9 SCFG_EXT,"
+    "ARM9 SCFG_EXT 잠금",                 // "avoiding conflict with recent libnds."
+
+    "부트스트랩 파일을 ",                               // "Change between release and"
+    "공식/비공식으로 변경.",                               // "unofficial bootstrap file."
+
+    /** Start menu **/
+    // Options
+    "게임 위치",                                            // "Game location"
+    "박스아트: 켜짐",                                             // "Box Art: On"
+    "박스아트: 꺼짐",                                             // "Box Art: OFF"
+    "GBARunner2 구동",                                            // "Start GBARunner2"
+    "상단 테두리: 켜짐",                                         // "Top border: On"
+    "상단 테두리: 꺼짐",                                         // "Top border: Off"
+    "donor rom 해제",                                         // "Unset donor rom"
+    "검색",                                                   // "Search"
+    // Values
+    "SD 카드",                                                    // "SD Card"
+    "플래시카드",                                              // "Flashcard"
+    "롬 검색 시 키보드 사용",                          // "Use the keyboard to find roms"
+
+    /** Select menu **/
+    // Options
+    "ARM9 CPU 속도",                                          // "ARM9 CPU Speed"
+    "VRAM 부스트",                                               // "VRAM boost"
+    "ARM9 SCFG_EXT 고정",                                     // "Lock ARM9 SCFG_EXT"
+    "donor ROM으로 설정",                                           // "Set as donor ROM"
+    "LED 색상",                                           // "Set LED color"
+    // Values
+    "기본값",                                                    // "Default"
+
+    /** Sub-theme **/
+    "하위 테마 선택: DSi 메뉴",                             // "Sub-theme select: DSi Menu"
+    "하위 테마 선택: R4",                                     // "Sub-theme select: R4"
+    "하위 테마 선택: akMenu/Wood",                            // "Sub-theme select: Wood"
+
+    "하위 테마가 없습니다.",                       // "No sub-themes exist for this theme."
+
+    /** Settings others minor strings **/
+    "A/B: 저장 후 되돌아가기",                                      // "A/B: Save and Return"
+    "</>: 선택",                                          // "Left/Right: Pick"
+    "GUI 설정",                                           // "Settings: GUI"
+    "NTR/TWL-mode 설정",                                  // "Settings: NTR/TWL-mode"
 
 };
 

--- a/gui/source/languages/portuguese.h
+++ b/gui/source/languages/portuguese.h
@@ -4,167 +4,167 @@
 #include <3ds/types.h>
 
 // PORTUGUESE
-static const char *const lang_PT[STR_MAX] = {
+static const char* const lang_PT[STR_MAX] = {
 
-	/** GUI **/
-	": Voltar ao Menu HOME",									// "Return to HOME Menu"
-	"Abrir",													// "START" (used on cartridge indicator)
-	"Sem cartucho",												// "No cartridge"
-	"Cartucho desconhecido", 									// "Unknown Cartridge"
-	"Definições",												// "Settings"
-	"B： Voltar",													// "B: Back"
+    /** GUI **/
+    ": Voltar ao Menu HOME",                                    // "Return to HOME Menu"
+    "Abrir",                                                    // "START" (used on cartridge indicator)
+    "Sem cartucho",                                             // "No cartridge"
+    "Cartucho desconhecido",                                    // "Unknown Cartridge"
+    "Definições",                                             // "Settings"
+    "B： Voltar",                                                  // "B: Back"
 
-	/** Settings: GUI **/
-	"Língua",													// "Language"
-	"Tema",														// "Theme"
-	"Cor",														// "Color"
-	"Cor do menu",												// "Menu Color"
-	"Mostrar nome do ficheiro",									// "Show filename"
-	"Contador de jogos",										// "Game counter"
-	"Imagem da parte inferior personalizada",					// "Custom bottom image"
-	"Actualização automática: Bootstrap",						// "Auto-update bootstrap"
-	"Actualização automática: Último TWLoader",					// "Auto-update to latest TWLoader"
+    /** Settings: GUI **/
+    "Língua",                                                  // "Language"
+    "Tema",                                                     // "Theme"
+    "Cor",                                                      // "Color"
+    "Cor do menu",                                              // "Menu Color"
+    "Mostrar nome do ficheiro",                                 // "Show filename"
+    "Contador de jogos",                                        // "Game counter"
+    "Imagem da parte inferior personalizada",                   // "Custom bottom image"
+    "Actualização automática: Bootstrap",                        // "Auto-update bootstrap"
+    "Actualização automática: Último TWLoader",                 // "Auto-update to latest TWLoader"
 
-	/** Settings: NTR/TWL_mode **/
-	"Selectionar Flashcard(s)",									// "Flashcard(s) select"
-	"LED Arco-íris",											// "Rainbow LED"
-	"Velocidade do CPU ARM9",									// "ARM9 CPU Speed"
-	"Boost de VRAM",											// "VRAM boost"
-	"Ecrã de Boot DS/DSi",										// "DS/DSi Boot Screen"
-	"Mensagem de saúde e segurança",							// "Health and Safety message"
-	"Reiniciar Slot-1",											// "Reset Slot-1"
-	"Console output",											// "Console output"
-	"Bloquear ARM9 SCFG_EXT",									// "Lock ARM9 SCFG_EXT"
-	"Bootstrap",												// "Bootstrap"
+    /** Settings: NTR/TWL_mode **/
+    "Selectionar Flashcard(s)",                                 // "Flashcard(s) select"
+    "LED Arco-íris",                                           // "Rainbow LED"
+    "Velocidade do CPU ARM9",                                   // "ARM9 CPU Speed"
+    "Boost de VRAM",                                            // "VRAM boost"
+    "Ecrã de Boot DS/DSi",                                     // "DS/DSi Boot Screen"
+    "Mensagem de saúde e segurança",                          // "Health and Safety message"
+    "Reiniciar Slot-1",                                         // "Reset Slot-1"
+    "Console output",                                           // "Console output"
+    "Bloquear ARM9 SCFG_EXT",                                   // "Lock ARM9 SCFG_EXT"
+    "Bootstrap",                                                // "Bootstrap"
 
-	/** Settings: Top Screen **/
-	"X: Actualizar bootstrap (Versão oficial)",					// "X: Update bootstrap (Official release)"
-	"Y: Actualizar bootstrap (Versão não-oficial)",				// "Y: Update bootstrap (Unofficial release)"
-	"START: Actualizar TWLoader",								// "START: Update TWLoader"
+    /** Settings: Top Screen **/
+    "X: Actualizar bootstrap (Versão oficial)",                    // "X: Update bootstrap (Official release)"
+    "Y: Actualizar bootstrap (Versão não-oficial)",               // "Y: Update bootstrap (Unofficial release)"
+    "START: Actualizar TWLoader",                               // "START: Update TWLoader"
 
-	/** Settings: GUI values **/
+    /** Settings: GUI values **/
 
-	// Color
-	"Cinzento",													// "Gray"
-	"Castanho",													// "Brown"
-	"Vermelho",													// "Red"
-	"Cor-de-rosa",												// "Pink"
-	"Laranja",													// "Orange"
-	"Amarelo",													// "Yellow"
-	"Amarelo-Verde",											// "Yellow-Green"
-	"Verde 1",													// "Green 1"
-	"Verde 2",													// "Green 2"
-	"Verde claro",												// "Light green"
-	"Azul céu",													// "Sky blue"
-	"Azul claro",												// "Light blue"
-	"Azul",														// "Blue"
-	"Violeta",													// "Violet"
-	"Roxo",														// "Purple"
-	"Fuchsia",													// "Fuchsia"
-	"Vermelho e azul",											// "Red and blue"
-	"Verde and amarelo",										// "Green and yellow"
-	"Natal",													// "Christmas"
+    // Color
+    "Cinzento",                                                 // "Gray"
+    "Castanho",                                                 // "Brown"
+    "Vermelho",                                                 // "Red"
+    "Cor-de-rosa",                                              // "Pink"
+    "Laranja",                                                  // "Orange"
+    "Amarelo",                                                  // "Yellow"
+    "Amarelo-Verde",                                            // "Yellow-Green"
+    "Verde 1",                                                  // "Green 1"
+    "Verde 2",                                                  // "Green 2"
+    "Verde claro",                                              // "Light green"
+    "Azul céu",                                                    // "Sky blue"
+    "Azul claro",                                               // "Light blue"
+    "Azul",                                                     // "Blue"
+    "Violeta",                                                  // "Violet"
+    "Roxo",                                                     // "Purple"
+    "Fuchsia",                                                  // "Fuchsia"
+    "Vermelho e azul",                                          // "Red and blue"
+    "Verde and amarelo",                                        // "Green and yellow"
+    "Natal",                                                    // "Christmas"
 
-	// Menu Color
-	"Branco",													// "White"
-	"Preto",													// "Black"
+    // Menu Color
+    "Branco",                                                   // "White"
+    "Preto",                                                    // "Black"
 
-	/** Settings: GUI descriptions **/
-	"A língua a utilisar para a interface,",					// "The language to use for the UI,"
-	"incluindo o texto da imagem do jogo.",						// "including game banner text."
+    /** Settings: GUI descriptions **/
+    "A língua a utilisar para a interface,",                   // "The language to use for the UI,"
+    "incluindo o texto da imagem do jogo.",                     // "including game banner text."
 
-	"O tema a utilisar no TWLoader.",							// "The theme to use in TWLoader."
-	"Carregue em A para sub-temas.",							// "Press A for sub-themes."
+    "O tema a utilisar no TWLoader.",                           // "The theme to use in TWLoader."
+    "Carregue em A para sub-temas.",                            // "Press A for sub-themes."
 
-	"A cor de fundo do topo,",									// "The color of the top background,"
-	"a borda de START, e os pontos circulares.",				// "the START border, and the circling dots."
+    "A cor de fundo do topo,",                                  // "The color of the top background,"
+    "a borda de START, e os pontos circulares.",                // "the START border, and the circling dots."
 
-	"A cor da borda do topo,",									// "The color of the top border,"
-	"e o fundo da parte inferior.",								// "and the bottom background."
+    "A cor da borda do topo,",                                  // "The color of the top border,"
+    "e o fundo da parte inferior.",                             // "and the bottom background."
 
-	"Mostrar o nome do ficheiro do jogo no",					// "Shows game filename at the top of the bubble."
-	"topo da bolha.",											// (empty)
+    "Mostrar o nome do ficheiro do jogo no",                    // "Shows game filename at the top of the bubble."
+    "topo da bolha.",                                           // (empty)
 
-	"O número de jogos selectionados e listados",				// "A number of selected game and listed games"
-	"aparece por baixo da bolha de texto.",						// "is shown below the text bubble."
+    "O número de jogos selectionados e listados",              // "A number of selected game and listed games"
+    "aparece por baixo da bolha de texto.",                     // "is shown below the text bubble."
 
-	"Carrega uma imagem personalizada para",					// "Loads a custom bottom screen image"
-	"a parte inferior do menu do jogo.",						// "for the game menu."
+    "Carrega uma imagem personalizada para",                    // "Loads a custom bottom screen image"
+    "a parte inferior do menu do jogo.",                        // "for the game menu."
 
-	"Actualizar automáticamente o nds-bootstrap",				// "Auto-update nds-bootstrap at launch."
-	"durante o lançamento da aplicação.",						// (empty)
+    "Actualizar automáticamente o nds-bootstrap",              // "Auto-update nds-bootstrap at launch."
+    "durante o lançamento da aplicação.",                        // (empty)
 
-	"Download automático da versão mais recente",				// "Auto-download the CIA of the latest"
-	"do TWLoader durante o lançamento.",						// "TWLoader version at launch."
+    "Download automático da versão mais recente",             // "Auto-download the CIA of the latest"
+    "do TWLoader durante o lançamento.",                       // "TWLoader version at launch."
 
-	/** Settings: NTR/TWL_mode descriptions **/
-	"Escolha uma flashcard para iniciar",						// "Pick a flashcard to use to"
-	"ROMs.",													// "run ROMs from it."
+    /** Settings: NTR/TWL_mode descriptions **/
+    "Escolha uma flashcard para iniciar",                       // "Pick a flashcard to use to"
+    "ROMs.",                                                    // "run ROMs from it."
 
-	"Ver as cores do arco-íris brilhar",						// "See rainbow colors glowing in"
-	"como LED de notificação.",									// "the Notification LED."
+    "Ver as cores do arco-íris brilhar",                       // "See rainbow colors glowing in"
+    "como LED de notificação.",                                   // "the Notification LED."
 
-	"Selecionar como TWL para eliminar o",						// "Set to TWL to get rid of lags in some games."
-	"lag em certos jogos.",										// (empty)
+    "Selecionar como TWL para eliminar o",                      // "Set to TWL to get rid of lags in some games."
+    "lag em certos jogos.",                                     // (empty)
 
-	"Permite escritura de 8 bit VRAM",							// "Allows 8 bit VRAM writes"
-	"e expande o bus para 32 bit.",								// "and expands the bus to 32 bit."
+    "Permite escritura de 8 bit VRAM",                          // "Allows 8 bit VRAM writes"
+    "e expande o bus para 32 bit.",                             // "and expands the bus to 32 bit."
 
-	"Mostrar a animação de boot de DS/DSi",						// "Displays the DS/DSi boot animation"
-	"antes do lançamento do jogo.",								// "before launched game."
+    "Mostrar a animação de boot de DS/DSi",                       // "Displays the DS/DSi boot animation"
+    "antes do lançamento do jogo.",                                // "before launched game."
 
-	"Mostrar a mensagem de saúde e segurança",					// "Displays the Health and Safety"
-	"no ecrã inferior.",										// "message on the bottom screen."
+    "Mostrar a mensagem de saúde e segurança",                    // "Displays the Health and Safety"
+    "no ecrã inferior.",                                       // "message on the bottom screen."
 
-	"Activar isto se os cartuchos no Slot-1 estão",				// "Enable this if Slot-1 carts are stuck"
-	"bloqueados em ecrãs brancos.",								// "on white screens."
+    "Activar isto se os cartuchos no Slot-1 estão",                // "Enable this if Slot-1 carts are stuck"
+    "bloqueados em ecrãs brancos.",                                // "on white screens."
 
-	"Mostra algum texto antes do lançamento do jogo.",			// "Displays some text before launched game."
-	"",															// (empty)
+    "Mostra algum texto antes do lançamento do jogo.",         // "Displays some text before launched game."
+    "",                                                         // (empty)
 
-	"Bloquear o ARM9 SCFG_EXT, para evitar",					// "Locks the ARM9 SCFG_EXT,"
-	"conflitos com libnds recentes.",							// "avoiding conflict with recent libnds."
+    "Bloquear o ARM9 SCFG_EXT, para evitar",                    // "Locks the ARM9 SCFG_EXT,"
+    "conflitos com libnds recentes.",                           // "avoiding conflict with recent libnds."
 
-	"Mudar entre bootstrap oficial ou",							// "Change between release and"
-	"não-oficial.",												// "unofficial bootstrap file."
+    "Mudar entre bootstrap oficial ou",                         // "Change between release and"
+    "não-oficial.",                                                // "unofficial bootstrap file."
 
-	/** Start menu **/
-	// Options
-	"Localização do jogo",										// "Game location"
-	"Capa do jogo: On",											// "Box Art: On"
-	"Capa do jogo: Off",											// "Box Art: OFF"
-	"Iniciar GBARunner2",										// "Start GBARunner2"
-	"Borda do topo: Off",										// "Top border: On"
-	"Borda do topo: On",										// "Top border: Off"
-	"Desactivar ROM donor",											// "Unset donor rom"
-	"Procurar",													// "Search"
-	// Values
-	"Carta SD",													// "SD Card"
-	"Flashcard",												// "Flashcard"
-	"Utilisar teclado para encontrar roms",						// "Use the keyboard to find roms"
+    /** Start menu **/
+    // Options
+    "Localização do jogo",                                        // "Game location"
+    "Capa do jogo: On",                                         // "Box Art: On"
+    "Capa do jogo: Off",                                            // "Box Art: OFF"
+    "Iniciar GBARunner2",                                       // "Start GBARunner2"
+    "Borda do topo: Off",                                       // "Top border: On"
+    "Borda do topo: On",                                        // "Top border: Off"
+    "Desactivar ROM donor",                                         // "Unset donor rom"
+    "Procurar",                                                 // "Search"
+    // Values
+    "Carta SD",                                                 // "SD Card"
+    "Flashcard",                                                // "Flashcard"
+    "Utilisar teclado para encontrar roms",                     // "Use the keyboard to find roms"
 
-	/** Select menu **/
-	// Options
-	"Velocidade do CPU ARM9",									// "ARM9 CPU Speed"
-	"Boost VRAM",												// "VRAM boost"
-	"Bloquear ARM9 SCFG_EXT",									// "Lock ARM9 SCFG_EXT"
-	"Definir como ROM donor",											// "Set as donor ROM"
-	"Definir a cor do LED",										// "Set LED color"
-	// Values
-	"Valores padrão",											// "Default"
+    /** Select menu **/
+    // Options
+    "Velocidade do CPU ARM9",                                   // "ARM9 CPU Speed"
+    "Boost VRAM",                                               // "VRAM boost"
+    "Bloquear ARM9 SCFG_EXT",                                   // "Lock ARM9 SCFG_EXT"
+    "Definir como ROM donor",                                           // "Set as donor ROM"
+    "Definir a cor do LED",                                     // "Set LED color"
+    // Values
+    "Valores padrão",                                          // "Default"
 
-	/** Sub-theme **/
-	"Selecionar Sub-tema: Menu DSi",							// "Sub-theme select: DSi Menu"
-	"Selecionar Sub-tema: R4",									// "Sub-theme select: R4"
-	"Selecionar Sub-tema: akMenu/Madeira",						// "Sub-theme select: Wood"
+    /** Sub-theme **/
+    "Selecionar Sub-tema: Menu DSi",                            // "Sub-theme select: DSi Menu"
+    "Selecionar Sub-tema: R4",                                  // "Sub-theme select: R4"
+    "Selecionar Sub-tema: akMenu/Madeira",                      // "Sub-theme select: Wood"
 
-	"Não existem sub-temas para este tema.",					// "No sub-themes exist for this theme."
+    "Não existem sub-temas para este tema.",                   // "No sub-themes exist for this theme."
 
-	/** Settings others minor strings **/
-	"A/B: Guardar e Voltar",									// "A/B: Save and Return"
-	"Esquerda/Direita: Escolher",								// "Left/Right: Pick"
-	"Definições: GUI",											// "Settings: GUI"
-	"Definições: Modo NTR/TWL",									// "Settings: NTR/TWL-mode"
+    /** Settings others minor strings **/
+    "A/B: Guardar e Voltar",                                    // "A/B: Save and Return"
+    "Esquerda/Direita: Escolher",                               // "Left/Right: Pick"
+    "Definições: GUI",                                            // "Settings: GUI"
+    "Definições: Modo NTR/TWL",                                   // "Settings: NTR/TWL-mode"
 
 };
 

--- a/gui/source/languages/russian.h
+++ b/gui/source/languages/russian.h
@@ -4,167 +4,167 @@
 #include <3ds/types.h>
 
 // RUSSIAN
-static const char *const lang_RU[STR_MAX] = {
+static const char* const lang_RU[STR_MAX] = {
 
-	/** GUI **/
-  ": Вернуться в меню HOME",									// "Return to HOME Menu"
-	"START",													// "START" (used on cartridge indicator)
-	"Отсутствует Картридж",												// "No cartridge"
-	"Неизвестный Картридж",											// "Unknown Cartridge"
-	"Настройки",											// "Settings"
-	"B: Назад",												// "B: Back"
+    /** GUI **/
+    ": Вернуться в меню HOME",                                  // "Return to HOME Menu"
+    "START",                                                    // "START" (used on cartridge indicator)
+    "Отсутствует Картридж",                                              // "No cartridge"
+    "Неизвестный Картридж",                                          // "Unknown Cartridge"
+    "Настройки",                                           // "Settings"
+    "B: Назад",                                                // "B: Back"
 
-	/** Settings: GUI **/
-	"Язык",													// "Language"
-	"Оформление",													// "Theme"
-	"Цвет",													// "Color"
-	"Цвет меню",												// "Menu Color"
-	"Показать имя файла",										// "Show filename"
-	"Игровой счетчик",												// "Game counter"
-	"Пользовательское изображение снизу",							// "Custom bottom image"
-	"Автоматическое обновление: bootsrap",							// "Auto-update bootstrap"
-	"Автоматическое обновление: TWLoader",								// "Auto-update to latest TWLoader"
+    /** Settings: GUI **/
+    "Язык",                                                 // "Language"
+    "Оформление",                                                 // "Theme"
+    "Цвет",                                                 // "Color"
+    "Цвет меню",                                                // "Menu Color"
+    "Показать имя файла",                                       // "Show filename"
+    "Игровой счетчик",                                                // "Game counter"
+    "Пользовательское изображение снизу",                           // "Custom bottom image"
+    "Автоматическое обновление: bootsrap",                          // "Auto-update bootstrap"
+    "Автоматическое обновление: TWLoader",                              // "Auto-update to latest TWLoader"
 
-	/** Settings: NTR/TWL_mode **/
-	"Выбор флешкарты",									// "Flashcard(s) select"
-	"Радуга LED",											// "Rainbow LED"
-	"ARM9 CPU скорость",									// "ARM9 CPU Speed"
-	"VRAM ускорение",										// "VRAM boost"
-	"DS/DSi стартовый экран",									// "DS/DSi Boot Screen"
-	"Сообщение о здоровье и безопасности",				// "Health and Safety message"
-	"Перезагрузить Slot-1",										// "Reset Slot-1"
-	"Вывод консоли",											// "Console output"
-	"Заблокировать ARM9 SCFG_EXT",								// "Lock ARM9 SCFG_EXT"
-	"Bootstrap",												// "Bootstrap"
+    /** Settings: NTR/TWL_mode **/
+    "Выбор флешкарты",                                    // "Flashcard(s) select"
+    "Радуга LED",                                         // "Rainbow LED"
+    "ARM9 CPU скорость",                                    // "ARM9 CPU Speed"
+    "VRAM ускорение",                                      // "VRAM boost"
+    "DS/DSi стартовый экран",                                 // "DS/DSi Boot Screen"
+    "Сообщение о здоровье и безопасности",               // "Health and Safety message"
+    "Перезагрузить Slot-1",                                        // "Reset Slot-1"
+    "Вывод консоли",                                            // "Console output"
+    "Заблокировать ARM9 SCFG_EXT",                             // "Lock ARM9 SCFG_EXT"
+    "Bootstrap",                                                // "Bootstrap"
 
-	/** Settings: Top Screen **/
-	"X: Обновить Bootstrap (Оффициальная версия)",				// "X: Update bootstrap (Official release)"
-	"Y: Обновить Bootstrap (Неоффициальная версия)",				// "Y: Update bootstrap (Unofficial release)"
-  "START: Обновить TWLoader",							// "START: Update TWLoader"
+    /** Settings: Top Screen **/
+    "X: Обновить Bootstrap (Оффициальная версия)",                // "X: Update bootstrap (Official release)"
+    "Y: Обновить Bootstrap (Неоффициальная версия)",                // "Y: Update bootstrap (Unofficial release)"
+    "START: Обновить TWLoader",                           // "START: Update TWLoader"
 
-	/** Settings: GUI values **/
+    /** Settings: GUI values **/
 
-	// Color
-	"Серый",														// "Gray"
-	"Коричневый",													// "Brown"
-	"Красный",														// "Red"
-	"Розовый",												 		// "Pink"
-	"Оранжевый",													// "Orange"
-	"Желтый",														// "Yellow"
-	"Желто-Зеленый",												// "Yellow-Green"
-	"Зеленый 1",													// "Green 1"
-	"Зеленый 2",													// "Green 2"
-	"Светло зеленый",													// "Light green"
-	"Небесно голубой",												// "Sky blue"
-	"Голубой",													// "Light blue"
-	"Синий",														// "Blue"
-	"Фиолетовый",													// "Violet"
-	"Пурпурный",														// "Purple"
-	"Фуксия",													// "Fuchsia"
-	"Красный и синий",												// "Red and blue"
-	"Зеленый и желтый",											// "Green and yellow"
-	"Рождество",												// "Christmas"
+    // Color
+    "Серый",                                                       // "Gray"
+    "Коричневый",                                                 // "Brown"
+    "Красный",                                                       // "Red"
+    "Розовый",                                                       // "Pink"
+    "Оранжевый",                                                   // "Orange"
+    "Желтый",                                                     // "Yellow"
+    "Желто-Зеленый",                                                // "Yellow-Green"
+    "Зеленый 1",                                                 // "Green 1"
+    "Зеленый 2",                                                 // "Green 2"
+    "Светло зеленый",                                                  // "Light green"
+    "Небесно голубой",                                                // "Sky blue"
+    "Голубой",                                                   // "Light blue"
+    "Синий",                                                       // "Blue"
+    "Фиолетовый",                                                 // "Violet"
+    "Пурпурный",                                                       // "Purple"
+    "Фуксия",                                                 // "Fuchsia"
+    "Красный и синий",                                             // "Red and blue"
+    "Зеленый и желтый",                                           // "Green and yellow"
+    "Рождество",                                               // "Christmas"
 
-	// Menu Color
-	"Белый",														// "White"
-	"Черный",													// "Black"
+    // Menu Color
+    "Белый",                                                       // "White"
+    "Черный",                                                 // "Black"
 
-	/** Settings: GUI descriptions **/
-	"Язый интерфейса,",						// "The language to use for the UI,"
-	"включая игровой баннер.",										// "including game banner text."
+    /** Settings: GUI descriptions **/
+    "Язый интерфейса,",                       // "The language to use for the UI,"
+    "включая игровой баннер.",                                      // "including game banner text."
 
-	"Оформление для TWLoader.",						// "The theme to use in TWLoader."
-	"Нажмите A для под-тем оформления.",								// "Press A for sub-themes."
+    "Оформление для TWLoader.",                        // "The theme to use in TWLoader."
+    "Нажмите A для под-тем оформления.",                              // "Press A for sub-themes."
 
-	"Цвет заливки сверху,",						// "The color of the top background,"
-	"границ START и круглых точек.",			// "the START border, and the circling dots."
+    "Цвет заливки сверху,",                        // "The color of the top background,"
+    "границ START и круглых точек.",         // "the START border, and the circling dots."
 
-	"Цвет верхней границы",								// "The color of the top border,"
-	"и заливки снизу.",							// "and the bottom background."
+    "Цвет верхней границы",                               // "The color of the top border,"
+    "и заливки снизу.",                            // "and the bottom background."
 
-	"Показать имя файла в пузыре сверху.",		// "Shows game filename at the top of the bubble."
-	"",															// (empty)
+    "Показать имя файла в пузыре сверху.",     // "Shows game filename at the top of the bubble."
+    "",                                                         // (empty)
 
-	"Номер выбранной игры, общее количество игр",				// "A number of selected game and listed games"
-	"показаны ниже пузыря с текстом.",	// "is shown below the text bubble."
+    "Номер выбранной игры, общее количество игр",               // "A number of selected game and listed games"
+    "показаны ниже пузыря с текстом.",    // "is shown below the text bubble."
 
-	"Загрузить собственное изображение для низа",			// "Loads a custom bottom screen image"
-	"игрового меню.",								// "for the game menu."
+    "Загрузить собственное изображение для низа",         // "Loads a custom bottom screen image"
+    "игрового меню.",                               // "for the game menu."
 
-	"Автоматическое обновление nds-bootstrap при старте.",			// "Auto-update nds-bootstrap at launch."
-	"",															// (empty)
+    "Автоматическое обновление nds-bootstrap при старте.",         // "Auto-update nds-bootstrap at launch."
+    "",                                                         // (empty)
 
-	"Автоматическая загрузка последнего CIA файла",					// "Auto-download the CIA of the latest"
-	"TWLoader при запуске.",								// "TWLoader version at launch."
+    "Автоматическая загрузка последнего CIA файла",                    // "Auto-download the CIA of the latest"
+    "TWLoader при запуске.",                              // "TWLoader version at launch."
 
-	/** Settings: NTR/TWL_mode descriptions **/
-	"Выберите флешкарту для",							// "Pick a flashcard to use to"
-	"запуска ROM-ов с нее.",						// "run ROMs from it."
+    /** Settings: NTR/TWL_mode descriptions **/
+    "Выберите флешкарту для",                           // "Pick a flashcard to use to"
+    "запуска ROM-ов с нее.",                       // "run ROMs from it."
 
-	"Показывать смену цветов радуги",							// "See rainbow colors glowing in"
-	"на LED для уведомлений.",								// "the Notification LED."
+    "Показывать смену цветов радуги",                            // "See rainbow colors glowing in"
+    "на LED для уведомлений.",                              // "the Notification LED."
 
-	"Установить TWL, чтобы убрать лаги в",						// "Set to TWL to get rid of lags in some games."
-	"некоторых играх.",									// (empty)
+    "Установить TWL, чтобы убрать лаги в",                        // "Set to TWL to get rid of lags in some games."
+    "некоторых играх.",                                   // (empty)
 
-	"Позволяет делать 8 битные записи VRAM",						// "Allows 8 bit VRAM writes"
-	"и расширяет шину до 32 бит.",						// "and expands the bus to 32 bit."
+    "Позволяет делать 8 битные записи VRAM",                     // "Allows 8 bit VRAM writes"
+    "и расширяет шину до 32 бит.",                       // "and expands the bus to 32 bit."
 
-	"Показывать DS/DSi стартовую анимацию",							// "Displays the DS/DSi boot animation"
-	"перед запуском игр.",									// "before launched game."
+    "Показывать DS/DSi стартовую анимацию",                          // "Displays the DS/DSi boot animation"
+    "перед запуском игр.",                                  // "before launched game."
 
-	"Показывать предупреждение о здоровье и",					// "Displays the Health and Safety"
-	"безопасности снизу экрана.",					// "message on the bottom screen."
+    "Показывать предупреждение о здоровье и",                 // "Displays the Health and Safety"
+    "безопасности снизу экрана.",                    // "message on the bottom screen."
 
-	"Активируйте это если Slot-1 карта",						// "Enable this if Slot-1 carts are stuck"
-	"застревает на белом экране.",					// "on white screens."
+    "Активируйте это если Slot-1 карта",                     // "Enable this if Slot-1 carts are stuck"
+    "застревает на белом экране.",                   // "on white screens."
 
-	"Показывает текст перед запуском игры.",					// "Displays some text before launched game."
-	"",															// (empty)
+    "Показывает текст перед запуском игры.",                    // "Displays some text before launched game."
+    "",                                                         // (empty)
 
-	"Блокировака ARM9 SCFG_EXT позволяет избегать",							// "Locks the ARM9 SCFG_EXT,"
-	"конфликтов с последними сборками libnds.",					// "avoiding conflict with recent libnds."
+    "Блокировака ARM9 SCFG_EXT позволяет избегать",                         // "Locks the ARM9 SCFG_EXT,"
+    "конфликтов с последними сборками libnds.",                    // "avoiding conflict with recent libnds."
 
-	"Использовать стабильный или неоффициальный",							// "Change between release and"
-	"Bootstrap файл или наоборот",						// "unofficial bootstrap file."
+    "Использовать стабильный или неоффициальный",                            // "Change between release and"
+    "Bootstrap файл или наоборот",                       // "unofficial bootstrap file."
 
-	/** Start menu **/
-	// Options
-	"Расположение игр",													// "Game location"
-	"Box-Art: Включить",												// "Box Art: On"
-	"Box-Art: Выключить",												// "Box Art: OFF"
-	"Запустить GBARunner2",										// "Start GBARunner2"
-	"Верхняя граница: Включить",											// "Top border: On"
-	"Верхняя граница: Выключить",											// "Top border: Off"
-	"Отключить донорский ROM",										// "Unset donor rom"
-	"Поиск",													// "Search"
-	// Values
-	"SD карта",													// "SD Card"
-	"Флешкарта",												// "Flashcard"
-	"Используйте клавиатуру для поиска ROM-ов",					// "Use the keyboard to find roms"
+    /** Start menu **/
+    // Options
+    "Расположение игр",                                                  // "Game location"
+    "Box-Art: Включить",                                                // "Box Art: On"
+    "Box-Art: Выключить",                                              // "Box Art: OFF"
+    "Запустить GBARunner2",                                        // "Start GBARunner2"
+    "Верхняя граница: Включить",                                          // "Top border: On"
+    "Верхняя граница: Выключить",                                            // "Top border: Off"
+    "Отключить донорский ROM",                                        // "Unset donor rom"
+    "Поиск",                                                   // "Search"
+    // Values
+    "SD карта",                                                    // "SD Card"
+    "Флешкарта",                                               // "Flashcard"
+    "Используйте клавиатуру для поиска ROM-ов",                 // "Use the keyboard to find roms"
 
-	/** Select menu **/
-	// Options
-	"Скорость ARM9 CPU",									// "ARM9 CPU Speed"
-	"VRAM ускорение",										// "VRAM boost"
-	"Блокировка ARM9 SCFG_EXT",								// "Lock ARM9 SCFG_EXT"
-	"Выбрать донорский ROM",									// "Set as donor ROM"
-	"Выбрать цвет LED",											// "Set LED color"
-	// Values
-	"По умолчанию",													// "Default"
+    /** Select menu **/
+    // Options
+    "Скорость ARM9 CPU",                                    // "ARM9 CPU Speed"
+    "VRAM ускорение",                                      // "VRAM boost"
+    "Блокировка ARM9 SCFG_EXT",                               // "Lock ARM9 SCFG_EXT"
+    "Выбрать донорский ROM",                                    // "Set as donor ROM"
+    "Выбрать цвет LED",                                          // "Set LED color"
+    // Values
+    "По умолчанию",                                                  // "Default"
 
-	/** Sub-theme **/
-	"Выбрать доп-оформление: Меню DSi",								// "Sub-theme select: DSi Menu"
-	"Выбрать доп-оформление: R4",									// "Sub-theme select: R4"
-	"Выбрать доп-оформление: Дерево",									// "Sub-theme select: Wood"
+    /** Sub-theme **/
+    "Выбрать доп-оформление: Меню DSi",                             // "Sub-theme select: DSi Menu"
+    "Выбрать доп-оформление: R4",                                   // "Sub-theme select: R4"
+    "Выбрать доп-оформление: Дерево",                                 // "Sub-theme select: Wood"
 
-	"Отсутствует доп-оформление для данной темы оформления.",			// "No sub-themes exist for this theme."
+    "Отсутствует доп-оформление для данной темы оформления.",            // "No sub-themes exist for this theme."
 
-	/** Settings others minor strings **/
-	"A/B: Сохранить и вернуться",								// "A/B: Save and Return"
-	"Влево/Вправо: Выбрать",									// "Left/Right: Pick"
-	"Настройки: GUI",										// "Settings: GUI"
-	"Настройки: NTR/TWL-mode",								// "Settings: NTR/TWL-mode"
+    /** Settings others minor strings **/
+    "A/B: Сохранить и вернуться",                                // "A/B: Save and Return"
+    "Влево/Вправо: Выбрать",                                  // "Left/Right: Pick"
+    "Настройки: GUI",                                      // "Settings: GUI"
+    "Настройки: NTR/TWL-mode",                             // "Settings: NTR/TWL-mode"
 
 };
 

--- a/gui/source/languages/spanish.h
+++ b/gui/source/languages/spanish.h
@@ -4,167 +4,167 @@
 #include <3ds/types.h>
 
 // SPANISH
-static const char *const lang_ES[STR_MAX] = {
-	
-	/** GUI **/
-    ": Volver al menú HOME",									// "Return to HOME Menu"
-	"INICIO",													// "START" (used on cartridge indicator)tor)
-	"Sin cartucho",												// "No cartridge"
-	"Cartucho desconocido", 									// "Unknown Cartridge"
-	"Ajustes",													// "Settings"
-	"B: Volver",												// "B: Back"	
-	
-	/** Settings: GUI **/
-	"Idioma",													// "Language"
-	"Tema",														// "Theme"
-	"Color",													// "Color"
-	"Color del menú",											// "Menu Color"
-	"Mostrar nombre del archivo",								// "Show filename"
-	"Contador de juegos",										// "Game counter"
-	"Usar imagen personalizada",								// "Custom bottom image"
-	"Auto actualizar bootstrap",								// "Auto-update bootstrap"
-	"Auto actualizar TWLoader",									// "Auto-update to latest TWLoader"
-	
-	/** Settings: NTR/TWL_mode **/
-	"Seleccionar flashcard",									// "Flashcard(s) select"
-	"LED arcoiris",												// "Rainbow LED"
-	"Velocidad del CPU ARM9",									// "ARM9 CPU Speed"
-	"Aumentar VRAM",											// "VRAM boost"
-	"Pantalla de arranque DS/DSi",								// "DS/DSi Boot Screen"
-	"Mensaje de Salud y Seguridad",								// "Health and Safety message"
-	"Reiniciar el Slot-1",										// "Reset Slot-1"
-	"Salida de consola",										// "Console output"
-	"Bloquear el SCFG_EXT del ARM9",							// "Lock ARM9 SCFG_EXT"
-	"Bootstrap",												// "Bootstrap"
-	
-	/** Settings: Top Screen **/
-	"X: Actualizar bootstrap (Versión estable)",				// "X: Update bootstrap (Official release)"
-	"Y: Actualizar bootstrap (Versión inestable)",				// "Y: Update bootstrap (Unofficial release)"
-	"START: Actualizar TWLoader",								// "START: Update TWLoader"
-	
-	/** Settings: GUI values **/
-	
-	// Color
-	"Gris",														// "Gray"
-	"Marrón",													// "Brown"
-	"Rojo",														// "Red"
-	"Rosa",												 		// "Pink"
-	"Naranja",													// "Orange"
-	"Amarillo",													// "Yellow"
-	"Amarrilo verde",											// "Yellow-Green"
-	"Verde 1",													// "Green 1"
-	"Verde 2",													// "Green 2"
-	"Verde claro",												// "Light green"
-	"Azul cielo",												// "Sky blue"
-	"Azul claro",												// "Light blue"
-	"Azul",														// "Blue"
-	"Violeta",													// "Violet"
-	"Púrpura",													// "Purple"
-	"Fucsia",													// "Fuchsia"
-	"Rojo y azul",												// "Red and blue"
-	"Verde y amarillo",											// "Green and yellow"
-	"Navidad",													// "Christmas"
+static const char* const lang_ES[STR_MAX] = {
 
-	// Menu Color
-	"Blanco",													// "White"
-	"Negro",													// "Black"
+    /** GUI **/
+    ": Volver al menú HOME",                                   // "Return to HOME Menu"
+    "INICIO",                                                   // "START" (used on cartridge indicator)tor)
+    "Sin cartucho",                                             // "No cartridge"
+    "Cartucho desconocido",                                     // "Unknown Cartridge"
+    "Ajustes",                                                  // "Settings"
+    "B: Volver",                                                // "B: Back"
 
-	/** Settings: GUI descriptions **/
-	"El idioma para usar en TWLoader.",							// "The language to use for the UI,"
-	"(también afecta al banner de las roms)",					// "including game banner text."
-	
-	"El tema para TWLoader.",									// "The theme to use in TWLoader."
-	"Pulsa A para elegir un sub tema.",							// "Press A for sub-themes."
-	
-	"El color del fondo de la pantalla superior, el marco",		// "The color of the top background,"
-	"de selección de ROMs y el círculo de puntos.",				// "the START border, and the circling dots."
-	
-	"Color del marco superior,",								// "The color of the top border,"
-	"y del fondo de la pantalla inferior.",						// "and the bottom background."
-	
-	"Muestra el nombre del archivo en la parte ", 				// "Shows game filename at the top of the bubble."
-	"superior de la burbuja de información",					// (empty)
-	
-	"Muestra el número de la ROM selecionada y el",				// "A number of selected game and listed games"
-	"total debajo de la burbuja de información.",				// "is shown below the text bubble."
-	
-	"Carga una imagen personalizada para",						// "Loads a custom bottom screen image"
-	"la pantalla inferior.",									// "for the game menu."
-	
-	"Auto actualizar bootstrap durante el arranque.",			// "Auto-update nds-bootstrap at launch."
-	"",															// (empty) 
-	
-	"Auto actualizar e installar los CIAS de TWLoader",			// "Auto-download the CIA of the latest"
-	"durante el arranque.",										// "TWLoader version at launch."
-	
-	/** Settings: NTR/TWL_mode descriptions **/
-	"Elije una flashcard para cargar",							// "Pick a flashcard to use to"
-	"ROMs desde ella.",											// "run ROMs from it."
-	
-	"Mostrar un efecto arcoiris de colores",					// "See rainbow colors glowing in"
-	"en el LED de notificaciones.",								// "the Notification LED."
-	
-	"Selecciona el modo TWL para eliminar ",					// "Set to TWL to get rid of lags in some games."
-	"el lag en algunas ROMs.",									// (empty) 
+    /** Settings: GUI **/
+    "Idioma",                                                   // "Language"
+    "Tema",                                                     // "Theme"
+    "Color",                                                    // "Color"
+    "Color del menú",                                          // "Menu Color"
+    "Mostrar nombre del archivo",                               // "Show filename"
+    "Contador de juegos",                                       // "Game counter"
+    "Usar imagen personalizada",                                // "Custom bottom image"
+    "Auto actualizar bootstrap",                                // "Auto-update bootstrap"
+    "Auto actualizar TWLoader",                                 // "Auto-update to latest TWLoader"
 
-	"Permite escribir en la VRAM 8 bit",						// "Allows 8 bit VRAM writes"
-	"y expandir el bus de datos a 32 bits.",					// "and expands the bus to 32 bit."
-	
-	"Muestra la animación de arranque de la DS/DSi",			// "Displays the DS/DSi boot animation"
-	"antes de ejecutar la ROM.",								// "before launched game."
-	
-	"Muestra el mensaje de Salud y Seguridad",					// "Displays the Health and Safety"
-	"en la pantalla inferior.",									// "message on the bottom screen."
-	
-	"Activa esta opción para reiniciar el Slot-1",				// "Enable this if Slot-1 carts are stuck"
-	"si el cartucho se queda con pantallas blancas.",			// "on white screens."
-	
-	"Muestra información de depuración",						// "Displays some text before launched game."
-	"antes de lanzar la ROM.",									// (empty) 
+    /** Settings: NTR/TWL_mode **/
+    "Seleccionar flashcard",                                    // "Flashcard(s) select"
+    "LED arcoiris",                                             // "Rainbow LED"
+    "Velocidad del CPU ARM9",                                   // "ARM9 CPU Speed"
+    "Aumentar VRAM",                                            // "VRAM boost"
+    "Pantalla de arranque DS/DSi",                              // "DS/DSi Boot Screen"
+    "Mensaje de Salud y Seguridad",                             // "Health and Safety message"
+    "Reiniciar el Slot-1",                                      // "Reset Slot-1"
+    "Salida de consola",                                        // "Console output"
+    "Bloquear el SCFG_EXT del ARM9",                            // "Lock ARM9 SCFG_EXT"
+    "Bootstrap",                                                // "Bootstrap"
 
-	"Bloquea el SCFG_EXT del ARM9, evitando",					// "Locks the ARM9 SCFG_EXT,"
-	"conflictos con las librerias libnds más recientes.",		// "avoiding conflict with recent libnds."
-	
-	"Cambia entre la version 'Release' (estable) ",				// "Change between release and"
-	"y la 'Unofficial' (inestable).",							// "unofficial bootstrap file."
+    /** Settings: Top Screen **/
+    "X: Actualizar bootstrap (Versión estable)",               // "X: Update bootstrap (Official release)"
+    "Y: Actualizar bootstrap (Versión inestable)",             // "Y: Update bootstrap (Unofficial release)"
+    "START: Actualizar TWLoader",                               // "START: Update TWLoader"
 
-	/** Start menu **/
-	// Options
-	"Localización:",											// "Game location"
-	"Carátulas: On",											// "Box Art: On"
-	"Carátulas: Off",											// "Box Art: OFF"
-	"Iniciar GBARunner2",										// "Start GBARunner2"
-	"Borde superior: On",										// "Top border: On"
-	"Borde superior: Off",										// "Top border: Off"
-	"Eliminar donor",											// "Unset donor rom"
-	"Buscar",													// "Search"
-	// Values
-	"Tarjeta SD",												// "SD Card"
-	"Flashcard",												// "Flashcard"
-	"Usa el teclado para buscar ROMs",							// "Use the keyboard to find roms"
-	
-	/** Select menu **/
-	// Options
-	"Velocidad CPU ARM9:",										// "ARM9 CPU Speed"
-	"Aumento VRAM:",											// "VRAM boost"
-	"Bloq. SCFG_EXT ARM9:",										// "Lock ARM9 SCFG_EXT"
-	"Elegir como donor",										// "Set as donor ROM"
-	"Elegir color del LED",										// "Set LED color"
-	// Values
-	"Por defecto",												// "Default"
-	
-	/** Sub-theme **/
-	"Sub tema seleccionado: Menu DSi",							// "Sub-theme select: DSi Menu"
-	"Sub tema seleccionado: R4",								// "Sub-theme select: R4"
-	"Sub tema seleccionado: akMenu/Wood",						// "Sub-theme select: Wood"
-	
-	"No hay sub temas para este tema.",							// "No sub-themes exist for this theme."
-	
-	/** Settings others minor strings **/
-	"A/B: Guardar y volver",									// "A/B: Save and Return"
-	"Izquierda/Derecha: Seleccionar",							// "Left/Right: Pick"
-	"Ajustes: GUI",												// "Settings: GUI"
-	"Ajustes: Modo NTR/TWL",									// "Settings: NTR/TWL-mode"
+    /** Settings: GUI values **/
+
+    // Color
+    "Gris",                                                     // "Gray"
+    "Marrón",                                                  // "Brown"
+    "Rojo",                                                     // "Red"
+    "Rosa",                                                     // "Pink"
+    "Naranja",                                                  // "Orange"
+    "Amarillo",                                                 // "Yellow"
+    "Amarrilo verde",                                           // "Yellow-Green"
+    "Verde 1",                                                  // "Green 1"
+    "Verde 2",                                                  // "Green 2"
+    "Verde claro",                                              // "Light green"
+    "Azul cielo",                                               // "Sky blue"
+    "Azul claro",                                               // "Light blue"
+    "Azul",                                                     // "Blue"
+    "Violeta",                                                  // "Violet"
+    "Púrpura",                                                 // "Purple"
+    "Fucsia",                                                   // "Fuchsia"
+    "Rojo y azul",                                              // "Red and blue"
+    "Verde y amarillo",                                         // "Green and yellow"
+    "Navidad",                                                  // "Christmas"
+
+    // Menu Color
+    "Blanco",                                                   // "White"
+    "Negro",                                                    // "Black"
+
+    /** Settings: GUI descriptions **/
+    "El idioma para usar en TWLoader.",                         // "The language to use for the UI,"
+    "(también afecta al banner de las roms)",                  // "including game banner text."
+
+    "El tema para TWLoader.",                                   // "The theme to use in TWLoader."
+    "Pulsa A para elegir un sub tema.",                         // "Press A for sub-themes."
+
+    "El color del fondo de la pantalla superior, el marco",     // "The color of the top background,"
+    "de selección de ROMs y el círculo de puntos.",               // "the START border, and the circling dots."
+
+    "Color del marco superior,",                                // "The color of the top border,"
+    "y del fondo de la pantalla inferior.",                     // "and the bottom background."
+
+    "Muestra el nombre del archivo en la parte ",               // "Shows game filename at the top of the bubble."
+    "superior de la burbuja de información",                   // (empty)
+
+    "Muestra el número de la ROM selecionada y el",                // "A number of selected game and listed games"
+    "total debajo de la burbuja de información.",              // "is shown below the text bubble."
+
+    "Carga una imagen personalizada para",                      // "Loads a custom bottom screen image"
+    "la pantalla inferior.",                                    // "for the game menu."
+
+    "Auto actualizar bootstrap durante el arranque.",           // "Auto-update nds-bootstrap at launch."
+    "",                                                         // (empty)
+
+    "Auto actualizar e installar los CIAS de TWLoader",         // "Auto-download the CIA of the latest"
+    "durante el arranque.",                                     // "TWLoader version at launch."
+
+    /** Settings: NTR/TWL_mode descriptions **/
+    "Elije una flashcard para cargar",                          // "Pick a flashcard to use to"
+    "ROMs desde ella.",                                         // "run ROMs from it."
+
+    "Mostrar un efecto arcoiris de colores",                    // "See rainbow colors glowing in"
+    "en el LED de notificaciones.",                             // "the Notification LED."
+
+    "Selecciona el modo TWL para eliminar ",                    // "Set to TWL to get rid of lags in some games."
+    "el lag en algunas ROMs.",                                  // (empty)
+
+    "Permite escribir en la VRAM 8 bit",                        // "Allows 8 bit VRAM writes"
+    "y expandir el bus de datos a 32 bits.",                    // "and expands the bus to 32 bit."
+
+    "Muestra la animación de arranque de la DS/DSi",           // "Displays the DS/DSi boot animation"
+    "antes de ejecutar la ROM.",                                // "before launched game."
+
+    "Muestra el mensaje de Salud y Seguridad",                  // "Displays the Health and Safety"
+    "en la pantalla inferior.",                                 // "message on the bottom screen."
+
+    "Activa esta opción para reiniciar el Slot-1",             // "Enable this if Slot-1 carts are stuck"
+    "si el cartucho se queda con pantallas blancas.",           // "on white screens."
+
+    "Muestra información de depuración",                      // "Displays some text before launched game."
+    "antes de lanzar la ROM.",                                  // (empty)
+
+    "Bloquea el SCFG_EXT del ARM9, evitando",                   // "Locks the ARM9 SCFG_EXT,"
+    "conflictos con las librerias libnds más recientes.",      // "avoiding conflict with recent libnds."
+
+    "Cambia entre la version 'Release' (estable) ",             // "Change between release and"
+    "y la 'Unofficial' (inestable).",                           // "unofficial bootstrap file."
+
+    /** Start menu **/
+    // Options
+    "Localización:",                                           // "Game location"
+    "Carátulas: On",                                           // "Box Art: On"
+    "Carátulas: Off",                                          // "Box Art: OFF"
+    "Iniciar GBARunner2",                                       // "Start GBARunner2"
+    "Borde superior: On",                                       // "Top border: On"
+    "Borde superior: Off",                                      // "Top border: Off"
+    "Eliminar donor",                                           // "Unset donor rom"
+    "Buscar",                                                   // "Search"
+    // Values
+    "Tarjeta SD",                                               // "SD Card"
+    "Flashcard",                                                // "Flashcard"
+    "Usa el teclado para buscar ROMs",                          // "Use the keyboard to find roms"
+
+    /** Select menu **/
+    // Options
+    "Velocidad CPU ARM9:",                                      // "ARM9 CPU Speed"
+    "Aumento VRAM:",                                            // "VRAM boost"
+    "Bloq. SCFG_EXT ARM9:",                                     // "Lock ARM9 SCFG_EXT"
+    "Elegir como donor",                                        // "Set as donor ROM"
+    "Elegir color del LED",                                     // "Set LED color"
+    // Values
+    "Por defecto",                                              // "Default"
+
+    /** Sub-theme **/
+    "Sub tema seleccionado: Menu DSi",                          // "Sub-theme select: DSi Menu"
+    "Sub tema seleccionado: R4",                                // "Sub-theme select: R4"
+    "Sub tema seleccionado: akMenu/Wood",                       // "Sub-theme select: Wood"
+
+    "No hay sub temas para este tema.",                         // "No sub-themes exist for this theme."
+
+    /** Settings others minor strings **/
+    "A/B: Guardar y volver",                                    // "A/B: Save and Return"
+    "Izquierda/Derecha: Seleccionar",                           // "Left/Right: Pick"
+    "Ajustes: GUI",                                             // "Settings: GUI"
+    "Ajustes: Modo NTR/TWL",                                    // "Settings: NTR/TWL-mode"
 
 };
 

--- a/gui/source/languages/traditional_chinese.h
+++ b/gui/source/languages/traditional_chinese.h
@@ -4,168 +4,168 @@
 #include <3ds/types.h>
 
 // TRADITIONAL CHINESE
-static const char *const lang_EN[STR_MAX] = {
-	
-	/** GUI **/
-    ": 返回主畫面",									// "Return to HOME Menu"
-	"啟動",													// "START" (used on cartridge indicator)
-	"沒有卡帶",												// "No cartridge"
-	"未知的卡帶", 										// "Unknown Cartridge"
-	"設置",													// "Settings"
-	"B: 返回",													// "B: Back"	
-	
-	/** Settings: GUI **/
-	"語言",													// "Language"
-	"主題",													// "Theme"
-	"顏色",													// "Color"
-	"選單顏色",												// "Menu Color"
-	"顯示檔案名稱",											// "Show filename"
-	"遊戲計數器",												// "Game counter"
-	"自訂下層圖案",										// "Custom bottom image"
-	"自動更新 bootstrap",									// "Auto-update bootstrap"
-	"自動更新到最新的 TWLoader",							// "Auto-update to latest TWLoader"
-	
-	/** Settings: NTR/TWL_mode **/
-	"選擇燒錄卡",										// "Flashcard(s) select"
-	"彩虹 LED",												// "Rainbow LED"
-	"ARM9 CPU 速度",											// "ARM9 CPU Speed"
-	"VRAM 加速",												// "VRAM boost"
-	"DS/DSi 啟動畫面",										// "DS/DSi Boot Screen"
-	"健康與安全信息",								// "Health and Safety message"
-	"重置 Slot-1",												// "Reset Slot-1"
-	"控制台輸出",											// "Console output"
-	"鎖定 ARM9 SCFG_EXT",										// "Lock ARM9 SCFG_EXT"
-	"Bootstrap",												// "Bootstrap"
-	
-	/** Settings: Top Screen **/
-	"X: 更新 bootstrap (官方釋出版本)",					// "X: Update bootstrap (Official release)"
-	"Y: 更新 bootstrap (非官方釋出版本)",					// "Y: Update bootstrap (Unofficial release)"
-    "START: 更新 TWLoader",    								// "START: Update TWLoader"
-	
-	/** Settings: GUI values **/
-	
-	// Color
-	"灰色",														// "Gray"
-	"棕色",													// "Brown"
-	"紅色",														// "Red"
-	"粉紅",												 		// "Pink"
-	"橘色",													// "Orange"
-	"黃色",													// "Yellow"
-	"黃綠色",												// "Yellow-Green"
-	"綠色 1",													// "Green 1"
-	"綠色 2",													// "Green 2"
-	"淺綠",												// "Light green"
-	"天空藍",													// "Sky blue"
-	"淺藍",												// "Light blue"
-	"藍色",														// "Blue"
-	"紫羅蘭色",													// "Violet"
-	"紫色",													// "Purple"
-	"紫紅色",													// "Fuchsia"
-	"紅&藍",													// "Red and blue"
-	"綠&黃",												// "Green and yellow"
-	"聖誕",												// "Christmas"
+static const char* const lang_EN[STR_MAX] = {
 
-	// Menu Color
-	"白色",													// "White"
-	"黑色",													// "Black"
+    /** GUI **/
+    ": 返回主畫面",                                    // "Return to HOME Menu"
+    "啟動",                                                   // "START" (used on cartridge indicator)
+    "沒有卡帶",                                             // "No cartridge"
+    "未知的卡帶",                                      // "Unknown Cartridge"
+    "設置",                                                   // "Settings"
+    "B: 返回",                                                    // "B: Back"
 
-	/** Settings: GUI descriptions **/
-	"介面上所使用的語言,",							// "The language to use for the UI,"
-	"包含遊戲橫幅上的文字.",								// "including game banner text."
-	
-	"TWLoader所使用的主題.",							// "The theme to use in TWLoader."
-	"點擊 A 來使用副主題.",									// "Press A for sub-themes."
-	
-	"上面背景的顏色,",							// "The color of the top background,"
-	"START 的邊緣以及小圓點.",					// "the START border, and the circling dots."
-	
-	"上面邊緣的顏色,",								// "The color of the top border,"
-	"以及下面的背景.",								// "and the bottom background."
-	
-	"在泡泡的上端顯示檔案名稱.",			// "Shows game filename at the top of the bubble."
-	"",															// (empty)
-	
-	"選定以及列出的遊戲數量",				// "A number of selected game and listed games"
-	"會顯示在遊戲泡泡之下.",							// "is shown below the text bubble."
-	
-	"選定一個你喜歡的圖像",						// "Loads a custom bottom screen image"
-	"給遊戲選單使用.",										// "for the game menu."
-	
-	"啟動時自動更新 nds-bootstrap.",						// "Auto-update nds-bootstrap at launch."
-	"",															// (empty)
+    /** Settings: GUI **/
+    "語言",                                                   // "Language"
+    "主題",                                                   // "Theme"
+    "顏色",                                                   // "Color"
+    "選單顏色",                                             // "Menu Color"
+    "顯示檔案名稱",                                           // "Show filename"
+    "遊戲計數器",                                              // "Game counter"
+    "自訂下層圖案",                                       // "Custom bottom image"
+    "自動更新 bootstrap",                                   // "Auto-update bootstrap"
+    "自動更新到最新的 TWLoader",                            // "Auto-update to latest TWLoader"
 
-	"啟動時自動下載最新版本的",						// "Auto-download the CIA of the latest"
-	"TWLoader CIA.",								// "TWLoader version at launch."
-	
-	/** Settings: NTR/TWL_mode descriptions **/
-	"選擇一個要使用來運行",								// "Pick a flashcard to use to"
-	"遊戲 ROMs 的燒錄卡.",										// "run ROMs from it."
-	
-	"提示 LED會閃爍出",							// "See rainbow colors glowing in"
-	"如彩虹般的光.",									// "the Notification LED."
-	
-	"設定到 TWL 來避免某些遊戲中的拖慢.",				// "Set to TWL to get rid of lags in some games."
-	"",															// (empty)
-	
-	"允許 8 bit VRAM 寫入",									// "Allows 8 bit VRAM writes"
-	"以及拓展 bus 到 32 bit.",							// "and expands the bus to 32 bit."
-	
-	"運行遊戲之前顯示",						// "Displays the DS/DSi boot animation"
-	" DS/DSi 開機動畫.",									// "before launched game."
-	
-	"在下面螢幕顯示",							// "Displays the Health and Safety"
-	"健康與安全信息.",							// "message on the bottom screen."
-	
-	"如果 Slot-1 卡帶卡在白畫面的話",					// "Enable this if Slot-1 carts are stuck"
-	"請啟動這項.",										// "on white screens."
-	
-	"顯示遊戲之前顯示一些文本.",					// "Displays some text before launched game."
-	"",															// (empty)
-	
-	"鎖定 ARM9 SCFG_EXT,",									// "Locks the ARM9 SCFG_EXT,"
-	"避免與當前的 libnds 衝突.",					// "avoiding conflict with recent libnds."
-	
-	"在官方與非官方的",								// "Change between release and"
-	"bootstrap 檔案之間切換.",								// "unofficial bootstrap file."
-	
-	/** Start menu **/
-	// Options
-	"遊戲位置",											// "Game location"
-	"遊戲圖示: 開",												// "Box Art: On"
-	"遊戲圖示: 關",												// "Box Art: OFF"
-	"啟動 GBARunner2",											// "Start GBARunner2"
-	"上邊緣: 開",											// "Top border: On"
-	"上邊緣: 關",											// "Top border: Off"
-	"取消 donor rom",											// "Unset donor rom"
-	"搜尋",													// "Search"
-	// Values
-	"SD 卡",													// "SD Card"
-	"燒錄卡",												// "Flashcard"
-	"使用鍵盤選找 roms",							// "Use the keyboard to find roms"
-	
-	/** Select menu **/
-	// Options
-	"ARM9 CPU 速度",											// "ARM9 CPU Speed"
-	"VRAM 提速",												// "VRAM boost"
-	"鎖定 ARM9 SCFG_EXT",										// "Lock ARM9 SCFG_EXT"
-	"設置為 donor ROM",											// "Set as donor ROM"
-	"設定 LED 顏色",											// "Set LED color"
-	// Values
-	"預設值",													// "Default"
-	
-	/** Sub-theme **/
-	"副主題選取: DSi 選單",								// "Sub-theme select: DSi Menu"
-	"副主題選取: R4",										// "Sub-theme select: R4"
-	"副主題選取: akMenu/Wood",									// "Sub-theme select: Wood"
-	
-	"這個主題並無相應的副主題.",						// "No sub-themes exist for this theme."
-	
-	/** Settings others minor strings **/
-	"A/B: 儲存並返回",										// "A/B: Save and Return"
-	"左/右: 選取",											// "Left/Right: Pick"
-	"設置: GUI",											// "Settings: GUI"
-	"設置: NTR/TWL-mode",									// "Settings: NTR/TWL-mode"
-	
+    /** Settings: NTR/TWL_mode **/
+    "選擇燒錄卡",                                      // "Flashcard(s) select"
+    "彩虹 LED",                                               // "Rainbow LED"
+    "ARM9 CPU 速度",                                          // "ARM9 CPU Speed"
+    "VRAM 加速",                                              // "VRAM boost"
+    "DS/DSi 啟動畫面",                                      // "DS/DSi Boot Screen"
+    "健康與安全信息",                                // "Health and Safety message"
+    "重置 Slot-1",                                                // "Reset Slot-1"
+    "控制台輸出",                                          // "Console output"
+    "鎖定 ARM9 SCFG_EXT",                                     // "Lock ARM9 SCFG_EXT"
+    "Bootstrap",                                                // "Bootstrap"
+
+    /** Settings: Top Screen **/
+    "X: 更新 bootstrap (官方釋出版本)",                 // "X: Update bootstrap (Official release)"
+    "Y: 更新 bootstrap (非官方釋出版本)",                  // "Y: Update bootstrap (Unofficial release)"
+    "START: 更新 TWLoader",                                   // "START: Update TWLoader"
+
+    /** Settings: GUI values **/
+
+    // Color
+    "灰色",                                                       // "Gray"
+    "棕色",                                                   // "Brown"
+    "紅色",                                                       // "Red"
+    "粉紅",                                                       // "Pink"
+    "橘色",                                                   // "Orange"
+    "黃色",                                                   // "Yellow"
+    "黃綠色",                                                // "Yellow-Green"
+    "綠色 1",                                                 // "Green 1"
+    "綠色 2",                                                 // "Green 2"
+    "淺綠",                                               // "Light green"
+    "天空藍",                                                    // "Sky blue"
+    "淺藍",                                               // "Light blue"
+    "藍色",                                                       // "Blue"
+    "紫羅蘭色",                                                 // "Violet"
+    "紫色",                                                   // "Purple"
+    "紫紅色",                                                    // "Fuchsia"
+    "紅&藍",                                                  // "Red and blue"
+    "綠&黃",                                              // "Green and yellow"
+    "聖誕",                                               // "Christmas"
+
+    // Menu Color
+    "白色",                                                   // "White"
+    "黑色",                                                   // "Black"
+
+    /** Settings: GUI descriptions **/
+    "介面上所使用的語言,",                         // "The language to use for the UI,"
+    "包含遊戲橫幅上的文字.",                              // "including game banner text."
+
+    "TWLoader所使用的主題.",                          // "The theme to use in TWLoader."
+    "點擊 A 來使用副主題.",                                 // "Press A for sub-themes."
+
+    "上面背景的顏色,",                           // "The color of the top background,"
+    "START 的邊緣以及小圓點.",                  // "the START border, and the circling dots."
+
+    "上面邊緣的顏色,",                               // "The color of the top border,"
+    "以及下面的背景.",                               // "and the bottom background."
+
+    "在泡泡的上端顯示檔案名稱.",            // "Shows game filename at the top of the bubble."
+    "",                                                         // (empty)
+
+    "選定以及列出的遊戲數量",                // "A number of selected game and listed games"
+    "會顯示在遊戲泡泡之下.",                          // "is shown below the text bubble."
+
+    "選定一個你喜歡的圖像",                       // "Loads a custom bottom screen image"
+    "給遊戲選單使用.",                                       // "for the game menu."
+
+    "啟動時自動更新 nds-bootstrap.",                     // "Auto-update nds-bootstrap at launch."
+    "",                                                         // (empty)
+
+    "啟動時自動下載最新版本的",                     // "Auto-download the CIA of the latest"
+    "TWLoader CIA.",                                // "TWLoader version at launch."
+
+    /** Settings: NTR/TWL_mode descriptions **/
+    "選擇一個要使用來運行",                               // "Pick a flashcard to use to"
+    "遊戲 ROMs 的燒錄卡.",                                        // "run ROMs from it."
+
+    "提示 LED會閃爍出",                           // "See rainbow colors glowing in"
+    "如彩虹般的光.",                                  // "the Notification LED."
+
+    "設定到 TWL 來避免某些遊戲中的拖慢.",             // "Set to TWL to get rid of lags in some games."
+    "",                                                         // (empty)
+
+    "允許 8 bit VRAM 寫入",                                 // "Allows 8 bit VRAM writes"
+    "以及拓展 bus 到 32 bit.",                         // "and expands the bus to 32 bit."
+
+    "運行遊戲之前顯示",                     // "Displays the DS/DSi boot animation"
+    " DS/DSi 開機動畫.",                                    // "before launched game."
+
+    "在下面螢幕顯示",                            // "Displays the Health and Safety"
+    "健康與安全信息.",                           // "message on the bottom screen."
+
+    "如果 Slot-1 卡帶卡在白畫面的話",                    // "Enable this if Slot-1 carts are stuck"
+    "請啟動這項.",                                     // "on white screens."
+
+    "顯示遊戲之前顯示一些文本.",                    // "Displays some text before launched game."
+    "",                                                         // (empty)
+
+    "鎖定 ARM9 SCFG_EXT,",                                    // "Locks the ARM9 SCFG_EXT,"
+    "避免與當前的 libnds 衝突.",                    // "avoiding conflict with recent libnds."
+
+    "在官方與非官方的",                             // "Change between release and"
+    "bootstrap 檔案之間切換.",                                // "unofficial bootstrap file."
+
+    /** Start menu **/
+    // Options
+    "遊戲位置",                                         // "Game location"
+    "遊戲圖示: 開",                                                // "Box Art: On"
+    "遊戲圖示: 關",                                                // "Box Art: OFF"
+    "啟動 GBARunner2",                                            // "Start GBARunner2"
+    "上邊緣: 開",                                           // "Top border: On"
+    "上邊緣: 關",                                           // "Top border: Off"
+    "取消 donor rom",                                         // "Unset donor rom"
+    "搜尋",                                                   // "Search"
+    // Values
+    "SD 卡",                                                   // "SD Card"
+    "燒錄卡",                                                // "Flashcard"
+    "使用鍵盤選找 roms",                          // "Use the keyboard to find roms"
+
+    /** Select menu **/
+    // Options
+    "ARM9 CPU 速度",                                          // "ARM9 CPU Speed"
+    "VRAM 提速",                                              // "VRAM boost"
+    "鎖定 ARM9 SCFG_EXT",                                     // "Lock ARM9 SCFG_EXT"
+    "設置為 donor ROM",                                          // "Set as donor ROM"
+    "設定 LED 顏色",                                            // "Set LED color"
+    // Values
+    "預設值",                                                    // "Default"
+
+    /** Sub-theme **/
+    "副主題選取: DSi 選單",                              // "Sub-theme select: DSi Menu"
+    "副主題選取: R4",                                      // "Sub-theme select: R4"
+    "副主題選取: akMenu/Wood",                                 // "Sub-theme select: Wood"
+
+    "這個主題並無相應的副主題.",                        // "No sub-themes exist for this theme."
+
+    /** Settings others minor strings **/
+    "A/B: 儲存並返回",                                     // "A/B: Save and Return"
+    "左/右: 選取",                                          // "Left/Right: Pick"
+    "設置: GUI",                                          // "Settings: GUI"
+    "設置: NTR/TWL-mode",                                 // "Settings: NTR/TWL-mode"
+
 };
 
 

--- a/gui/source/log.cpp
+++ b/gui/source/log.cpp
@@ -4,93 +4,97 @@
 
 bool LogCreated = false;
 
-int createLog(void) {
-	if (!LogCreated){
-		FILE* log = fopen(LOG_PATH, "w");
-		if (!log){
-			return -1;
-		}
-		LogCreated = true;
-		Log("************** Log file created at ");
-		Log(RetTime(true).c_str());
-		Log(" **************");
-		Log("\n");
-		fclose(log);
-	}
-	return 0;
+int createLog(void)
+{
+    if (!LogCreated) {
+        FILE* log = fopen(LOG_PATH, "w");
+        if (!log) {
+            return -1;
+        }
+        LogCreated = true;
+        Log("************** Log file created at ");
+        Log(RetTime(true).c_str());
+        Log(" **************");
+        Log("\n");
+        fclose(log);
+    }
+    return 0;
 }
 
-void Log(const char *message) {
-	FILE *log;
- 
-	if (!LogCreated) {
-		log = fopen(LOG_PATH, "w");
-		LogCreated = true;
-	} else {
-		log = fopen(LOG_PATH, "a");
-	}
+void Log(const char* message)
+{
+    FILE* log;
 
-	if (log == NULL) {
-		if (LogCreated) {
-			LogCreated = false;
-		}
-		return;
-	} else {
-		fputs(message, log);
-		fclose(log);
-	} 
+    if (!LogCreated) {
+        log = fopen(LOG_PATH, "w");
+        LogCreated = true;
+    } else {
+        log = fopen(LOG_PATH, "a");
+    }
+
+    if (log == NULL) {
+        if (LogCreated) {
+            LogCreated = false;
+        }
+        return;
+    } else {
+        fputs(message, log);
+        fclose(log);
+    }
 }
 
-void LogFM(const char *from, const char *message) {
-	FILE *log;
+void LogFM(const char* from, const char* message)
+{
+    FILE* log;
 
-	if (!LogCreated) {
-		log = fopen(LOG_PATH, "w");
-		LogCreated = true;
-	} else {
-		log = fopen(LOG_PATH, "a");
-	}
+    if (!LogCreated) {
+        log = fopen(LOG_PATH, "w");
+        LogCreated = true;
+    } else {
+        log = fopen(LOG_PATH, "a");
+    }
 
-	if (log == NULL) {
-		if (LogCreated) {
-			LogCreated = false;
-		}
-		return;
-	} else {
-		fputs("Method: <", log);
-		fputs(from, log);
-		fputs("> :\r\t\tMessage:<", log);
-		fputs(message, log);
-		fputs(">", log);
-		fputs("\n", log);
-		fclose(log);
-	}
+    if (log == NULL) {
+        if (LogCreated) {
+            LogCreated = false;
+        }
+        return;
+    } else {
+        fputs("Method: <", log);
+        fputs(from, log);
+        fputs("> :\r\t\tMessage:<", log);
+        fputs(message, log);
+        fputs(">", log);
+        fputs("\n", log);
+        fclose(log);
+    }
 }
 
-void LogFMA(const char *from, const char *message, const char *additional_info) {
-	FILE *log;
+void LogFMA(const char* from, const char* message, const char* additional_info)
+{
+    FILE* log;
 
-	if (!LogCreated) {
-		log = fopen(LOG_PATH, "w");
-		LogCreated = true;
-	} else {
-		log = fopen(LOG_PATH, "a");
-	}
+    if (!LogCreated) {
+        log = fopen(LOG_PATH, "w");
+        LogCreated = true;
+    } else {
+        log = fopen(LOG_PATH, "a");
+    }
 
-	if (log == NULL) {
-		if (LogCreated) {
-			LogCreated = false;
-		}
-		return;
-	} else {
-		fputs("Method: <", log);
-		fputs(from, log);
-		fputs("> :\r\t\tMessage: <", log);
-		fputs(message, log);
-		fputs("> \tAdditional info:<", log);
-		fputs(additional_info, log);		
-		fputs(">", log);
-		fputs("\n", log);
-		fclose(log);
-	} 
+    if (log == NULL) {
+        if (LogCreated) {
+            LogCreated = false;
+        }
+        return;
+    } else {
+        fputs("Method: <", log);
+        fputs(from, log);
+        fputs("> :\r\t\tMessage: <", log);
+        fputs(message, log);
+        fputs("> \tAdditional info:<", log);
+        fputs(additional_info, log);
+        fputs(">", log);
+        fputs("\n", log);
+        fclose(log);
+    }
 }

--- a/gui/source/log.h
+++ b/gui/source/log.h
@@ -1,11 +1,11 @@
 /**
 
-	This method is created by Jolty95 (umbjolt in gbatemp) to help debugging TWLoader
-	Use:
-		#int createLog() to start using it
-		#void Log(const char *message) write in log file a simple message. Use again if you want to write a new line with \n
-		#void LogFM(const char *from, const char *message) write in log file a message FROM a method. Usefull to check which method make an exception
-		#void LogFMA(const char *from, const char *message, const char *additional_info) write in log file a message with additional info. Ex. write in log a return value. Remember to parse it as a string.
+    This method is created by Jolty95 (umbjolt in gbatemp) to help debugging TWLoader
+    Use:
+        #int createLog() to start using it
+        #void Log(const char *message) write in log file a simple message. Use again if you want to write a new line with \n
+        #void LogFM(const char *from, const char *message) write in log file a message FROM a method. Usefull to check which method make an exception
+        #void LogFMA(const char *from, const char *message, const char *additional_info) write in log file a message with additional info. Ex. write in log a return value. Remember to parse it as a string.
 
 */
 
@@ -17,7 +17,7 @@
 extern bool LogCreated;
 
 int createLog(void);
-void Log(const char *message);
-void LogFM(const char *from, const char *message);
-void LogFMA(const char *from, const char *message, const char *additional_info);
+void Log(const char* message);
+void LogFM(const char* from, const char* message);
+void LogFMA(const char* from, const char* message, const char* additional_info);
 #endif // LOG_H

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -55,58 +55,58 @@ bool menuaction_prevpage = false;
 bool menuaction_launch = false;
 bool menudboxaction_switchloc = false;
 
-CIniFile bootstrapini( "sdmc:/_nds/nds-bootstrap.ini" );
+CIniFile bootstrapini("sdmc:/_nds/nds-bootstrap.ini");
 #include "ndsheaderbanner.h"
 
 int equals;
 
-sftd_font *font;
-sftd_font *font_b;
+sftd_font* font;
+sftd_font* font_b;
 
 // Dialog box textures.
-sf2d_texture *dialogboxtex;	// Dialog box
-static sf2d_texture *dboxtex_iconbox = NULL;
-static sf2d_texture *dboxtex_button = NULL;
-static sf2d_texture *dboxtex_buttonback = NULL;
+sf2d_texture* dialogboxtex; // Dialog box
+static sf2d_texture* dboxtex_iconbox = NULL;
+static sf2d_texture* dboxtex_button = NULL;
+static sf2d_texture* dboxtex_buttonback = NULL;
 
-sf2d_texture *settingslogotex;	// TWLoader logo.
+sf2d_texture* settingslogotex;  // TWLoader logo.
 
-static sf2d_texture *slot1boxarttex = NULL;
+static sf2d_texture* slot1boxarttex = NULL;
 
-std::string	bootstrapPath;
+std::string bootstrapPath;
 
 // Current screen mode.
 ScreenMode screenmode = SCREEN_MODE_ROM_SELECT;
 
-/* enum RomSelect_Mode {	// R4 Theme only
-	ROMSEL_MODE_MENU = 0,	// Menu
-	ROMSEL_MODE_ROMSEL = 1,	// ROM Select
+/* enum RomSelect_Mode {    // R4 Theme only
+    ROMSEL_MODE_MENU = 0,   // Menu
+    ROMSEL_MODE_ROMSEL = 1, // ROM Select
 };
 RomSelect_Mode menudboxmode = DBOX_MODE_OPTIONS; */
 
 enum MenuDBox_Mode {
-	DBOX_MODE_OPTIONS = 0,	// Options
-	DBOX_MODE_SETTINGS = 1,	// Game Settings
+    DBOX_MODE_OPTIONS = 0,  // Options
+    DBOX_MODE_SETTINGS = 1, // Game Settings
 };
 MenuDBox_Mode menudboxmode = DBOX_MODE_OPTIONS;
 
 enum Menu_ControlSet {
-	CTRL_SET_MENU = 0,	// Menu (R4 Theme only)
-	CTRL_SET_GAMESEL = 1,	// ROM Select
-	CTRL_SET_DBOX = 2,	// Dialog box mode
+    CTRL_SET_MENU = 0,  // Menu (R4 Theme only)
+    CTRL_SET_GAMESEL = 1,   // ROM Select
+    CTRL_SET_DBOX = 2,  // Dialog box mode
 };
 Menu_ControlSet menu_ctrlset = CTRL_SET_GAMESEL;
 
-static sf2d_texture *bnricontexnum = NULL;
-static sf2d_texture *bnricontexlaunch = NULL;	// DO NOT FREE; points to bnricontex[]
-static sf2d_texture *boxarttexnum = NULL;
+static sf2d_texture* bnricontexnum = NULL;
+static sf2d_texture* bnricontexlaunch = NULL;   // DO NOT FREE; points to bnricontex[]
+static sf2d_texture* boxarttexnum = NULL;
 
 // Banners and boxart. (formerly bannerandboxart.h)
 // bnricontex[]: 0-19
-static sf2d_texture *bnricontex[20] = { };
+static sf2d_texture* bnricontex[20] = { };
 // boxartpath[]: 0-19; 20 is for blank boxart only
 static char* boxartpath[21] = { };
-static sf2d_texture *boxarttex[6] = { };
+static sf2d_texture* boxarttex[6] = { };
 
 int bnriconnum = 0;
 int bnriconframenum = 0;
@@ -117,8 +117,8 @@ const char* musicpath = "romfs:/null.wav";
 
 
 // Shoulder buttons.
-sf2d_texture *shoulderLtex = NULL;
-sf2d_texture *shoulderRtex = NULL;
+sf2d_texture* shoulderLtex = NULL;
+sf2d_texture* shoulderRtex = NULL;
 // sf2d_texture *shoulderYtex = NULL;
 // sf2d_texture *shoulderXtex = NULL;
 
@@ -132,14 +132,14 @@ int RshoulderYpos = 220;
 
 
 // Sound effects.
-sound *bgm_menu = NULL;
+sound* bgm_menu = NULL;
 //sound *bgm_settings = NULL;
-sound *sfx_launch = NULL;
-sound *sfx_select = NULL;
-sound *sfx_stop = NULL;
-sound *sfx_switch = NULL;
-sound *sfx_wrong = NULL;
-sound *sfx_back = NULL;
+sound* sfx_launch = NULL;
+sound* sfx_select = NULL;
+sound* sfx_stop = NULL;
+sound* sfx_switch = NULL;
+sound* sfx_wrong = NULL;
+sound* sfx_back = NULL;
 
 
 // Title box animation.
@@ -158,7 +158,7 @@ static const char fcrompathini_flashcardrom[] = "FLASHCARD-ROM";
 static const char fcrompathini_rompath[] = "NDS_PATH";
 static const char fcrompathini_tid[] = "TID";
 static const char fcrompathini_bnriconaniseq[] = "BNR_ICONANISEQ";
-	
+
 
 // Bootstrap .ini file
 static const char bootstrapini_ndsbootstrap[] = "NDS-BOOTSTRAP";
@@ -177,7 +177,7 @@ bool run = true;
 // End
 
 bool showdialogbox = false;
-bool showdialogbox_menu = false;	// for Game Select menu
+bool showdialogbox_menu = false;    // for Game Select menu
 int menudbox_movespeed = 22;
 int menudbox_Ypos = -240;
 int menudbox_bgalpha = 0;
@@ -203,11 +203,11 @@ bool fadein = true;
 bool fadeout = false;
 
 static const char* romsel_filename;
-static wstring romsel_filename_w;	// Unicode filename for display.
-static vector<wstring> romsel_gameline;	// from banner
+static wstring romsel_filename_w;   // Unicode filename for display.
+static vector<wstring> romsel_gameline; // from banner
 
-static const char* rom = "";		// Selected ROM image.
-std::string sav;		// Associated save file.
+static const char* rom = "";        // Selected ROM image.
+std::string sav;        // Associated save file.
 
 // These are used by flashcard functions and must retain their trailing slash.
 static const std::string sdmc = "sdmc:/";
@@ -221,15 +221,16 @@ static const char fcbnriconfolder[] = "sdmc:/_nds/twloader/bnricons/flashcard";
 static const char boxartfolder[] = "sdmc:/_nds/twloader/boxart";
 static const char fcboxartfolder[] = "sdmc:/_nds/twloader/boxart/flashcard";
 // End
-	
+
 bool keepsdvalue = false;
 int gbarunnervalue = 0;
 
 bool logEnabled = false;
 
-static std::string ReplaceAll(std::string str, const std::string& from, const std::string& to) {
+static std::string ReplaceAll(std::string str, const std::string& from, const std::string& to)
+{
     size_t start_pos = 0;
-    while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+    while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
         str.replace(start_pos, from.length(), to);
         start_pos += to.length(); // Handles case where 'to' is a substring of 'from'
     }
@@ -264,8 +265,7 @@ static inline Result ptmsysmExit(void)
     return svcCloseHandle(ptmsysmHandle);
 }
 
-typedef struct
-{
+typedef struct {
     u32 ani;
     u8 r[32];
     u8 g[32];
@@ -278,7 +278,9 @@ static Result ptmsysmSetInfoLedPattern(const RGBLedPattern* pattern)
     ipc[0] = 0x8010640;
     memcpy(&ipc[1], pattern, 0x64);
     Result ret = svcSendSyncRequest(ptmsysmHandle);
-    if(ret < 0) return ret;
+    if (ret < 0) {
+        return ret;
+    }
     return ipc[1];
 }
 
@@ -288,68 +290,74 @@ static string dialog_text;
  * Make the dialog box appear.
  * @param text Dialog box text.
  */
-void DialogBoxAppear(const char *text, int mode) {
-	if (showdialogbox)
-		return;
+void DialogBoxAppear(const char* text, int mode)
+{
+    if (showdialogbox) {
+        return;
+    }
 
-	// Save the dialog text so we can make
-	// use if it if nullptr is specified.
-	if (text) {
-		dialog_text = text;
-	}
+    // Save the dialog text so we can make
+    // use if it if nullptr is specified.
+    if (text) {
+        dialog_text = text;
+    }
 
-	int movespeed = 22;
-	for (int i = 0; i < 240; i += movespeed) {
-		if (movespeed <= 1) {
-			movespeed = 1;
-		} else {
-			movespeed -= 0.2;
-		}
-		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-		if (screenmode == SCREEN_MODE_SETTINGS) {
-			sf2d_draw_texture(settingstex, 0, 0);
-		}
-		sf2d_draw_texture(dialogboxtex, 0, i-240);
-		if (mode == 1) {
-			sftd_draw_textf(font, 40, 72+i-240, RGBA8(0, 0, 0, 255), 16, dialog_text.c_str());
-		} else
-			sftd_draw_textf(font, 12, 16+i-240, RGBA8(0, 0, 0, 255), 12, dialog_text.c_str());
-		sf2d_end_frame();
-		sf2d_swapbuffers();
-	}
-	showdialogbox = true;
+    int movespeed = 22;
+    for (int i = 0; i < 240; i += movespeed) {
+        if (movespeed <= 1) {
+            movespeed = 1;
+        } else {
+            movespeed -= 0.2;
+        }
+        sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+        if (screenmode == SCREEN_MODE_SETTINGS) {
+            sf2d_draw_texture(settingstex, 0, 0);
+        }
+        sf2d_draw_texture(dialogboxtex, 0, i - 240);
+        if (mode == 1) {
+            sftd_draw_textf(font, 40, 72 + i - 240, RGBA8(0, 0, 0, 255), 16, dialog_text.c_str());
+        } else {
+            sftd_draw_textf(font, 12, 16 + i - 240, RGBA8(0, 0, 0, 255), 12, dialog_text.c_str());
+        }
+        sf2d_end_frame();
+        sf2d_swapbuffers();
+    }
+    showdialogbox = true;
 }
 
 /**
  * Make the dialog box disappear.
  * @param text Dialog box text.
  */
-void DialogBoxDisappear(const char *text, int mode) {
-	if (!showdialogbox)
-		return;
+void DialogBoxDisappear(const char* text, int mode)
+{
+    if (!showdialogbox) {
+        return;
+    }
 
-	// Save the dialog text so we can make
-	// use if it if nullptr is specified.
-	if (text) {
-		dialog_text = text;
-	}
+    // Save the dialog text so we can make
+    // use if it if nullptr is specified.
+    if (text) {
+        dialog_text = text;
+    }
 
-	int movespeed = 1;
-	for (int i = 0; i < 240; i += movespeed) {
-		movespeed += 1;
-		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-		if (screenmode == SCREEN_MODE_SETTINGS) {
-			sf2d_draw_texture(settingstex, 0, 0);
-		}
-		sf2d_draw_texture(dialogboxtex, 0, i);
-		if (mode == 1) {
-			sftd_draw_textf(font, 40, 72+i, RGBA8(0, 0, 0, 255), 16, dialog_text.c_str());
-		} else
-			sftd_draw_textf(font, 12, 16+i, RGBA8(0, 0, 0, 255), 12, dialog_text.c_str());
-		sf2d_end_frame();
-		sf2d_swapbuffers();
-	}
-	showdialogbox = false;
+    int movespeed = 1;
+    for (int i = 0; i < 240; i += movespeed) {
+        movespeed += 1;
+        sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+        if (screenmode == SCREEN_MODE_SETTINGS) {
+            sf2d_draw_texture(settingstex, 0, 0);
+        }
+        sf2d_draw_texture(dialogboxtex, 0, i);
+        if (mode == 1) {
+            sftd_draw_textf(font, 40, 72 + i, RGBA8(0, 0, 0, 255), 16, dialog_text.c_str());
+        } else {
+            sftd_draw_textf(font, 12, 16 + i, RGBA8(0, 0, 0, 255), 12, dialog_text.c_str());
+        }
+        sf2d_end_frame();
+        sf2d_swapbuffers();
+    }
+    showdialogbox = false;
 }
 
 /**
@@ -357,280 +365,299 @@ void DialogBoxDisappear(const char *text, int mode) {
  * @param filename Filename.
  * @return 0 on success; non-zero on error.
  */
-static int CreateGameSave(const char *filename) {
-	char nds_path[256];
-	snprintf(nds_path, sizeof(nds_path), "sdmc:/%s/%s", settings.ui.romfolder.c_str() , rom);
-	FILE *f_nds_file = fopen(nds_path, "rb");
-	if (!f_nds_file) {
-		DialogBoxAppear("fopen(nds_path) failed, continuing anyway.", 0);
-		DialogBoxDisappear("fopen(nds_path) failed, continuing anyway.", 0);
-		return -1;
-	}
+static int CreateGameSave(const char* filename)
+{
+    char nds_path[256];
+    snprintf(nds_path, sizeof(nds_path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), rom);
+    FILE* f_nds_file = fopen(nds_path, "rb");
+    if (!f_nds_file) {
+        DialogBoxAppear("fopen(nds_path) failed, continuing anyway.", 0);
+        DialogBoxDisappear("fopen(nds_path) failed, continuing anyway.", 0);
+        return -1;
+    }
 
-	char game_TID[5];
-	grabTID(f_nds_file, game_TID);
-	game_TID[4] = 0;
-	fclose(f_nds_file);
-	
-	if (strcmp(game_TID, "####") != 0) {	// Create save if game isn't homebrew
-		DialogBoxAppear("Creating save file...", 1);
-		static const int BUFFER_SIZE = 4096;
-		char buffer[BUFFER_SIZE];
-		memset(buffer, 0, sizeof(buffer));
+    char game_TID[5];
+    grabTID(f_nds_file, game_TID);
+    game_TID[4] = 0;
+    fclose(f_nds_file);
 
-		int savesize = 524288;	// 512KB (default size for most games)
-		
-		// Set save size to 1MB for the following games
-		if (strcmp(game_TID, "AZLJ") == 0 ||	// Wagamama Fashion: Girls Mode
-			strcmp(game_TID, "AZLE") == 0 ||	// Style Savvy
-			strcmp(game_TID, "AZLP") == 0 ||	// Nintendo presents: Style Boutique
-			strcmp(game_TID, "AZLK") == 0 )	// Namanui Collection: Girls Style
-		{
-			savesize = 1048576;
-		}
+    if (strcmp(game_TID, "####") != 0) {    // Create save if game isn't homebrew
+        DialogBoxAppear("Creating save file...", 1);
+        static const int BUFFER_SIZE = 4096;
+        char buffer[BUFFER_SIZE];
+        memset(buffer, 0, sizeof(buffer));
 
-		// Set save size to 32MB for the following games
-		if (strcmp(game_TID, "UORE") == 0 ||	// WarioWare - D.I.Y.
-			strcmp(game_TID, "UORP") == 0 )	// WarioWare - Do It Yourself
-		{
-			savesize = 1048576*32;
-		}
+        int savesize = 524288;  // 512KB (default size for most games)
 
-		FILE *pFile = fopen(filename, "wb");
-		if (pFile) {
-			for (int i = savesize; i > 0; i -= BUFFER_SIZE) {
-				fwrite(buffer, 1, sizeof(buffer), pFile);
-			}
-			fclose(pFile);
-		}
+        // Set save size to 1MB for the following games
+        if (strcmp(game_TID, "AZLJ") == 0 ||    // Wagamama Fashion: Girls Mode
+                strcmp(game_TID, "AZLE") == 0 ||    // Style Savvy
+                strcmp(game_TID, "AZLP") == 0 ||    // Nintendo presents: Style Boutique
+                strcmp(game_TID, "AZLK") == 0) { // Namanui Collection: Girls Style
+            savesize = 1048576;
+        }
 
-		DialogBoxDisappear("Done!", 1);
-	}
-	return 0;
+        // Set save size to 32MB for the following games
+        if (strcmp(game_TID, "UORE") == 0 ||    // WarioWare - D.I.Y.
+                strcmp(game_TID, "UORP") == 0) { // WarioWare - Do It Yourself
+            savesize = 1048576 * 32;
+        }
+
+        FILE* pFile = fopen(filename, "wb");
+        if (pFile) {
+            for (int i = savesize; i > 0; i -= BUFFER_SIZE) {
+                fwrite(buffer, 1, sizeof(buffer), pFile);
+            }
+            fclose(pFile);
+        }
+
+        DialogBoxDisappear("Done!", 1);
+    }
+    return 0;
 }
 
 /**
  * Set MPU settings for a specific game.
  */
-void SetMPUSettings() {
-	const u32 hHeld = hidKeysHeld();
+void SetMPUSettings()
+{
+    const u32 hHeld = hidKeysHeld();
 
-	char nds_path[256];
-	snprintf(nds_path, sizeof(nds_path), "sdmc:/%s/%s", settings.ui.romfolder.c_str() , rom);
-	FILE *f_nds_file = fopen(nds_path, "rb");
+    char nds_path[256];
+    snprintf(nds_path, sizeof(nds_path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), rom);
+    FILE* f_nds_file = fopen(nds_path, "rb");
 
-	char game_TID[5];
-	grabTID(f_nds_file, game_TID);
-	game_TID[4] = 0;
-	game_TID[3] = 0;
-	fclose(f_nds_file);
-	
-	if(hHeld & KEY_B){
-		settings.twl.mpuregion = 1;
-	} else if(hHeld & KEY_X){
-		settings.twl.mpuregion = 2;
-	} else if(hHeld & KEY_Y){
-		settings.twl.mpuregion = 3;
-	} else {
-		settings.twl.mpuregion = 0;
-	}
-	if(hHeld & KEY_RIGHT){
-		settings.twl.mpusize = 3145728;
-	} else if(hHeld & KEY_LEFT){
-		settings.twl.mpusize = 1;
-	} else {
-		settings.twl.mpusize = 0;
-	}
+    char game_TID[5];
+    grabTID(f_nds_file, game_TID);
+    game_TID[4] = 0;
+    game_TID[3] = 0;
+    fclose(f_nds_file);
 
-	// Check for games that need an MPU size of 3 MB.
-	static const char mpu_3MB_list[][4] = {
-		"A7A",	// DS Download Station - Vol 1
-		"A7B",	// DS Download Station - Vol 2
-		"A7C",	// DS Download Station - Vol 3
-		"A7D",	// DS Download Station - Vol 4
-		"A7E",	// DS Download Station - Vol 5
-		"A7F",	// DS Download Station - Vol 6 (EUR)
-		"A7G",	// DS Download Station - Vol 6 (USA)
-		"A7H",	// DS Download Station - Vol 7
-		"A7I",	// DS Download Station - Vol 8
-		"A7J",	// DS Download Station - Vol 9
-		"A7K",	// DS Download Station - Vol 10
-		"A7L",	// DS Download Station - Vol 11
-		"A7M",	// DS Download Station - Vol 12
-		"A7N",	// DS Download Station - Vol 13
-		"A7O",	// DS Download Station - Vol 14
-		"A7P",	// DS Download Station - Vol 15
-		"A7Q",	// DS Download Station - Vol 16
-		"A7R",	// DS Download Station - Vol 17
-		"A7S",	// DS Download Station - Vol 18
-		"A7T",	// DS Download Station - Vol 19
-		"ARZ",	// Rockman ZX/MegaMan ZX
-		"YZX",	// Rockman ZX Advent/MegaMan ZX Advent
-		"B6Z",	// Rockman Zero Collection/MegaMan Zero Collection
-	};
+    if (hHeld & KEY_B) {
+        settings.twl.mpuregion = 1;
+    } else if (hHeld & KEY_X) {
+        settings.twl.mpuregion = 2;
+    } else if (hHeld & KEY_Y) {
+        settings.twl.mpuregion = 3;
+    } else {
+        settings.twl.mpuregion = 0;
+    }
+    if (hHeld & KEY_RIGHT) {
+        settings.twl.mpusize = 3145728;
+    } else if (hHeld & KEY_LEFT) {
+        settings.twl.mpusize = 1;
+    } else {
+        settings.twl.mpusize = 0;
+    }
 
-	// TODO: If the list gets large enough, switch to bsearch().
-	for (unsigned int i = 0; i < sizeof(mpu_3MB_list)/sizeof(mpu_3MB_list[0]); i++) {
-		if (!memcmp(game_TID, mpu_3MB_list[i], 3)) {
-			// Found a match.
-			settings.twl.mpuregion = 1;
-			settings.twl.mpusize = 3145728;
-			break;
-		}
-	}
+    // Check for games that need an MPU size of 3 MB.
+    static const char mpu_3MB_list[][4] = {
+        "A7A",  // DS Download Station - Vol 1
+        "A7B",  // DS Download Station - Vol 2
+        "A7C",  // DS Download Station - Vol 3
+        "A7D",  // DS Download Station - Vol 4
+        "A7E",  // DS Download Station - Vol 5
+        "A7F",  // DS Download Station - Vol 6 (EUR)
+        "A7G",  // DS Download Station - Vol 6 (USA)
+        "A7H",  // DS Download Station - Vol 7
+        "A7I",  // DS Download Station - Vol 8
+        "A7J",  // DS Download Station - Vol 9
+        "A7K",  // DS Download Station - Vol 10
+        "A7L",  // DS Download Station - Vol 11
+        "A7M",  // DS Download Station - Vol 12
+        "A7N",  // DS Download Station - Vol 13
+        "A7O",  // DS Download Station - Vol 14
+        "A7P",  // DS Download Station - Vol 15
+        "A7Q",  // DS Download Station - Vol 16
+        "A7R",  // DS Download Station - Vol 17
+        "A7S",  // DS Download Station - Vol 18
+        "A7T",  // DS Download Station - Vol 19
+        "ARZ",  // Rockman ZX/MegaMan ZX
+        "YZX",  // Rockman ZX Advent/MegaMan ZX Advent
+        "B6Z",  // Rockman Zero Collection/MegaMan Zero Collection
+    };
+
+    // TODO: If the list gets large enough, switch to bsearch().
+    for (unsigned int i = 0; i < sizeof(mpu_3MB_list) / sizeof(mpu_3MB_list[0]); i++) {
+        if (!memcmp(game_TID, mpu_3MB_list[i], 3)) {
+            // Found a match.
+            settings.twl.mpuregion = 1;
+            settings.twl.mpusize = 3145728;
+            break;
+        }
+    }
 }
 
 /**
  * Set a rainbow cycle pattern on the notification LED.
  * @return 0 on success; non-zero on error.
  */
-static int RainbowLED(void) {
-	static const RGBLedPattern pat = {
-		32,	// Number of valid entries.
+static int RainbowLED(void)
+{
+    static const RGBLedPattern pat = {
+        32, // Number of valid entries.
 
-		//marcus@Werkstaetiun:/media/marcus/WESTERNDIGI/dev_threedee/MCU_examples/RGB_rave$ lua graphics/colorgen.lua
+        //marcus@Werkstaetiun:/media/marcus/WESTERNDIGI/dev_threedee/MCU_examples/RGB_rave$ lua graphics/colorgen.lua
 
-		// Red
-		{128, 103,  79,  57,  38,  22,  11,   3,   1,   3,  11,  22,  38,  57,  79, 103,
-		 128, 153, 177, 199, 218, 234, 245, 253, 255, 253, 245, 234, 218, 199, 177, 153},
+        // Red
+        {
+            128, 103,  79,  57,  38,  22,  11,   3,   1,   3,  11,  22,  38,  57,  79, 103,
+            128, 153, 177, 199, 218, 234, 245, 253, 255, 253, 245, 234, 218, 199, 177, 153
+        },
 
-		// Green
-		{238, 248, 254, 255, 251, 242, 229, 212, 192, 169, 145, 120,  95,  72,  51,  33,
-		  18,   8,   2,   1,   5,  14,  27,  44,  65,  87, 111, 136, 161, 184, 205, 223},
+        // Green
+        {
+            238, 248, 254, 255, 251, 242, 229, 212, 192, 169, 145, 120,  95,  72,  51,  33,
+            18,   8,   2,   1,   5,  14,  27,  44,  65,  87, 111, 136, 161, 184, 205, 223
+        },
 
-		// Blue
-		{ 18,  33,  51,  72,  95, 120, 145, 169, 192, 212, 229, 242, 251, 255, 254, 248,
-		 238, 223, 205, 184, 161, 136, 111,  87,  64,  44,  27,  14,   5,   1,   2,   8},
-	};
+        // Blue
+        {
+            18,  33,  51,  72,  95, 120, 145, 169, 192, 212, 229, 242, 251, 255, 254, 248,
+            238, 223, 205, 184, 161, 136, 111,  87,  64,  44,  27,  14,   5,   1,   2,   8
+        },
+    };
 
-	if (ptmsysmInit() < 0)
-		return -1;
-	ptmsysmSetInfoLedPattern(&pat);
-	ptmsysmExit();
-	if (logEnabled)	LogFM("Main.RainbowLED", "Rainbow LED is on");
-	return 0;
+    if (ptmsysmInit() < 0) {
+        return -1;
+    }
+    ptmsysmSetInfoLedPattern(&pat);
+    ptmsysmExit();
+    if (logEnabled) {
+        LogFM("Main.RainbowLED", "Rainbow LED is on");
+    }
+    return 0;
 }
 
 /**
  * Set a user led color for notification LED
  * @return 0 on success; non-zero on error.
  */
-static int PergameLed(void) {
-	RGBLedPattern pattern;
-	pattern.ani = 32;	// Need to be 32 in order to be it constant
+static int PergameLed(void)
+{
+    RGBLedPattern pattern;
+    pattern.ani = 32;   // Need to be 32 in order to be it constant
 
-	// Set the color values to a single RGB value.
-	memset(&pattern.r, (u8)RGB[0], sizeof(pattern.r));
-	memset(&pattern.g, (u8)RGB[1], sizeof(pattern.g));
-	memset(&pattern.b, (u8)RGB[2], sizeof(pattern.b));
+    // Set the color values to a single RGB value.
+    memset(&pattern.r, (u8)RGB[0], sizeof(pattern.r));
+    memset(&pattern.g, (u8)RGB[1], sizeof(pattern.g));
+    memset(&pattern.b, (u8)RGB[2], sizeof(pattern.b));
 
-	if (ptmsysmInit() < 0)
-		return -1;
-	ptmsysmSetInfoLedPattern(&pattern);
-	ptmsysmExit();
-	return 0;
+    if (ptmsysmInit() < 0) {
+        return -1;
+    }
+    ptmsysmSetInfoLedPattern(&pattern);
+    ptmsysmExit();
+    return 0;
 }
 
-static void ChangeBNRIconNo(void) {
-	// Get the bnriconnum relative to the current page.
-	const int idx = bnriconnum - (pagenum * 20);
-	if (idx >= 0 && idx < 20) {
-		// Selected banner icon is on the current page.
-		bnricontexnum = bnricontex[idx];
-	}
+static void ChangeBNRIconNo(void)
+{
+    // Get the bnriconnum relative to the current page.
+    const int idx = bnriconnum - (pagenum * 20);
+    if (idx >= 0 && idx < 20) {
+        // Selected banner icon is on the current page.
+        bnricontexnum = bnricontex[idx];
+    }
 }
 
-static void ChangeBoxArtNo(void) {
-	// Get the boxartnum relative to the current page.
-	const int idx = boxartnum - (pagenum * 20);
-	if (idx >= 0 && idx < 20) {
-		// Selected boxart is on the current page.
-		// NOTE: Only 6 slots for boxart.
-		boxarttexnum = boxarttex[idx % 6];
-	}
+static void ChangeBoxArtNo(void)
+{
+    // Get the boxartnum relative to the current page.
+    const int idx = boxartnum - (pagenum * 20);
+    if (idx >= 0 && idx < 20) {
+        // Selected boxart is on the current page.
+        // NOTE: Only 6 slots for boxart.
+        boxarttexnum = boxarttex[idx % 6];
+    }
 }
 
 /**
  * Store a boxart path.
  * @param path Boxart path. (will be strdup()'d)
  */
-static void StoreBoxArtPath(const char *path) {
-	// Get the boxartnum relative to the current page.
-	const int idx = boxartnum - (pagenum * 20);
-	if (idx >= 0 && idx < 20) {
-		// Selected boxart is on the current page.
-		free(boxartpath[idx]);
-		boxartpath[idx] = strdup(path);
-	} else {
-		free(boxartpath[20]);
-		boxartpath[20] = strdup("romfs:/graphics/blank_128x115.png");
-	}
+static void StoreBoxArtPath(const char* path)
+{
+    // Get the boxartnum relative to the current page.
+    const int idx = boxartnum - (pagenum * 20);
+    if (idx >= 0 && idx < 20) {
+        // Selected boxart is on the current page.
+        free(boxartpath[idx]);
+        boxartpath[idx] = strdup(path);
+    } else {
+        free(boxartpath[20]);
+        boxartpath[20] = strdup("romfs:/graphics/blank_128x115.png");
+    }
 }
 
 /**
  * Load a banner icon at the current bnriconnum.
  * @param filename Banner filename, or NULL for notextbanner.
  */
-static void LoadBNRIcon(const char *filename) {
-	// Get the bnriconnum relative to the current page.
-	const int idx = bnriconnum - (pagenum * 20);
-	if (idx >= 0 && idx < 20) {
-		// Selected bnriconnum is on the current page.
-		sf2d_free_texture(bnricontex[idx]);
-		bnricontex[idx] = NULL;
+static void LoadBNRIcon(const char* filename)
+{
+    // Get the bnriconnum relative to the current page.
+    const int idx = bnriconnum - (pagenum * 20);
+    if (idx >= 0 && idx < 20) {
+        // Selected bnriconnum is on the current page.
+        sf2d_free_texture(bnricontex[idx]);
+        bnricontex[idx] = NULL;
 
-		if (!filename) {
-			filename = "romfs:/notextbanner";
-		}
-		FILE *f_bnr = fopen(filename, "rb");
-		if (!f_bnr) {
-			filename = "romfs:/notextbanner";
-			f_bnr = fopen(filename, "rb");
-		}
+        if (!filename) {
+            filename = "romfs:/notextbanner";
+        }
+        FILE* f_bnr = fopen(filename, "rb");
+        if (!f_bnr) {
+            filename = "romfs:/notextbanner";
+            f_bnr = fopen(filename, "rb");
+        }
 
-		bnricontex[idx] = grabIcon(f_bnr);
-		fclose(f_bnr);
-	}
+        bnricontex[idx] = grabIcon(f_bnr);
+        fclose(f_bnr);
+    }
 }
 
 /**
  * Load a banner icon at the current cursorPosition.
  * @param filename Banner filename, or NULL for notextbanner.
  */
-static void LoadBNRIcon_R4Theme(const char *filename) {
-	sf2d_free_texture(bnricontex[0]);
-	bnricontex[0] = NULL;
+static void LoadBNRIcon_R4Theme(const char* filename)
+{
+    sf2d_free_texture(bnricontex[0]);
+    bnricontex[0] = NULL;
 
-	if (!filename) {
-		filename = "romfs:/notextbanner";
-	}
-	FILE *f_bnr = fopen(filename, "rb");
-	if (!f_bnr) {
-		filename = "romfs:/notextbanner";
-		f_bnr = fopen(filename, "rb");
-	}
+    if (!filename) {
+        filename = "romfs:/notextbanner";
+    }
+    FILE* f_bnr = fopen(filename, "rb");
+    if (!f_bnr) {
+        filename = "romfs:/notextbanner";
+        f_bnr = fopen(filename, "rb");
+    }
 
-	bnricontex[0] = grabIcon(f_bnr);
-	fclose(f_bnr);
+    bnricontex[0] = grabIcon(f_bnr);
+    fclose(f_bnr);
 }
 
-static void LoadBoxArt(void) {
-	// Get the boxartnum relative to the current page.
-	const int idx = boxartnum - (pagenum * 20);
-	if (idx >= 0 && idx < 21) {
-		// Selected boxart is on the current page.
-		// NOTE: Only 6 slots for boxart.
-		sf2d_free_texture(boxarttex[idx % 6]);
-		const char *path = (boxartpath[idx] ? boxartpath[idx] : "romfs:/graphics/blank_128x115.png");
-		boxarttex[idx % 6] = sfil_load_PNG_file(path, SF2D_PLACE_RAM); // Box art
-	}
+static void LoadBoxArt(void)
+{
+    // Get the boxartnum relative to the current page.
+    const int idx = boxartnum - (pagenum * 20);
+    if (idx >= 0 && idx < 21) {
+        // Selected boxart is on the current page.
+        // NOTE: Only 6 slots for boxart.
+        sf2d_free_texture(boxarttex[idx % 6]);
+        const char* path = (boxartpath[idx] ? boxartpath[idx] : "romfs:/graphics/blank_128x115.png");
+        boxarttex[idx % 6] = sfil_load_PNG_file(path, SF2D_PLACE_RAM); // Box art
+    }
 }
 
-static void LoadBoxArt_WoodTheme(const int idx) {
-	// Selected boxart is on the current page.
-	sf2d_free_texture(boxarttex[0]);
-	const char *path = (boxartpath[idx] ? boxartpath[idx] : "romfs:/graphics/blank_128x115.png");
-	boxarttex[0] = sfil_load_PNG_file(path, SF2D_PLACE_RAM); // Box art
+static void LoadBoxArt_WoodTheme(const int idx)
+{
+    // Selected boxart is on the current page.
+    sf2d_free_texture(boxarttex[0]);
+    const char* path = (boxartpath[idx] ? boxartpath[idx] : "romfs:/graphics/blank_128x115.png");
+    boxarttex[0] = sfil_load_PNG_file(path, SF2D_PLACE_RAM); // Box art
 }
 
 /**
@@ -638,19 +665,21 @@ static void LoadBoxArt_WoodTheme(const int idx) {
  */
 static void LoadBootstrapConfig(void)
 {
-	switch (bootstrapini.GetInt(bootstrapini_ndsbootstrap, bootstrapini_debug, -1)) {
-		case 1:
-			settings.twl.console = 2;
-			break;
-		case 0:
-		default:
-			settings.twl.console = 1;
-			break;
-		case -1:
-			settings.twl.console = 0;
-			break;
-	}
-	if (logEnabled)	LogFM("Main.LoadBootstrapConfig", "Bootstrap configuration loaded successfully");
+    switch (bootstrapini.GetInt(bootstrapini_ndsbootstrap, bootstrapini_debug, -1)) {
+        case 1:
+            settings.twl.console = 2;
+            break;
+        case 0:
+        default:
+            settings.twl.console = 1;
+            break;
+        case -1:
+            settings.twl.console = 0;
+            break;
+    }
+    if (logEnabled) {
+        LogFM("Main.LoadBootstrapConfig", "Bootstrap configuration loaded successfully");
+    }
 }
 
 /**
@@ -658,42 +687,42 @@ static void LoadBootstrapConfig(void)
  */
 static void SaveBootstrapConfig(void)
 {
-	if (applaunchon) {
-		// Set ROM path if ROM is selected
-		if (!settings.twl.launchslot1) {
-			SetMPUSettings();
-			bootstrapini.SetString(bootstrapini_ndsbootstrap, bootstrapini_ndspath, fat+settings.ui.romfolder+slashchar+rom);
-			bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_mpuregion, settings.twl.mpuregion);
-			bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_mpusize, settings.twl.mpusize);
-			bootstrapini.SetString(bootstrapini_ndsbootstrap, bootstrapini_bootstrappath, bootstrapPath);
-			if (gbarunnervalue == 0) {
-				bootstrapini.SetString(bootstrapini_ndsbootstrap, bootstrapini_savpath, fat+settings.ui.romfolder+slashchar+sav);
-				char path[256];
-				snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), sav.c_str());
-				if (access(path, F_OK) == -1) {
-					// Create a save file if it doesn't exist
-					CreateGameSave(path);
-				}
-			}
-		}
-	}
-	bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_boostcpu, settings.twl.cpuspeed);
+    if (applaunchon) {
+        // Set ROM path if ROM is selected
+        if (!settings.twl.launchslot1) {
+            SetMPUSettings();
+            bootstrapini.SetString(bootstrapini_ndsbootstrap, bootstrapini_ndspath, fat + settings.ui.romfolder + slashchar + rom);
+            bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_mpuregion, settings.twl.mpuregion);
+            bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_mpusize, settings.twl.mpusize);
+            bootstrapini.SetString(bootstrapini_ndsbootstrap, bootstrapini_bootstrappath, bootstrapPath);
+            if (gbarunnervalue == 0) {
+                bootstrapini.SetString(bootstrapini_ndsbootstrap, bootstrapini_savpath, fat + settings.ui.romfolder + slashchar + sav);
+                char path[256];
+                snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), sav.c_str());
+                if (access(path, F_OK) == -1) {
+                    // Create a save file if it doesn't exist
+                    CreateGameSave(path);
+                }
+            }
+        }
+    }
+    bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_boostcpu, settings.twl.cpuspeed);
 
-	// TODO: Change the default to 0?
-	switch (settings.twl.console) {
-		case 0:
-			bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_debug, -1);
-			break;
-		case 1:
-		default:
-			bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_debug, 0);
-			break;
-		case 2:
-			bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_debug, 1);
-			break;
-	}
+    // TODO: Change the default to 0?
+    switch (settings.twl.console) {
+        case 0:
+            bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_debug, -1);
+            break;
+        case 1:
+        default:
+            bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_debug, 0);
+            break;
+        case 2:
+            bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_debug, 1);
+            break;
+    }
 
-	bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
+    bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
 }
 
 /**
@@ -701,34 +730,42 @@ static void SaveBootstrapConfig(void)
  */
 static void LoadPerGameSettings(void)
 {
-	std::string inifilename;
-	if (!settings.twl.forwarder)
-		inifilename = ReplaceAll(rom, ".nds", ".ini");
-	else {
-		char path[256];
-		snprintf(path, sizeof(path), "%s/%s", "flashcard", rom);
-		inifilename = path;
-	}
-	char path[256];
-	snprintf(path, sizeof(path), "sdmc:/_nds/twloader/gamesettings/%s", inifilename.c_str());
-	CIniFile gamesettingsini(path);
-	settings.pergame.cpuspeed = gamesettingsini.GetInt("GAME-SETTINGS", "TWL_CLOCK", -1);
-	settings.pergame.extvram = gamesettingsini.GetInt("GAME-SETTINGS", "TWL_VRAM", -1);
-	settings.pergame.lockarm9scfgext = gamesettingsini.GetInt("GAME-SETTINGS", bootstrapini_lockarm9scfgext, -1);
-	settings.pergame.red = gamesettingsini.GetInt("GAME-SETTINGS", "LED_RED", -1);
-	settings.pergame.green = gamesettingsini.GetInt("GAME-SETTINGS", "LED_GREEN", -1);
-	settings.pergame.blue = gamesettingsini.GetInt("GAME-SETTINGS", "LED_BLUE", -1);
+    std::string inifilename;
+    if (!settings.twl.forwarder) {
+        inifilename = ReplaceAll(rom, ".nds", ".ini");
+    } else {
+        char path[256];
+        snprintf(path, sizeof(path), "%s/%s", "flashcard", rom);
+        inifilename = path;
+    }
+    char path[256];
+    snprintf(path, sizeof(path), "sdmc:/_nds/twloader/gamesettings/%s", inifilename.c_str());
+    CIniFile gamesettingsini(path);
+    settings.pergame.cpuspeed = gamesettingsini.GetInt("GAME-SETTINGS", "TWL_CLOCK", -1);
+    settings.pergame.extvram = gamesettingsini.GetInt("GAME-SETTINGS", "TWL_VRAM", -1);
+    settings.pergame.lockarm9scfgext = gamesettingsini.GetInt("GAME-SETTINGS", bootstrapini_lockarm9scfgext, -1);
+    settings.pergame.red = gamesettingsini.GetInt("GAME-SETTINGS", "LED_RED", -1);
+    settings.pergame.green = gamesettingsini.GetInt("GAME-SETTINGS", "LED_GREEN", -1);
+    settings.pergame.blue = gamesettingsini.GetInt("GAME-SETTINGS", "LED_BLUE", -1);
 
-	RGB[0] = settings.pergame.red;
-	RGB[1] = settings.pergame.green;
-	RGB[2] = settings.pergame.blue;
+    RGB[0] = settings.pergame.red;
+    RGB[1] = settings.pergame.green;
+    RGB[2] = settings.pergame.blue;
 
-	// In case if the .ini was manually edited
-	if(RGB[0] > 255) RGB[0] = 255;
-	if(RGB[1] > 255) RGB[1] = 255;
-	if(RGB[2] > 255) RGB[2] = 255;
-	
-	if (logEnabled)	LogFM("Main.LoadPerGameSettings", "Per-game settings loaded successfully");
+    // In case if the .ini was manually edited
+    if (RGB[0] > 255) {
+        RGB[0] = 255;
+    }
+    if (RGB[1] > 255) {
+        RGB[1] = 255;
+    }
+    if (RGB[2] > 255) {
+        RGB[2] = 255;
+    }
+
+    if (logEnabled) {
+        LogFM("Main.LoadPerGameSettings", "Per-game settings loaded successfully");
+    }
 }
 
 /**
@@ -736,25 +773,27 @@ static void LoadPerGameSettings(void)
  */
 static void SavePerGameSettings(void)
 {
-	std::string inifilename;
-	if (!settings.twl.forwarder)
-		inifilename = ReplaceAll(rom, ".nds", ".ini");
-	else {
-		char path[256];
-		snprintf(path, sizeof(path), "%s/%s", "flashcard", rom);
-		inifilename = path;
-	}
-	char path[256];
-	snprintf(path, sizeof(path), "sdmc:/_nds/twloader/gamesettings/%s", inifilename.c_str());
-	CIniFile gamesettingsini(path);
-	gamesettingsini.SetInt("GAME-SETTINGS", "TWL_CLOCK", settings.pergame.cpuspeed);
-	gamesettingsini.SetInt("GAME-SETTINGS", "TWL_VRAM", settings.pergame.extvram);
-	gamesettingsini.SetInt("GAME-SETTINGS", bootstrapini_lockarm9scfgext, settings.pergame.lockarm9scfgext);
-	gamesettingsini.SetInt("GAME-SETTINGS", "LED_RED", settings.pergame.red);
-	gamesettingsini.SetInt("GAME-SETTINGS", "LED_GREEN", settings.pergame.green);
-	gamesettingsini.SetInt("GAME-SETTINGS", "LED_BLUE", settings.pergame.blue);
-	gamesettingsini.SaveIniFile(path);
-	if (logEnabled)	LogFM("Main.SavePerGameSettings", "Per-game settings saved successfully");
+    std::string inifilename;
+    if (!settings.twl.forwarder) {
+        inifilename = ReplaceAll(rom, ".nds", ".ini");
+    } else {
+        char path[256];
+        snprintf(path, sizeof(path), "%s/%s", "flashcard", rom);
+        inifilename = path;
+    }
+    char path[256];
+    snprintf(path, sizeof(path), "sdmc:/_nds/twloader/gamesettings/%s", inifilename.c_str());
+    CIniFile gamesettingsini(path);
+    gamesettingsini.SetInt("GAME-SETTINGS", "TWL_CLOCK", settings.pergame.cpuspeed);
+    gamesettingsini.SetInt("GAME-SETTINGS", "TWL_VRAM", settings.pergame.extvram);
+    gamesettingsini.SetInt("GAME-SETTINGS", bootstrapini_lockarm9scfgext, settings.pergame.lockarm9scfgext);
+    gamesettingsini.SetInt("GAME-SETTINGS", "LED_RED", settings.pergame.red);
+    gamesettingsini.SetInt("GAME-SETTINGS", "LED_GREEN", settings.pergame.green);
+    gamesettingsini.SetInt("GAME-SETTINGS", "LED_BLUE", settings.pergame.blue);
+    gamesettingsini.SaveIniFile(path);
+    if (logEnabled) {
+        LogFM("Main.SavePerGameSettings", "Per-game settings saved successfully");
+    }
 }
 
 /**
@@ -762,26 +801,26 @@ static void SavePerGameSettings(void)
  */
 static void SetPerGameSettings(void)
 {
-	std::string inifilename = "sd:/_nds/twloader/gamesettings/null";
-	if (!settings.twl.launchslot1) {
-		inifilename = ReplaceAll(rom, ".nds", ".ini");
-		char path[256];
-		snprintf(path, sizeof(path), "%s/%s", "sd:/_nds/twloader/gamesettings", inifilename.c_str());
-		inifilename = path;
-	} else {
-		if (settings.twl.forwarder) {
-			char path[256];
-			snprintf(path, sizeof(path), "%s/%s", "sd:/_nds/twloader/gamesettings/flashcard", rom);
-			inifilename = path;
-		}
-	}
-	CIniFile settingsini("sdmc:/_nds/twloader/settings.ini");
-	settingsini.SetString("TWL-MODE", "GAMESETTINGS_PATH", inifilename);
-	settingsini.SaveIniFile("sdmc:/_nds/twloader/settings.ini");
+    std::string inifilename = "sd:/_nds/twloader/gamesettings/null";
+    if (!settings.twl.launchslot1) {
+        inifilename = ReplaceAll(rom, ".nds", ".ini");
+        char path[256];
+        snprintf(path, sizeof(path), "%s/%s", "sd:/_nds/twloader/gamesettings", inifilename.c_str());
+        inifilename = path;
+    } else {
+        if (settings.twl.forwarder) {
+            char path[256];
+            snprintf(path, sizeof(path), "%s/%s", "sd:/_nds/twloader/gamesettings/flashcard", rom);
+            inifilename = path;
+        }
+    }
+    CIniFile settingsini("sdmc:/_nds/twloader/settings.ini");
+    settingsini.SetString("TWL-MODE", "GAMESETTINGS_PATH", inifilename);
+    settingsini.SaveIniFile("sdmc:/_nds/twloader/settings.ini");
 }
- 
+
 bool dspfirmfound = false;
-static sf2d_texture *voltex[6] = { };
+static sf2d_texture* voltex[6] = { };
 
 /**
  * Draw the volume slider.
@@ -789,32 +828,32 @@ static sf2d_texture *voltex[6] = { };
  * The Dsi has 8 positions for volume and the 3ds has 64
  * Remap volume to simulate the 8 positions
  */
-void draw_volume_slider(sf2d_texture *texarray[])
+void draw_volume_slider(sf2d_texture* texarray[])
 {
-	u8 volumeLevel = 0;
-	if (!dspfirmfound) {
-		// No DSP Firm.
-		sf2d_draw_texture(texarray[5], 5, 2);
-	} else if (R_SUCCEEDED(HIDUSER_GetSoundVolume(&volumeLevel))) {
-		u8 voltex_id = 0;
-		if (volumeLevel == 0) {
-			voltex_id = 0;	// 3ds 0, dsi 0 = volume0 texture
-		} else if (volumeLevel <= 21) {
-			voltex_id = 1;	// 3ds  1-21, dsi 1,2 = volume1 texture
-		} else if (volumeLevel <= 42) {
-			voltex_id = 2;	// 3ds 22-42, dsi 3,4 = volume2 texture
-		} else if (volumeLevel <= 62) {
-			voltex_id = 3;	// 3ds 43-62, dsi 5,6 = volume3 texture
-		} else if (volumeLevel == 63) {
-			voltex_id = 4;	// 3ds 63, dsi 8  = volume4 texture
-		}
-		sf2d_draw_texture(texarray[voltex_id], 5, 2);
-	}
+    u8 volumeLevel = 0;
+    if (!dspfirmfound) {
+        // No DSP Firm.
+        sf2d_draw_texture(texarray[5], 5, 2);
+    } else if (R_SUCCEEDED(HIDUSER_GetSoundVolume(&volumeLevel))) {
+        u8 voltex_id = 0;
+        if (volumeLevel == 0) {
+            voltex_id = 0;  // 3ds 0, dsi 0 = volume0 texture
+        } else if (volumeLevel <= 21) {
+            voltex_id = 1;  // 3ds  1-21, dsi 1,2 = volume1 texture
+        } else if (volumeLevel <= 42) {
+            voltex_id = 2;  // 3ds 22-42, dsi 3,4 = volume2 texture
+        } else if (volumeLevel <= 62) {
+            voltex_id = 3;  // 3ds 43-62, dsi 5,6 = volume3 texture
+        } else if (volumeLevel == 63) {
+            voltex_id = 4;  // 3ds 63, dsi 8  = volume4 texture
+        }
+        sf2d_draw_texture(texarray[voltex_id], 5, 2);
+    }
 }
 
-sf2d_texture *batteryIcon = NULL;		// Current battery level icon.
-static sf2d_texture *batterychrgtex = NULL;	// Fully charged.
-static sf2d_texture *batterytex[6] = { };	// Battery levels.
+sf2d_texture* batteryIcon = NULL;       // Current battery level icon.
+static sf2d_texture* batterychrgtex = NULL; // Fully charged.
+static sf2d_texture* batterytex[6] = { };   // Battery levels.
 
 /**
  * Update the battery level icon.
@@ -822,45 +861,45 @@ static sf2d_texture *batterytex[6] = { };	// Battery levels.
  * @param texarray Texture array for other levels. (batterytex or setbatterytex)
  * The global variable batteryIcon will be updated.
  */
-void update_battery_level(sf2d_texture *texchrg, sf2d_texture *texarray[])
+void update_battery_level(sf2d_texture* texchrg, sf2d_texture* texarray[])
 {
-	u8 batteryChargeState = 0;
-	u8 batteryLevel = 0;
-	if (R_SUCCEEDED(PTMU_GetBatteryChargeState(&batteryChargeState)) && batteryChargeState) {
-		batteryIcon = texchrg;
-	} else if (R_SUCCEEDED(PTMU_GetBatteryLevel(&batteryLevel))) {
-		switch (batteryLevel) {
-			case 5: {
-				// NOTE: PTMUX_GetAdapterState should be moved into
-				// ctrulib without the 'X' prefix.
-				u8 acAdapter = 0;
-				if (R_SUCCEEDED(PTMUX_GetAdapterState(&acAdapter)) && acAdapter) {
-					batteryIcon = texarray[5];
-				} else {
-					batteryIcon = texarray[4];
-				}
-				break;
-			}
-			case 4:
-				batteryIcon = texarray[4];
-				break;
-			case 3:
-				batteryIcon = texarray[3];
-				break;
-			case 2:
-				batteryIcon = texarray[2];
-				break;
-			case 1:
-			default:
-				batteryIcon = texarray[1];
-				break;
-		}
-	}
+    u8 batteryChargeState = 0;
+    u8 batteryLevel = 0;
+    if (R_SUCCEEDED(PTMU_GetBatteryChargeState(&batteryChargeState)) && batteryChargeState) {
+        batteryIcon = texchrg;
+    } else if (R_SUCCEEDED(PTMU_GetBatteryLevel(&batteryLevel))) {
+        switch (batteryLevel) {
+            case 5: {
+                // NOTE: PTMUX_GetAdapterState should be moved into
+                // ctrulib without the 'X' prefix.
+                u8 acAdapter = 0;
+                if (R_SUCCEEDED(PTMUX_GetAdapterState(&acAdapter)) && acAdapter) {
+                    batteryIcon = texarray[5];
+                } else {
+                    batteryIcon = texarray[4];
+                }
+                break;
+            }
+            case 4:
+                batteryIcon = texarray[4];
+                break;
+            case 3:
+                batteryIcon = texarray[3];
+                break;
+            case 2:
+                batteryIcon = texarray[2];
+                break;
+            case 1:
+            default:
+                batteryIcon = texarray[1];
+                break;
+        }
+    }
 
-	if (!batteryIcon) {
-		// No battery icon...
-		batteryIcon = texarray[0];
-	}
+    if (!batteryIcon) {
+        // No battery icon...
+        batteryIcon = texarray[0];
+    }
 }
 
 /**
@@ -870,41 +909,41 @@ void update_battery_level(sf2d_texture *texchrg, sf2d_texture *texarray[])
  * @param files Vector to append files to.
  * @return Number of files matched. (-1 if the directory could not be opened.)
  */
-static int scan_dir_for_files(const char *path, const char *ext, std::vector<std::string>& files)
+static int scan_dir_for_files(const char* path, const char* ext, std::vector<std::string>& files)
 {
-	files.clear();
+    files.clear();
 
-	DIR *dir = opendir(path);
-	if (!dir) {
-		// Unable to open the directory.
-		return -1;
-	}
+    DIR* dir = opendir(path);
+    if (!dir) {
+        // Unable to open the directory.
+        return -1;
+    }
 
-	struct dirent *ent;
-	const int extlen = (ext ? strlen(ext) : 0);
-	while ((ent = readdir(dir)) != NULL) {
-		std::string fname = (ent->d_name);
-		if (extlen > 0) {
-			// Check the file extension. (TODO needs verification)
-			size_t lastdotpos = fname.find_last_of('.');
-			if (lastdotpos == string::npos || lastdotpos + extlen > fname.size()) {
-				// Invalid file extension.
-				continue;
-			}
-			if (strcasecmp(&ent->d_name[lastdotpos], ext) != 0) {
-				// Incorrect file extension.
-				continue;
-			}
-		}
+    struct dirent* ent;
+    const int extlen = (ext ? strlen(ext) : 0);
+    while ((ent = readdir(dir)) != NULL) {
+        std::string fname = (ent->d_name);
+        if (extlen > 0) {
+            // Check the file extension. (TODO needs verification)
+            size_t lastdotpos = fname.find_last_of('.');
+            if (lastdotpos == string::npos || lastdotpos + extlen > fname.size()) {
+                // Invalid file extension.
+                continue;
+            }
+            if (strcasecmp(&ent->d_name[lastdotpos], ext) != 0) {
+                // Incorrect file extension.
+                continue;
+            }
+        }
 
-		// Append the file.
-		files.push_back(fname);
-	}
-	closedir(dir);
+        // Append the file.
+        files.push_back(fname);
+    }
+    closedir(dir);
 
-	// Sort the vector and we're done.
-	std::sort(files.begin(), files.end());
-	return (int)files.size();
+    // Sort the vector and we're done.
+    std::sort(files.begin(), files.end());
+    return (int)files.size();
 }
 
 // Files
@@ -916,46 +955,46 @@ vector<string> matching_files;
 
 // APT hook for "returned from HOME menu".
 static aptHookCookie rfhm_cookie;
-static void rfhm_callback(APT_HookType hook, void *param)
+static void rfhm_callback(APT_HookType hook, void* param)
 {
-	if (hook == APTHOOK_ONRESTORE) {
-		// param == pointer to bannertextloaded
-		// TODO: Only if cursorPosition == -1.
-		*((bool*)param) = false;
-		gamecardPoll(true);
-	}
+    if (hook == APTHOOK_ONRESTORE) {
+        // param == pointer to bannertextloaded
+        // TODO: Only if cursorPosition == -1.
+        *((bool*)param) = false;
+        gamecardPoll(true);
+    }
 }
 
 // Cartridge textures.
-static sf2d_texture *cartnulltex = NULL;
-static sf2d_texture *cartntrtex = NULL;
-static sf2d_texture *carttwltex = NULL;
-static sf2d_texture *cartctrtex = NULL;
+static sf2d_texture* cartnulltex = NULL;
+static sf2d_texture* cartntrtex = NULL;
+static sf2d_texture* carttwltex = NULL;
+static sf2d_texture* cartctrtex = NULL;
 
 /**
  * Determine the 3DS cartridge texture to use for Slot-1.
  * @return Cartridge texture.
  */
-static inline sf2d_texture *carttex(void)
+static inline sf2d_texture* carttex(void)
 {
-	// TODO: 3DS cartridges.
-	switch (gamecardGetType()) {
-		case CARD_TYPE_UNKNOWN:
-		default:
-			return cartnulltex;
+    // TODO: 3DS cartridges.
+    switch (gamecardGetType()) {
+        case CARD_TYPE_UNKNOWN:
+        default:
+            return cartnulltex;
 
-		case CARD_TYPE_NTR:
-		case CARD_TYPE_TWL_ENH:
-			return cartntrtex;
+        case CARD_TYPE_NTR:
+        case CARD_TYPE_TWL_ENH:
+            return cartntrtex;
 
-		case CARD_TYPE_TWL_ONLY:
-			return carttwltex;
-			break;
-			
-		case CARD_TYPE_CTR:
-			return cartctrtex;
-			break;
-	}
+        case CARD_TYPE_TWL_ONLY:
+            return carttwltex;
+            break;
+
+        case CARD_TYPE_CTR:
+            return cartctrtex;
+            break;
+    }
 }
 
 /**
@@ -963,47 +1002,51 @@ static inline sf2d_texture *carttex(void)
  */
 static void loadSlot1BoxArt(void)
 {
-	// Previously loaded boxart game ID.
-	static u32 prev_gameID_u32 = 0;
+    // Previously loaded boxart game ID.
+    static u32 prev_gameID_u32 = 0;
 
-	// Get the current game ID.
-	u32 gameID_u32 = gamecardGetGameID_u32();
-	if (gameID_u32 == prev_gameID_u32) {
-		// No change in the game ID.
-		if (!slot1boxarttex) {
-			// No boxart loaded yet.
-			// Load boxart_null.png.
-			slot1boxarttex = sfil_load_PNG_file("romfs:/graphics/boxart_null.png", SF2D_PLACE_RAM);
-		}
-		return;
-	}
-	prev_gameID_u32 = gameID_u32;
+    // Get the current game ID.
+    u32 gameID_u32 = gamecardGetGameID_u32();
+    if (gameID_u32 == prev_gameID_u32) {
+        // No change in the game ID.
+        if (!slot1boxarttex) {
+            // No boxart loaded yet.
+            // Load boxart_null.png.
+            slot1boxarttex = sfil_load_PNG_file("romfs:/graphics/boxart_null.png", SF2D_PLACE_RAM);
+        }
+        return;
+    }
+    prev_gameID_u32 = gameID_u32;
 
-	sf2d_texture *new_tex;
-	const char *gameID = gamecardGetGameID();
-	if (gameID) {
-		if (checkWifiStatus()) {
-			downloadSlot1BoxArt(gameID);
-		}
-		char path[256];
-		// example: ASME.png
-		if (logEnabled)	LogFMA("Main", "Loading Slot-1 box art", gameID);
-		snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, gameID);
-		if (access(path, F_OK) != -1) {
-			new_tex = sfil_load_PNG_file(path, SF2D_PLACE_RAM);
-		} else {
-			new_tex = sfil_load_PNG_file("romfs:/graphics/boxart_unknown.png", SF2D_PLACE_RAM);
-		}
-		if (logEnabled)	LogFMA("Main", "Done loading Slot-1 box art", gameID);
-	} else {
-		// No cartridge, or unrecognized cartridge.
-		new_tex = sfil_load_PNG_file("romfs:/graphics/boxart_null.png", SF2D_PLACE_RAM);
-	}
+    sf2d_texture* new_tex;
+    const char* gameID = gamecardGetGameID();
+    if (gameID) {
+        if (checkWifiStatus()) {
+            downloadSlot1BoxArt(gameID);
+        }
+        char path[256];
+        // example: ASME.png
+        if (logEnabled) {
+            LogFMA("Main", "Loading Slot-1 box art", gameID);
+        }
+        snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, gameID);
+        if (access(path, F_OK) != -1) {
+            new_tex = sfil_load_PNG_file(path, SF2D_PLACE_RAM);
+        } else {
+            new_tex = sfil_load_PNG_file("romfs:/graphics/boxart_unknown.png", SF2D_PLACE_RAM);
+        }
+        if (logEnabled) {
+            LogFMA("Main", "Done loading Slot-1 box art", gameID);
+        }
+    } else {
+        // No cartridge, or unrecognized cartridge.
+        new_tex = sfil_load_PNG_file("romfs:/graphics/boxart_null.png", SF2D_PLACE_RAM);
+    }
 
-	// Replace slot1boxarttex with the new boxart.
-	sf2d_texture *old_tex = slot1boxarttex;
-	slot1boxarttex = new_tex;
-	sf2d_free_texture(old_tex);
+    // Replace slot1boxarttex with the new boxart.
+    sf2d_texture* old_tex = slot1boxarttex;
+    slot1boxarttex = new_tex;
+    sf2d_free_texture(old_tex);
 }
 
 /**
@@ -1011,29 +1054,29 @@ static void loadSlot1BoxArt(void)
  */
 static void scanRomDirectories(void)
 {
-	char path[256];
+    char path[256];
 
-	// Use default directory if none is specified
-	if (settings.ui.romfolder.empty()) {
-		settings.ui.romfolder = "roms/nds";
-	}
-	snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.romfolder.c_str());
-	// Make sure the directory exists.
-	rmkdir(path, 0777);
+    // Use default directory if none is specified
+    if (settings.ui.romfolder.empty()) {
+        settings.ui.romfolder = "roms/nds";
+    }
+    snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.romfolder.c_str());
+    // Make sure the directory exists.
+    rmkdir(path, 0777);
 
-	// Scan the ROMs directory for ".nds" files.
-	scan_dir_for_files(path, ".nds", files);
-	
-	// Use default directory if none is specified
-	if (settings.ui.fcromfolder.empty()) {
-		settings.ui.fcromfolder = "roms/flashcard/nds";
-	}
-	snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.fcromfolder.c_str());
-	// Make sure the directory exists.
-	rmkdir(path, 0777);
+    // Scan the ROMs directory for ".nds" files.
+    scan_dir_for_files(path, ".nds", files);
 
-	// Scan the flashcard directory for configuration files.
-	scan_dir_for_files(path, ".ini", fcfiles);
+    // Use default directory if none is specified
+    if (settings.ui.fcromfolder.empty()) {
+        settings.ui.fcromfolder = "roms/flashcard/nds";
+    }
+    snprintf(path, sizeof(path), "sdmc:/%s", settings.ui.fcromfolder.c_str());
+    // Make sure the directory exists.
+    rmkdir(path, 0777);
+
+    // Scan the flashcard directory for configuration files.
+    scan_dir_for_files(path, ".ini", fcfiles);
 }
 
 // Cursor position.
@@ -1049,169 +1092,169 @@ static int gamesettings_cursorPosition = 0;
  */
 static void drawMenuDialogBox(void)
 {
-	sf2d_draw_rectangle(0, 0, 320, 240, RGBA8(0, 0, 0, menudbox_bgalpha)); // Fade in/out effect
-	sf2d_draw_texture(dialogboxtex, 0, menudbox_Ypos);
-	sf2d_draw_texture(dboxtex_buttonback, 233, menudbox_Ypos+193);
-	sftd_draw_wtext(font, 243, menudbox_Ypos+199, RGBA8(0, 0, 0, 255), 12, TR(STR_BACK));
-	if (menudboxmode == DBOX_MODE_SETTINGS) {
-		bnriconnum = cursorPosition;
-		ChangeBNRIconNo();
-		sf2d_draw_texture(dboxtex_iconbox, 23, menudbox_Ypos+23);
-		sf2d_draw_texture_part(bnricontexnum, 28, menudbox_Ypos+28, bnriconframenum*32, 0, 32, 32);
-		
-		if (cursorPosition >= 0) {
-			int y = 16, dy = 19;
-			// Print the banner text, center-aligned.
-			const size_t banner_lines = std::min(3U, romsel_gameline.size());
-			for (size_t i = 0; i < banner_lines; i++, y += dy) {
-				const int text_width = sftd_get_wtext_width(font_b, 16, romsel_gameline[i].c_str());
-				sftd_draw_wtext(font_b, 48+(264-text_width)/2, y+menudbox_Ypos, RGBA8(0, 0, 0, 255), 16, romsel_gameline[i].c_str());
-			}
-			sftd_draw_wtext(font, 16, 72+menudbox_Ypos, RGBA8(127, 127, 127, 255), 12, romsel_filename_w.c_str());
-		}
-		
-		const size_t file_count = (settings.twl.forwarder ? fcfiles.size() : files.size());
+    sf2d_draw_rectangle(0, 0, 320, 240, RGBA8(0, 0, 0, menudbox_bgalpha)); // Fade in/out effect
+    sf2d_draw_texture(dialogboxtex, 0, menudbox_Ypos);
+    sf2d_draw_texture(dboxtex_buttonback, 233, menudbox_Ypos + 193);
+    sftd_draw_wtext(font, 243, menudbox_Ypos + 199, RGBA8(0, 0, 0, 255), 12, TR(STR_BACK));
+    if (menudboxmode == DBOX_MODE_SETTINGS) {
+        bnriconnum = cursorPosition;
+        ChangeBNRIconNo();
+        sf2d_draw_texture(dboxtex_iconbox, 23, menudbox_Ypos + 23);
+        sf2d_draw_texture_part(bnricontexnum, 28, menudbox_Ypos + 28, bnriconframenum * 32, 0, 32, 32);
 
-		char romsel_counter1[16];
-		char romsel_counter2[16];
-		snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", storedcursorPosition+1);		
-		if(matching_files.size() == 0){
-			snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", file_count);
-		}else{
-			snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", matching_files.size());
-		}
-		
-		if (file_count < 100) {
-			sftd_draw_text(font, 16, 204+menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
-			sftd_draw_text(font, 35, 204+menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, "/");
-			sftd_draw_text(font, 40, 204+menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, romsel_counter2);
-		} else {
-			sftd_draw_text(font, 16, 204+menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
-			sftd_draw_text(font, 43, 204+menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, "/");
-			sftd_draw_text(font, 48, 204+menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, romsel_counter2);
-		}
-		
-		const struct {
-			int x;
-			int y;
-			const s8 *value;
-			const wchar_t *title;
-			const wchar_t *value_desc[2];	// 0 == off, 1 == on
-		} buttons[] = {
-			{ 23,  89, &settings.pergame.cpuspeed, TR(STR_START_ARM9_CPU_SPEED), {L"67 MHz (NTR)", L"133 MHz (TWL)"}},
-			{161,  89, &settings.pergame.extvram, TR(STR_START_VRAM_BOOST), {L"Off", L"On"}},
-			{ 23, 129, &settings.pergame.lockarm9scfgext, TR(STR_START_LOCK_ARM9_SCFG_EXT), {L"Off", L"On"}},
-			{161, 129, &settings.pergame.donor, TR(STR_START_SET_DONOR), {NULL, NULL}},
-			{ 23, 169, NULL, TR(STR_START_SET_LED), {NULL, NULL}},
-		};
-		
-		for (int i = (int)(sizeof(buttons)/sizeof(buttons[0]))-1; i >= 0; i--) {
-			if (gamesettings_cursorPosition == i) {
-				// Button is highlighted.
-				sf2d_draw_texture(dboxtex_button, buttons[i].x, menudbox_Ypos+buttons[i].y);
-			} else {
-				// Button is not highlighted. Darken the texture.
-				sf2d_draw_texture_blend(dboxtex_button, buttons[i].x, menudbox_Ypos+buttons[i].y, RGBA8(127, 127, 127, 255));
-			}
+        if (cursorPosition >= 0) {
+            int y = 16, dy = 19;
+            // Print the banner text, center-aligned.
+            const size_t banner_lines = std::min(3U, romsel_gameline.size());
+            for (size_t i = 0; i < banner_lines; i++, y += dy) {
+                const int text_width = sftd_get_wtext_width(font_b, 16, romsel_gameline[i].c_str());
+                sftd_draw_wtext(font_b, 48 + (264 - text_width) / 2, y + menudbox_Ypos, RGBA8(0, 0, 0, 255), 16, romsel_gameline[i].c_str());
+            }
+            sftd_draw_wtext(font, 16, 72 + menudbox_Ypos, RGBA8(127, 127, 127, 255), 12, romsel_filename_w.c_str());
+        }
 
-			const wchar_t *title = buttons[i].title;
-			const wchar_t *value_desc = TR(STR_START_DEFAULT);
-			if (i < 3) {
-				switch (*(buttons[i].value)) {
-					case -1:
-					default:
-						value_desc = TR(STR_START_DEFAULT);
-						break;
-					case 0:
-						value_desc = buttons[i].value_desc[0];
-						break;
-					case 1:
-						value_desc = buttons[i].value_desc[1];
-						break;
-				}
-			}
+        const size_t file_count = (settings.twl.forwarder ? fcfiles.size() : files.size());
 
-			// Determine the text height.
-			// NOTE: Button texture size is 132x34.
-			const int h = 32;
+        char romsel_counter1[16];
+        char romsel_counter2[16];
+        snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", storedcursorPosition + 1);
+        if (matching_files.size() == 0) {
+            snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", file_count);
+        } else {
+            snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", matching_files.size());
+        }
 
-			// Draw the title.
-			int y = menudbox_Ypos + buttons[i].y + ((34 - h) / 2);
-			int w = sftd_get_wtext_width(font, 12, title);
-			int x = ((132 - w) / 2) + buttons[i].x;
-			sftd_draw_wtext(font, x, y, RGBA8(0, 0, 0, 255), 12, title);
-			y += 16;
+        if (file_count < 100) {
+            sftd_draw_text(font, 16, 204 + menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
+            sftd_draw_text(font, 35, 204 + menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, "/");
+            sftd_draw_text(font, 40, 204 + menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, romsel_counter2);
+        } else {
+            sftd_draw_text(font, 16, 204 + menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
+            sftd_draw_text(font, 43, 204 + menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, "/");
+            sftd_draw_text(font, 48, 204 + menudbox_Ypos, RGBA8(0, 0, 0, 255), 12, romsel_counter2);
+        }
 
-			// Draw the value.
-			if (i < 3) {
-				w = sftd_get_wtext_width(font, 12, value_desc);
-				x = ((132 - w) / 2) + buttons[i].x;
-				sftd_draw_wtext(font, x, y, RGBA8(0, 0, 0, 255), 12, value_desc);
-			} else if (i == 4) {
-				// Show the RGB value.
-				char rgb_str[32];
-				snprintf(rgb_str, sizeof(rgb_str), "%d, %d, %d",
-					settings.pergame.red,
-					settings.pergame.green,
-					settings.pergame.blue);
-				w = sftd_get_text_width(font, 12, rgb_str);
-				x = ((132 - w) / 2) + buttons[i].x;
+        const struct {
+            int x;
+            int y;
+            const s8* value;
+            const wchar_t* title;
+            const wchar_t* value_desc[2];   // 0 == off, 1 == on
+        } buttons[] = {
+            { 23,  89, &settings.pergame.cpuspeed, TR(STR_START_ARM9_CPU_SPEED), {L"67 MHz (NTR)", L"133 MHz (TWL)"}},
+            {161,  89, &settings.pergame.extvram, TR(STR_START_VRAM_BOOST), {L"Off", L"On"}},
+            { 23, 129, &settings.pergame.lockarm9scfgext, TR(STR_START_LOCK_ARM9_SCFG_EXT), {L"Off", L"On"}},
+            {161, 129, &settings.pergame.donor, TR(STR_START_SET_DONOR), {NULL, NULL}},
+            { 23, 169, NULL, TR(STR_START_SET_LED), {NULL, NULL}},
+        };
 
-				// Print the RGB value using its color.
-				const u32 color = RGBA8(settings.pergame.red,
-					settings.pergame.green,
-					settings.pergame.blue, 255);
-				sftd_draw_text(font, x, y, color, 12, rgb_str);
-			}
-		}
-	} else {
-		// UI options.
-		const struct {
-			int x;
-			int y;
-			const bool *value;
-			const wchar_t *title;
-			const wchar_t *value_desc[2];	// 0 == off, 1 == on
-		} buttons[] = {
-			{ 23,  31, &settings.twl.forwarder, TR(STR_START_GAMELOCATION), {TR(STR_START_SD_CARD), TR(STR_START_FLASHCARD)}},
-			{161,  31, &settings.romselect.toplayout, NULL, {TR(STR_START_BOXART_ON), TR(STR_START_BOXART_OFF)}},
-			{ 23,  71, &is3DSX, TR(STR_START_START_GBARUNNER2), {NULL, NULL}},
-			{161,  71, &settings.ui.topborder, NULL, {TR(STR_START_TOP_BORDER_OFF), TR(STR_START_TOP_BORDER_ON)}},
-			{ 23, 111, NULL, TR(STR_START_UNSET_DONOR), {NULL, NULL}},
-			{161, 111, NULL, TR(STR_START_SEARCH), {NULL, NULL}},
-		};
+        for (int i = (int)(sizeof(buttons) / sizeof(buttons[0])) - 1; i >= 0; i--) {
+            if (gamesettings_cursorPosition == i) {
+                // Button is highlighted.
+                sf2d_draw_texture(dboxtex_button, buttons[i].x, menudbox_Ypos + buttons[i].y);
+            } else {
+                // Button is not highlighted. Darken the texture.
+                sf2d_draw_texture_blend(dboxtex_button, buttons[i].x, menudbox_Ypos + buttons[i].y, RGBA8(127, 127, 127, 255));
+            }
 
-		for (int i = (int)(sizeof(buttons)/sizeof(buttons[0])) - 1; i >= 0; i--) {
-			if (startmenu_cursorPosition == i) {
-				// Button is highlighted.
-				sf2d_draw_texture(dboxtex_button, buttons[i].x, menudbox_Ypos+buttons[i].y);
-			} else {
-				// Button is not highlighted. Darken the texture.
-				sf2d_draw_texture_blend(dboxtex_button, buttons[i].x, menudbox_Ypos+buttons[i].y, RGBA8(127, 127, 127, 255));
-			}
+            const wchar_t* title = buttons[i].title;
+            const wchar_t* value_desc = TR(STR_START_DEFAULT);
+            if (i < 3) {
+                switch (*(buttons[i].value)) {
+                    case -1:
+                    default:
+                        value_desc = TR(STR_START_DEFAULT);
+                        break;
+                    case 0:
+                        value_desc = buttons[i].value_desc[0];
+                        break;
+                    case 1:
+                        value_desc = buttons[i].value_desc[1];
+                        break;
+                }
+            }
 
-			const wchar_t *title = buttons[i].title;
-			const wchar_t *value_desc = (buttons[i].value ? buttons[i].value_desc[!!*(buttons[i].value)] : NULL);
+            // Determine the text height.
+            // NOTE: Button texture size is 132x34.
+            const int h = 32;
 
-			// Determine width and height.
-			const int h = (title && value_desc ? 32 : 16);
+            // Draw the title.
+            int y = menudbox_Ypos + buttons[i].y + ((34 - h) / 2);
+            int w = sftd_get_wtext_width(font, 12, title);
+            int x = ((132 - w) / 2) + buttons[i].x;
+            sftd_draw_wtext(font, x, y, RGBA8(0, 0, 0, 255), 12, title);
+            y += 16;
 
-			// Draw the text.
-			// NOTE: Button texture size is 132x34.
-			int y = menudbox_Ypos + buttons[i].y + ((34 - h) / 2);
-			if (title) {
-				const int w = sftd_get_wtext_width(font, 12, title);
-				const int x = ((132 - w) / 2) + buttons[i].x;
-				sftd_draw_wtext(font, x, y, RGBA8(0, 0, 0, 255), 12, title);
-				y += 16;
-			}
-			if (value_desc) {
-				const int w = sftd_get_wtext_width(font, 12, value_desc);
-				const int x = ((132 - w) / 2) + buttons[i].x;
-				sftd_draw_wtext(font, x, y, RGBA8(0, 0, 0, 255), 12, value_desc);
-			}
-		}
-	}
+            // Draw the value.
+            if (i < 3) {
+                w = sftd_get_wtext_width(font, 12, value_desc);
+                x = ((132 - w) / 2) + buttons[i].x;
+                sftd_draw_wtext(font, x, y, RGBA8(0, 0, 0, 255), 12, value_desc);
+            } else if (i == 4) {
+                // Show the RGB value.
+                char rgb_str[32];
+                snprintf(rgb_str, sizeof(rgb_str), "%d, %d, %d",
+                         settings.pergame.red,
+                         settings.pergame.green,
+                         settings.pergame.blue);
+                w = sftd_get_text_width(font, 12, rgb_str);
+                x = ((132 - w) / 2) + buttons[i].x;
+
+                // Print the RGB value using its color.
+                const u32 color = RGBA8(settings.pergame.red,
+                                        settings.pergame.green,
+                                        settings.pergame.blue, 255);
+                sftd_draw_text(font, x, y, color, 12, rgb_str);
+            }
+        }
+    } else {
+        // UI options.
+        const struct {
+            int x;
+            int y;
+            const bool* value;
+            const wchar_t* title;
+            const wchar_t* value_desc[2];   // 0 == off, 1 == on
+        } buttons[] = {
+            { 23,  31, &settings.twl.forwarder, TR(STR_START_GAMELOCATION), {TR(STR_START_SD_CARD), TR(STR_START_FLASHCARD)}},
+            {161,  31, &settings.romselect.toplayout, NULL, {TR(STR_START_BOXART_ON), TR(STR_START_BOXART_OFF)}},
+            { 23,  71, &is3DSX, TR(STR_START_START_GBARUNNER2), {NULL, NULL}},
+            {161,  71, &settings.ui.topborder, NULL, {TR(STR_START_TOP_BORDER_OFF), TR(STR_START_TOP_BORDER_ON)}},
+            { 23, 111, NULL, TR(STR_START_UNSET_DONOR), {NULL, NULL}},
+            {161, 111, NULL, TR(STR_START_SEARCH), {NULL, NULL}},
+        };
+
+        for (int i = (int)(sizeof(buttons) / sizeof(buttons[0])) - 1; i >= 0; i--) {
+            if (startmenu_cursorPosition == i) {
+                // Button is highlighted.
+                sf2d_draw_texture(dboxtex_button, buttons[i].x, menudbox_Ypos + buttons[i].y);
+            } else {
+                // Button is not highlighted. Darken the texture.
+                sf2d_draw_texture_blend(dboxtex_button, buttons[i].x, menudbox_Ypos + buttons[i].y, RGBA8(127, 127, 127, 255));
+            }
+
+            const wchar_t* title = buttons[i].title;
+            const wchar_t* value_desc = (buttons[i].value ? buttons[i].value_desc[!!*(buttons[i].value)] : NULL);
+
+            // Determine width and height.
+            const int h = (title && value_desc ? 32 : 16);
+
+            // Draw the text.
+            // NOTE: Button texture size is 132x34.
+            int y = menudbox_Ypos + buttons[i].y + ((34 - h) / 2);
+            if (title) {
+                const int w = sftd_get_wtext_width(font, 12, title);
+                const int x = ((132 - w) / 2) + buttons[i].x;
+                sftd_draw_wtext(font, x, y, RGBA8(0, 0, 0, 255), 12, title);
+                y += 16;
+            }
+            if (value_desc) {
+                const int w = sftd_get_wtext_width(font, 12, value_desc);
+                const int x = ((132 - w) / 2) + buttons[i].x;
+                sftd_draw_wtext(font, x, y, RGBA8(0, 0, 0, 255), 12, value_desc);
+            }
+        }
+    }
 }
 
 // TWLNAND side Title ID.
@@ -1224,3201 +1267,3335 @@ const u64 TWLNAND_TID = 0x0004800554574C44ULL;
 * MediaType: MEDIATYPE_NAND
 * @return: true if installed, false if not
 */
-bool checkTWLNANDSide(void) {
-	u64 tid = TWLNAND_TID;
-	AM_TitleEntry entry;
-	return R_SUCCEEDED(AM_GetTitleInfo(MEDIATYPE_NAND, 1, &tid, &entry));
+bool checkTWLNANDSide(void)
+{
+    u64 tid = TWLNAND_TID;
+    AM_TitleEntry entry;
+    return R_SUCCEEDED(AM_GetTitleInfo(MEDIATYPE_NAND, 1, &tid, &entry));
 }
 
 int main()
 {
-	sf2d_init();
-	sf2d_set_clear_color(RGBA8(0x00, 0x00, 0x00, 0x00));
-	sf2d_set_3D(0);
+    sf2d_init();
+    sf2d_set_clear_color(RGBA8(0x00, 0x00, 0x00, 0x00));
+    sf2d_set_3D(0);
 
-	if(is3DSX)
-		settingslogotex = sfil_load_PNG_buffer(logo_demo_png, SF2D_PLACE_RAM); // TWLoader (3DSX demo version) logo on top screen
-	else
-		settingslogotex = sfil_load_PNG_buffer(logo_png, SF2D_PLACE_RAM); // TWLoader logo on top screen
+    if (is3DSX) {
+        settingslogotex = sfil_load_PNG_buffer(logo_demo_png, SF2D_PLACE_RAM);    // TWLoader (3DSX demo version) logo on top screen
+    } else {
+        settingslogotex = sfil_load_PNG_buffer(logo_png, SF2D_PLACE_RAM);    // TWLoader logo on top screen
+    }
 
-	sf2d_start_frame(GFX_TOP, GFX_LEFT);
-	sf2d_draw_texture(settingslogotex, 400/2 - settingslogotex->width/2, 240/2 - settingslogotex->height/2);
-	sf2d_end_frame();
-	sf2d_start_frame(GFX_TOP, GFX_RIGHT);
-	sf2d_draw_texture(settingslogotex, 400/2 - settingslogotex->width/2, 240/2 - settingslogotex->height/2);
-	sf2d_end_frame();
-	sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-	sf2d_end_frame();
-	sf2d_swapbuffers();
+    sf2d_start_frame(GFX_TOP, GFX_LEFT);
+    sf2d_draw_texture(settingslogotex, 400 / 2 - settingslogotex->width / 2, 240 / 2 - settingslogotex->height / 2);
+    sf2d_end_frame();
+    sf2d_start_frame(GFX_TOP, GFX_RIGHT);
+    sf2d_draw_texture(settingslogotex, 400 / 2 - settingslogotex->width / 2, 240 / 2 - settingslogotex->height / 2);
+    sf2d_end_frame();
+    sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+    sf2d_end_frame();
+    sf2d_swapbuffers();
 
 
-	aptInit();
-	cfguInit();
-	amInit();
-	ptmuInit();	// For battery status
-	ptmuxInit();	// For AC adapter status
-	sdmcInit();
-	romfsInit();
-	srvInit();
-	hidInit();
-	acInit();
-		
-	bool bannertextloaded = false;	
-	// Register a handler for "returned from HOME Menu".
-	aptHook(&rfhm_cookie, rfhm_callback, &bannertextloaded);
-	
-	/* Log file is dissabled by default. If _nds/twloader/log exist, we turn log file on, else, log is dissabled */
-	struct stat logBuf;
-	logEnabled = stat("sdmc:/_nds/twloader/log", &logBuf) == 0;
-	/* Log configuration file end */
-	
-	if (logEnabled)	createLog();
+    aptInit();
+    cfguInit();
+    amInit();
+    ptmuInit(); // For battery status
+    ptmuxInit();    // For AC adapter status
+    sdmcInit();
+    romfsInit();
+    srvInit();
+    hidInit();
+    acInit();
 
-	// make folders if they don't exist
-	mkdir("sdmc:/_nds", 0777);
-	mkdir("sdmc:/_nds/twloader", 0777);
-	mkdir("sdmc:/_nds/twloader/bnricons", 0777);
-	mkdir("sdmc:/_nds/twloader/bnricons/flashcard", 0777);
-	mkdir("sdmc:/_nds/twloader/boxart", 0777);
-	mkdir("sdmc:/_nds/twloader/gamesettings", 0777);
-	mkdir("sdmc:/_nds/twloader/gamesettings/flashcard", 0777);
-	mkdir("sdmc:/_nds/twloader/loadflashcard", 0777);
-	//mkdir("sdmc:/_nds/twloader/tmp", 0777);
-	
-	// Font loading
-	sftd_init();
-	font = sftd_load_font_file("romfs:/fonts/FOT-RodinBokutoh Pro M.otf");
-	font_b = sftd_load_font_file("romfs:/fonts/FOT-RodinBokutoh Pro DB.otf");
-	sftd_draw_text(font, 0, 0, RGBA8(0, 0, 0, 255), 16, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890&:-.'!?()\"end"); //Hack to avoid blurry text!
-	sftd_draw_text(font_b, 0, 0, RGBA8(0, 0, 0, 255), 24, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890&:-.'!?()\"end"); //Hack to avoid blurry text!	
-	if (logEnabled)	LogFM("Main.Font loading", "Fonts load correctly");
-	
+    bool bannertextloaded = false;
+    // Register a handler for "returned from HOME Menu".
+    aptHook(&rfhm_cookie, rfhm_callback, &bannertextloaded);
+
+    /* Log file is dissabled by default. If _nds/twloader/log exist, we turn log file on, else, log is dissabled */
+    struct stat logBuf;
+    logEnabled = stat("sdmc:/_nds/twloader/log", &logBuf) == 0;
+    /* Log configuration file end */
+
+    if (logEnabled) {
+        createLog();
+    }
+
+    // make folders if they don't exist
+    mkdir("sdmc:/_nds", 0777);
+    mkdir("sdmc:/_nds/twloader", 0777);
+    mkdir("sdmc:/_nds/twloader/bnricons", 0777);
+    mkdir("sdmc:/_nds/twloader/bnricons/flashcard", 0777);
+    mkdir("sdmc:/_nds/twloader/boxart", 0777);
+    mkdir("sdmc:/_nds/twloader/gamesettings", 0777);
+    mkdir("sdmc:/_nds/twloader/gamesettings/flashcard", 0777);
+    mkdir("sdmc:/_nds/twloader/loadflashcard", 0777);
+    //mkdir("sdmc:/_nds/twloader/tmp", 0777);
+
+    // Font loading
+    sftd_init();
+    font = sftd_load_font_file("romfs:/fonts/FOT-RodinBokutoh Pro M.otf");
+    font_b = sftd_load_font_file("romfs:/fonts/FOT-RodinBokutoh Pro DB.otf");
+    sftd_draw_text(font, 0, 0, RGBA8(0, 0, 0, 255), 16, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890&:-.'!?()\"end"); //Hack to avoid blurry text!
+    sftd_draw_text(font_b, 0, 0, RGBA8(0, 0, 0, 255), 24, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890&:-.'!?()\"end"); //Hack to avoid blurry text!
+    if (logEnabled) {
+        LogFM("Main.Font loading", "Fonts load correctly");
+    }
+
     snprintf(settings_vertext, 14, "Ver. %d.%d.%d   ", VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO);
-	if (logEnabled)	LogFMA("Main.GUI version", "Successful reading version", settings_vertext);
-
-	LoadSettings();	
-	bootstrapPath = settings.twl.bootstrapfile ? "fat:/_nds/release-bootstrap.nds" : "fat:/_nds/unofficial-bootstrap.nds";
-	if (logEnabled) LogFMA("Main.bootstrapPath", "Using path:", bootstrapPath.c_str());
-	LoadBootstrapConfig();
-
-	// Store bootstrap version
-	checkBootstrapVersion();
-	
-	// Initialize translations.
-	langInit();	
-	
-	LoadColor();
-	LoadMenuColor();
-	LoadBottomImage();
-
-	// Dialog box textures.
-	dialogboxtex = sfil_load_PNG_file("romfs:/graphics/dialogbox.png", SF2D_PLACE_RAM); // Dialog box
-	dboxtex_iconbox = sfil_load_PNG_file("romfs:/graphics/dbox/iconbox.png", SF2D_PLACE_RAM); // Icon box
-	dboxtex_button = sfil_load_PNG_file("romfs:/graphics/dbox/button.png", SF2D_PLACE_RAM); // Icon box
-	dboxtex_buttonback = sfil_load_PNG_file("romfs:/graphics/dbox/button_back.png", SF2D_PLACE_RAM); // Icon box
-
-	sf2d_texture *toplogotex = NULL;		// Top of R4 menu
-	sf2d_texture *toptex = sfil_load_PNG_file("romfs:/graphics/top.png", SF2D_PLACE_RAM); // Top DSi-Menu border
-	sf2d_texture *topbgtex; // Top background, behind the DSi-Menu border
-
-	// Volume slider textures.
-	voltex[0] = sfil_load_PNG_file("romfs:/graphics/volume0.png", SF2D_PLACE_RAM); // Show no volume
-	voltex[1] = sfil_load_PNG_file("romfs:/graphics/volume1.png", SF2D_PLACE_RAM); // Volume low above 0
-	voltex[2] = sfil_load_PNG_file("romfs:/graphics/volume2.png", SF2D_PLACE_RAM); // Volume medium
-	voltex[3] = sfil_load_PNG_file("romfs:/graphics/volume3.png", SF2D_PLACE_RAM); // Hight volume
-	voltex[4] = sfil_load_PNG_file("romfs:/graphics/volume4.png", SF2D_PLACE_RAM); // 100%
-	voltex[5] = sfil_load_PNG_file("romfs:/graphics/volume5.png", SF2D_PLACE_RAM); // No DSP firm found
-
-	shoulderLtex = sfil_load_PNG_file("romfs:/graphics/shoulder_L.png", SF2D_PLACE_RAM); // L shoulder
-	shoulderRtex = sfil_load_PNG_file("romfs:/graphics/shoulder_R.png", SF2D_PLACE_RAM); // R shoulder
-
-	// Battery level textures.
-	batterychrgtex = sfil_load_PNG_file("romfs:/graphics/battery_charging.png", SF2D_PLACE_RAM);
-	batterytex[0] = sfil_load_PNG_file("romfs:/graphics/battery0.png", SF2D_PLACE_RAM);
-	batterytex[1] = sfil_load_PNG_file("romfs:/graphics/battery1.png", SF2D_PLACE_RAM);
-	batterytex[2] = sfil_load_PNG_file("romfs:/graphics/battery2.png", SF2D_PLACE_RAM);
-	batterytex[3] = sfil_load_PNG_file("romfs:/graphics/battery3.png", SF2D_PLACE_RAM);
-	batterytex[4] = sfil_load_PNG_file("romfs:/graphics/battery4.png", SF2D_PLACE_RAM);
-	batterytex[5] = sfil_load_PNG_file("romfs:/graphics/battery5.png", SF2D_PLACE_RAM);
-
-	sf2d_texture *iconstex = NULL;		// Bottom of menu (3 icons)
-	sf2d_texture *bottomtex = NULL;		// Bottom of menu
-	sf2d_texture *sdicontex = sfil_load_PNG_file("romfs:/graphics/wood/sd.png", SF2D_PLACE_RAM);
-	sf2d_texture *flashcardicontex = sfil_load_PNG_file("romfs:/graphics/wood/flashcard.png", SF2D_PLACE_RAM);
-	sf2d_texture *gbaicontex = sfil_load_PNG_file("romfs:/graphics/wood/gba.png", SF2D_PLACE_RAM);
-	sf2d_texture *smallsettingsicontex = sfil_load_PNG_file("romfs:/graphics/wood/settings.png", SF2D_PLACE_RAM);
-	sf2d_texture *iconnulltex = sfil_load_PNG_file("romfs:/graphics/icon_null.png", SF2D_PLACE_RAM); // Slot-1 cart icon if no cart is present
-	sf2d_texture *homeicontex = sfil_load_PNG_file("romfs:/graphics/homeicon.png", SF2D_PLACE_RAM); // HOME icon
-	sf2d_texture *bottomlogotex = sfil_load_PNG_file("romfs:/graphics/bottom_logo.png", SF2D_PLACE_RAM); // TWLoader logo on bottom screen
-	sf2d_texture *dotcircletex = NULL;	// Dots forming a circle
-	sf2d_texture *startbordertex = NULL;	// "START" border
-	sf2d_texture *settingsicontex = sfil_load_PNG_file("romfs:/graphics/settingsbox.png", SF2D_PLACE_RAM); // Settings box on bottom screen
-	sf2d_texture *getfcgameboxtex = sfil_load_PNG_file("romfs:/graphics/getfcgamebox.png", SF2D_PLACE_RAM);
-	cartnulltex = sfil_load_PNG_file("romfs:/graphics/cart_null.png", SF2D_PLACE_RAM); // NTR cartridge
-	cartntrtex = sfil_load_PNG_file("romfs:/graphics/cart_ntr.png", SF2D_PLACE_RAM); // NTR cartridge
-	carttwltex = sfil_load_PNG_file("romfs:/graphics/cart_twl.png", SF2D_PLACE_RAM); // TWL cartridge
-	cartctrtex = sfil_load_PNG_file("romfs:/graphics/cart_ctr.png", SF2D_PLACE_RAM); // CTR cartridge
-	sf2d_texture *boxfulltex = sfil_load_PNG_file("romfs:/graphics/box_full.png", SF2D_PLACE_RAM); // (DSiWare) box on bottom screen
-	sf2d_texture *bracetex = sfil_load_PNG_file("romfs:/graphics/brace.png", SF2D_PLACE_RAM); // Brace (C-shaped thingy)
-	sf2d_texture *bubbletex = sfil_load_PNG_file("romfs:/graphics/bubble.png", SF2D_PLACE_RAM); // Text bubble
-
-	if (logEnabled)	LogFM("Main.sf2d_textures", "Textures load successfully");
-
-	dspfirmfound = false;
- 	if( access( "sdmc:/3ds/dspfirm.cdc", F_OK ) != -1 ) {
-		ndspInit();
-		dspfirmfound = true;
-		if (logEnabled)	LogFM("Main.dspfirm", "DSP Firm found!");
-	}else{
-		if (logEnabled)	LogFM("Main.dspfirm", "DSP Firm not found");
-	}
-
-	bool musicbool = false;
-	if( access( "sdmc:/_nds/twloader/music.wav", F_OK ) != -1 ) {
-		musicpath = "sdmc:/_nds/twloader/music.wav";
-		if (logEnabled)	LogFM("Main.music", "Custom music file found!");
-	}else {
-		if (logEnabled)	LogFM("Main.dspfirm", "No music file found");
-	}
-
-	// Load the sound effects if DSP is available.
-	if (dspfirmfound) {
-		bgm_menu = new sound(musicpath);
-		//bgm_settings = new sound("sdmc:/_nds/twloader/music/settings.wav");
-		sfx_launch = new sound("romfs:/sounds/launch.wav", 2, false);
-		sfx_select = new sound("romfs:/sounds/select.wav", 2, false);
-		sfx_stop = new sound("romfs:/sounds/stop.wav", 2, false);
-		sfx_switch = new sound("romfs:/sounds/switch.wav", 2, false);
-		sfx_wrong = new sound("romfs:/sounds/wrong.wav", 2, false);
-		sfx_back = new sound("romfs:/sounds/back.wav", 2, false);
-	}
-
-	// Scan the ROM directories.
-	scanRomDirectories();
-
-	char romsel_counter2sd[16];	// Number of ROMs on the SD card.
-	snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
-	if (logEnabled)	LogFMA("Main. ROM scanning", "Number of ROMs on the SD card detected", romsel_counter2sd);
-	
-	char romsel_counter2fc[16];	// Number of ROMs on the flash card.
-	snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size());
-	if (logEnabled)	LogFMA("Main. ROM scanning", "Number of ROMs on the flashcard detected", romsel_counter2fc);
-	
-	// Download box art
-	if (checkWifiStatus()) {
-		downloadBoxArt();
-	}
-
-	// Cache banner data for ROMs on the SD card.
-	// TODO: Re-cache if it's 0 bytes?
-	if (logEnabled)	Log("********************************************************\n");
-	for (bnriconnum = 0; bnriconnum < (int)files.size(); bnriconnum++) {
-		static const char title[] = "Now checking banner data (SD Card)...";
-		char romsel_counter1[16];
-		snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", bnriconnum+1);
-		const char *tempfile = files.at(bnriconnum).c_str();
-
-		wstring tempfile_w = utf8_to_wstring(tempfile);
-		sftd_draw_wtext(font, 12, 64, RGBA8(0, 0, 0, 255), 12, tempfile_w.c_str());
-
-		char nds_path[256];
-		snprintf(nds_path, sizeof(nds_path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), tempfile);
-		FILE *f_nds_file = fopen(nds_path, "rb");
-		if (!f_nds_file)
-			continue;
-		if (logEnabled)	LogFMA("Main. Banner scanning", "Trying to read banner from file", nds_path);
-		
-		if(cacheBanner(f_nds_file, tempfile, font, dialogboxtex, title, romsel_counter1, romsel_counter2sd) == 0) {
-			if (logEnabled)	LogFM("Main. Banner scanning", "Done!");
-		}else {
-			if (logEnabled)	LogFM("Main. Banner scanning", "Error!");
-		}
-		
-		fclose(f_nds_file);
-	}
-
-	if (checkWifiStatus()) {
-		if (settings.ui.autodl && (checkUpdate() == 0) && !is3DSX) {
-			DownloadTWLoaderCIAs();
-		}
-
-		switch (settings.ui.autoupdate) {
-			case 2:
-				UpdateBootstrapUnofficial();
-				break;
-			case 1:
-				UpdateBootstrapRelease();
-				break;
-			default:
-				break;
-		}
-	}
-
-	DialogBoxDisappear(" ", 0);
-	sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-	sf2d_end_frame();
-	sf2d_swapbuffers();
-
-	int filenum = 0;
-	bool noromsfound = false;
-	
-	bool cursorPositionset = false;
-	
-	int soundwaittimer = 0;
-	bool playwrongsounddone = false;
-
-	bool colortexloaded = false;
-	bool colortexloaded_bot = false;
-	bool bnricontexloaded = false;
-	bool boxarttexloaded = false;
-
-	bool updatetopscreen = true;
-	bool screenmodeswitch = false;
-	bool applaunchicon = false;
-	
-	float rad = 0.0f;
-	
-	int boxartXpos;
-	int boxartXmovepos = 0;
-
-	int filenameYpos;
-	int filenameYmovepos = 0;
-	int setsboxXpos = 0;
-	int cartXpos = 64;
-	int boxartYmovepos = 63;
-	int boxartreflYmovepos = 264;
-	int ndsiconXpos;
-	int ndsiconYmovepos = 133;
-	int wood_ndsiconscaletimer = 0;
-	int wood_ndsiconscalelag = 0;
-	int wood_ndsiconscalemovepos = 0;
-	float wood_ndsiconscalesize = 0.00f;
-	bool wood_ndsiconscaledown = false;
-
-	int startbordermovepos = 0;
-	float startborderscalesize = 1.0f;
-	
-	if (settings.ui.theme >= 1)
-		menu_ctrlset = CTRL_SET_MENU;
-	sf2d_set_3D(1);
-
-	// Loop as long as the status is not exit
-	const bool isTWLNANDInstalled = checkTWLNANDSide();
-	// Save by default if the TWLNAND-side title is installed.
-	// Otherwise, we don't want to save anything.
-	bool saveOnExit = isTWLNANDInstalled;
-	while(run && aptMainLoop()) {
-	//while(run) {
-		// Scan hid shared memory for input events
-		hidScanInput();
-
-		const u32 hDown = hidKeysDown();
-		const u32 hHeld = hidKeysHeld();
-
-		// Check if the TWLNAND-side title is installed.
-		if (!isTWLNANDInstalled) {
-			static const char twlnand_msg[] =
-				"The TWLNAND-side title has not been installed.\n"
-				"Please install the TWLNAND-side CIA:\n"
-				"\n"
-				"/_nds/twloader/cias/TWLoader - TWLNAND side.cia\n"
-				"\n"
-				"\n"
-				"\n"
-				"\n"
-				"\n"
-				"\n"
-				"\n"
-				"\n"
-				"\n"
-				"\n"
-				"\n"
-				"\n"
-				"                 Press the HOME button to exit.";
-			DialogBoxAppear(twlnand_msg, 0);
-			sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-			sf2d_draw_texture(dialogboxtex, 0, 0);
-			sftd_draw_text(font, 12, 16, RGBA8(0, 0, 0, 255), 12, twlnand_msg);
-			sf2d_end_frame();
-			sf2d_swapbuffers();
-			continue;
-		}
-
-		offset3D[0].topbg = CONFIG_3D_SLIDERSTATE * -12.0f;
-		offset3D[1].topbg = CONFIG_3D_SLIDERSTATE * 12.0f;
-		offset3D[0].boxart = CONFIG_3D_SLIDERSTATE * -5.0f;
-		offset3D[1].boxart = CONFIG_3D_SLIDERSTATE * 5.0f;
-		offset3D[0].disabled = CONFIG_3D_SLIDERSTATE * -3.0f;
-		offset3D[1].disabled = CONFIG_3D_SLIDERSTATE * 3.0f;
-		
-		if (showdialogbox_menu) {
-			if (menudbox_movespeed <= 1) {
-				if (menudbox_Ypos >= 0) {
-					menudbox_movespeed = 0;
-					menudbox_Ypos = 0;
-				} else
-					menudbox_movespeed = 1;
-			} else {
-				menudbox_movespeed -= 0.2;
-				menudbox_bgalpha += 5;
-			}
-			menudbox_Ypos += menudbox_movespeed;
-		} else {
-			if (menudbox_Ypos <= -240 || menudbox_Ypos >= 240) {
-				menudbox_movespeed = 22;
-				menudbox_Ypos = -240;
-			} else {
-				menudbox_movespeed += 1;
-				menudbox_bgalpha -= 5;
-				if (menudbox_bgalpha <= 0) {
-					menudbox_bgalpha = 0;
-				}
-				menudbox_Ypos += menudbox_movespeed;
-			}
-		}
-
-
-		if (storedcursorPosition < 0)
-			storedcursorPosition = 0;
-
-		size_t file_count = (settings.twl.forwarder ? fcfiles.size() : files.size());
-
-		if(matching_files.size() != 0) {
-			file_count = matching_files.size();
-		}
-		const int pagemax = std::min((20+pagenum*20), (int)file_count);
-		const int pagemax_ba = std::min((21+pagenum*20), (int)file_count);
-
-		if(screenmode == SCREEN_MODE_ROM_SELECT) {
-			if (!colortexloaded) {
-				if (settings.ui.theme == 2) {
-					switch (settings.ui.subtheme) {
-						case 0:
-						default:
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/wood/gbatemp/upper_screen.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 1:
-							topbgtex = sfil_load_PNG_file("romfs:/graphics/wood/black/upper_screen.png", SF2D_PLACE_RAM); // Top background
-							break;
-						case 2:
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/wood/Adv.Evo/upper_screen.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 3:
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/wood/dstwo pink/upper_screen.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-					}
-				} else if (settings.ui.theme == 1) {
-					switch (settings.ui.subtheme) {
-						case 0:
-						default:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme01/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme01/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 1:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme02/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme02/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 2:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme03/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme03/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 3:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme04/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme04/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 4:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme05/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme05/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 5:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme06/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme06/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 6:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme07/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme07/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 7:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme08/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme08/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 8:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme09/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme09/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 9:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme10/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme10/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 10:
-							toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme11/logo.jpg", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme11/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
-							break;
-						case 11:
-							toplogotex = sfil_load_PNG_file("romfs:/graphics/r4/theme12/logo.png", SF2D_PLACE_RAM); // Top logo
-							topbgtex = sfil_load_PNG_file("romfs:/graphics/r4/theme12/bckgrd_1.png", SF2D_PLACE_RAM); // Top background
-							break;
-					}
-				} else
-					topbgtex = sfil_load_PNG_file(color_data->topbgloc, SF2D_PLACE_RAM); // Top background, behind the DSi-Menu border
-				settingsUnloadTextures();
-				colortexloaded = true;
-			}
-			if (!bnricontexloaded) {
-				if (!settings.twl.forwarder) {
-					/* sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-					sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Now loading banner icons (SD Card)...");
-					sf2d_end_frame();
-					sf2d_swapbuffers(); */
-					char path[256];
-					if(matching_files.size() == 0){
-						for (bnriconnum = pagenum*20; bnriconnum < pagemax; bnriconnum++) {						
-							if (bnriconnum < (int)files.size()) {
-								const char *tempfile = files.at(bnriconnum).c_str();
-								snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
-								LoadBNRIcon(path);
-							} else {
-								LoadBNRIcon(NULL);
-							}
-						}
-					}else{
-						for (bnriconnum = pagenum*20; bnriconnum < pagemax; bnriconnum++) {						
-							if (bnriconnum < (int)matching_files.size()) {
-								const char *tempfile = matching_files.at(bnriconnum).c_str();
-								snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
-								LoadBNRIcon(path);
-							} else {
-								LoadBNRIcon(NULL);
-							}
-						}
-					}
-				} else {
-					/* sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-					sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Now loading banner icons (Flashcard)...");
-					sf2d_end_frame();
-					sf2d_swapbuffers(); */
-					char path[256];
-					if(matching_files.size() == 0){
-						for (bnriconnum = pagenum*20; bnriconnum < pagemax; bnriconnum++) {
-							if (bnriconnum < (int)fcfiles.size()) {
-								const char *tempfile = fcfiles.at(bnriconnum).c_str();
-								snprintf(path, sizeof(path), "%s/%s.bin", fcbnriconfolder, tempfile);
-								if (access(path, F_OK) != -1) {
-									LoadBNRIcon(path);
-								} else {
-									LoadBNRIcon(NULL);
-								}
-							} else {
-								LoadBNRIcon(NULL);
-							}
-						}
-					}else{
-						for (bnriconnum = pagenum*20; bnriconnum < pagemax; bnriconnum++) {
-							if (bnriconnum < (int)matching_files.size()) {
-								const char *tempfile = matching_files.at(bnriconnum).c_str();
-								snprintf(path, sizeof(path), "%s/%s.bin", fcbnriconfolder, tempfile);
-								if (access(path, F_OK) != -1) {
-									LoadBNRIcon(path);
-								} else {
-									LoadBNRIcon(NULL);
-								}
-							} else {
-								LoadBNRIcon(NULL);
-							}
-						}
-					}
-				}
-
-				bnricontexloaded = true;
-				bnriconnum = 0+pagenum*20;
-			}			
-			if (!boxarttexloaded) {
-				if (!settings.twl.forwarder) {
-					/* sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-					sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Now storing box art filenames (SD Card)...");
-					sf2d_end_frame();
-					sf2d_swapbuffers(); */
-					char path[256];
-					if(matching_files.size() == 0){
-						for(boxartnum = pagenum*20; boxartnum < pagemax_ba; boxartnum++) {
-							if (boxartnum < (int)files.size()) {
-								const char *tempfile = files.at(boxartnum).c_str();
-								snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), tempfile);
-								FILE *f_nds_file = fopen(path, "rb");
-								if (!f_nds_file) {
-									// Can't open the NDS file.
-									StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-									continue;
-								}
-
-								char ba_TID[5];
-								grabTID(f_nds_file, ba_TID);
-								ba_TID[4] = 0;
-								fclose(f_nds_file);
-
-								// example: SuperMario64DS.nds.png
-								snprintf(path, sizeof(path), "%s/%s.png", boxartfolder, tempfile);
-								if (access(path, F_OK ) != -1 ) {
-									StoreBoxArtPath(path);
-								} else {
-									// example: ASME.png
-									snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
-									if (access(path, F_OK) != -1) {
-										StoreBoxArtPath(path);
-									} else {
-										StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-									}
-								}
-							} else {
-								StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-							}
-						}
-					}else{
-						for(boxartnum = pagenum*20; boxartnum < pagemax_ba; boxartnum++) {
-							if (boxartnum < (int)matching_files.size()) {
-								const char *tempfile = matching_files.at(boxartnum).c_str();
-								snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), tempfile);
-								FILE *f_nds_file = fopen(path, "rb");
-								if (!f_nds_file) {
-									// Can't open the NDS file.
-										StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-									continue;
-								}
-
-								char ba_TID[5];
-								grabTID(f_nds_file, ba_TID);
-								ba_TID[4] = 0;
-								fclose(f_nds_file);
-
-								// example: SuperMario64DS.nds.png
-								snprintf(path, sizeof(path), "%s/%s.png", boxartfolder, tempfile);
-								if (access(path, F_OK ) != -1 ) {
-									StoreBoxArtPath(path);
-								} else {
-									// example: ASME.png
-									snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
-									if (access(path, F_OK) != -1) {
-										StoreBoxArtPath(path);
-									} else {
-										StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-									}
-								}
-							} else {
-								StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-							}
-						}
-					}
-				} else {
-					/* sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-					sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Now storing box art filenames (Flashcard)...");
-					sf2d_end_frame();
-					sf2d_swapbuffers(); */
-					char path[256];
-					if(matching_files.size() == 0){
-						for(boxartnum = pagenum*20; boxartnum < pagemax; boxartnum++) {
-							if (boxartnum < (int)fcfiles.size()) {
-								const char *tempfile = fcfiles.at(boxartnum).c_str();
-								snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), tempfile);
-
-								CIniFile setfcrompathini( path );
-								std::string ba_TIDini = setfcrompathini.GetString(fcrompathini_flashcardrom, fcrompathini_tid, "");
-								if (ba_TIDini.size() < 4) {
-									// TID is too short.
-									StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-									continue;
-								}
-
-								char ba_TID[5];
-								strcpy(ba_TID, ba_TIDini.c_str());
-								ba_TID[4] = 0;
-
-								// example: SuperMario64DS.nds.png
-								snprintf(path, sizeof(path), "%s/%s.png", fcboxartfolder, tempfile);
-								if (access(path, F_OK ) != -1 ) {
-									StoreBoxArtPath(path);
-								} else {
-									// example: ASME.png
-									snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
-									if (access(path, F_OK) != -1) {
-										StoreBoxArtPath(path);
-									} else {
-										StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-									}
-								}
-							} else {
-								StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-							}
-						}
-					}else{
-						for(boxartnum = pagenum*20; boxartnum < pagemax; boxartnum++) {
-							if (boxartnum < (int)matching_files.size()) {
-								const char *tempfile = matching_files.at(boxartnum).c_str();
-								snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), tempfile);
-
-								CIniFile setfcrompathini( path );
-								std::string ba_TIDini = setfcrompathini.GetString(fcrompathini_flashcardrom, fcrompathini_tid, "");
-								if (ba_TIDini.size() < 4) {
-									// TID is too short.
-									StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-									continue;
-								}
-
-								char ba_TID[5];
-								strcpy(ba_TID, ba_TIDini.c_str());
-								ba_TID[4] = 0;
-
-								// example: SuperMario64DS.nds.png
-								snprintf(path, sizeof(path), "%s/%s.png", fcboxartfolder, tempfile);
-								if (access(path, F_OK ) != -1 ) {
-									StoreBoxArtPath(path);
-								} else {
-									// example: ASME.png
-									snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
-									if (access(path, F_OK) != -1) {
-										StoreBoxArtPath(path);
-									} else {
-										StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-									}
-								}
-							} else {
-								StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
-							}
-						}
-					}
-				}
-				
-				// Load up to 6 boxarts.
-				for (boxartnum = pagenum*20; boxartnum < 6+pagenum*20; boxartnum++) {
-					LoadBoxArt();
-				}
-				boxarttexloaded = true;
-				boxartnum = 0+pagenum*20;
-			}
-			
-			if (settings.ui.theme == 2) {	// akMenu/Wood theme
-				for (int topfb = GFX_LEFT; topfb <= GFX_RIGHT; topfb++) {
-					sf2d_start_frame(GFX_TOP, (gfx3dSide_t)topfb);	
-					sf2d_draw_texture(topbgtex, 40, 0);
-					if (menu_ctrlset == CTRL_SET_MENU) {
-						if (!settings.romselect.toplayout && woodmenu_cursorPosition == 2) {
-							// Load the boxart for the Slot-1 cartridge if necessary.
-							loadSlot1BoxArt();
-							// Draw box art
-							switch (settings.ui.subtheme) {
-								case 0:
-								default:
-									sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart+40+14, 62);
-									break;
-								case 1:
-								case 2:
-									sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart+40+176, 113);
-									break;
-								case 3:
-									sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart+40+164, 38);
-									break;
-							}
-						}
-					} else {
-						if (!settings.romselect.toplayout) {
-							if (!bannertextloaded) {
-								LoadBoxArt_WoodTheme(cursorPosition-pagenum*20);
-								bannertextloaded = true;
-							}
-							boxartnum = 0;
-							ChangeBoxArtNo();
-							// Draw box art
-							switch (settings.ui.subtheme) {
-								case 0:
-								default:
-									sf2d_draw_texture(boxarttexnum, offset3D[topfb].boxart+40+14, 62);
-									break;
-								case 1:
-								case 2:
-									sf2d_draw_texture(boxarttexnum, offset3D[topfb].boxart+40+176, 113);
-									break;
-								case 3:
-									sf2d_draw_texture(boxarttexnum, offset3D[topfb].boxart+40+164, 38);
-									break;
-							}
-						}
-					}
-					switch (settings.ui.subtheme) {
-						case 0:
-						default:
-							sftd_draw_text(font_b, 40+200, 148, RGBA8(16, 0, 0, 223), 22, RetTime(true).c_str());
-							DrawDateF(22+197, 198, FORMAT_MY, RGBA8(16, 0, 0, 223), 22);
-							break;
-						case 1:
-							sftd_draw_text(font_b, 40+184, 8, RGBA8(255, 255, 255, 255), 33, RetTime(true).c_str());
-							DrawDateF(40+182, 78, FORMAT_MY, RGBA8(255, 255, 255, 255), 22);
-							break;
-						case 2:
-							sftd_draw_text(font_b, 40+16, 76, RGBA8(255, 255, 255, 255), 33, RetTime(true).c_str());
-							DrawDateF(40+69, 204, FORMAT_MY, RGBA8(255, 255, 255, 255), 19);
-							break;
-						case 3:
-							sftd_draw_text(font_b, 40+176, 172, RGBA8(255, 255, 255, 255), 33, RetTime(true).c_str());
-							break;
-					}
-					sf2d_draw_rectangle(0, 0, 40, 240, RGBA8(0, 0, 0, 255)); // Left black bar
-					sf2d_draw_rectangle(360, 0, 40, 240, RGBA8(0, 0, 0, 255)); // Right black bar
-					sf2d_end_frame();
-				}
-			} else if (settings.ui.theme == 1) {	// R4 theme
-				if (updatetopscreen) {
-					sf2d_start_frame(GFX_TOP, GFX_LEFT);	
-					if (menu_ctrlset != CTRL_SET_MENU) {
-						sf2d_draw_texture(topbgtex, 40, 0);
-						filenameYpos = 15;
-						const int file_count = (settings.twl.forwarder ? fcfiles.size() : files.size());
-						for (filenum = 0; filenum < file_count; filenum++) {
-							u32 color;
-							if (cursorPosition == filenum) {
-								color = SET_ALPHA(color_data->color, 255);
-							} else {
-								color = RGBA8(255, 255, 255, 255);
-							}
-
-							// Get the current filename and convert it to wstring.
-							const char *filename = (settings.twl.forwarder
-									? fcfiles.at(filenum).c_str()
-									: files.at(filenum).c_str());
-							wstring wstr = utf8_to_wstring(filename);
-							sftd_draw_wtext(font, 42, filenameYpos+filenameYmovepos*15, color, 12, wstr.c_str());
-
-							filenameYpos += 15;
-						}
-
-						sf2d_draw_texture_part(topbgtex, 40, 0, 0, 0, 320, 15);
-						const char *title = (settings.twl.forwarder
-									? "Games (Flashcard)"
-									: "Games (SD Card)");
-						sftd_draw_textf(font, 42, 0, RGBA8(0, 0, 0, 255), 12, title);
-						
-						char romsel_counter1[16];
-						char romsel_counter2[16];
-						snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", cursorPosition+1);		
-						// if(matching_files.size() == 0){
-							snprintf(romsel_counter2, sizeof(romsel_counter2), "%d", file_count);
-						// }else{
-						// 	snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", matching_files.size());
-						// }
-						
-						if (settings.ui.counter) {
-							if (file_count < 100) {
-								sftd_draw_text(font, 40+276, 0, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
-								sftd_draw_text(font, 40+295, 0, RGBA8(0, 0, 0, 255), 12, "/");
-								sftd_draw_text(font, 40+300, 0, RGBA8(0, 0, 0, 255), 12, romsel_counter2);
-							} else {
-								sftd_draw_text(font, 40+276, 0, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
-								sftd_draw_text(font, 40+303, 0, RGBA8(0, 0, 0, 255), 12, "/");
-								sftd_draw_text(font, 40+308, 0, RGBA8(0, 0, 0, 255), 12, romsel_counter2);
-							}
-						}
-					} else {
-						sf2d_draw_texture(toplogotex, 40, 0);
-					}
-					sf2d_draw_rectangle(0, 0, 40, 240, RGBA8(0, 0, 0, 255)); // Left black bar
-					sf2d_draw_rectangle(360, 0, 40, 240, RGBA8(0, 0, 0, 255)); // Right black bar
-					sf2d_end_frame();
-					updatetopscreen = false;
-				}
-			} else {	// DSi-Menu theme
-				if (!settings.twl.forwarder) {
-					// Load the boxart for the Slot-1 cartridge if necessary.
-					loadSlot1BoxArt();
-				}
-
-				if (!musicbool) {
-					if (dspfirmfound) { bgm_menu->play(); }
-					musicbool = true;
-				}
-				if (settings.twl.forwarder) {
-					noromtext1 = "No games found!";
-					noromtext2 = "Select \"Add Games\" to get started.";
-				} else {
-					noromtext1 = "No games found!";
-					noromtext2 = " ";
-				}
-
-				update_battery_level(batterychrgtex, batterytex);
-				for (int topfb = GFX_LEFT; topfb <= GFX_RIGHT; topfb++) {
-					sf2d_start_frame(GFX_TOP, (gfx3dSide_t)topfb);	
-					sf2d_draw_texture_scale(topbgtex, offset3D[topfb].topbg-12, 0, 1.32, 1);
-					if (filenum != 0) {	// If ROMs are found, then display box art
-						if (!settings.romselect.toplayout) {
-							boxartXpos = 136;
-							if (!settings.twl.forwarder && pagenum == 0) {
-								if (cursorPosition < 2) {
-									sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart+boxartXpos-144+boxartXmovepos, 240/2 - slot1boxarttex->height/2); // Draw box art
-									sf2d_draw_texture_scale_blend(slot1boxarttex, offset3D[topfb].boxart+boxartXpos-144+boxartXmovepos, 264, 1, -0.75, SET_ALPHA(color_data->color, 0xC0)); // Draw box art's reflection
-								}
-							}
-							for (boxartnum = pagenum*20; boxartnum < pagemax; boxartnum++) {
-								if (boxartnum < 9+pagenum*20) {
-									ChangeBoxArtNo();
-									// Draw box art
-									sf2d_draw_texture(boxarttexnum, offset3D[topfb].boxart+boxartXpos+boxartXmovepos, 240/2 - boxarttexnum->height/2);
-									// Draw box art's reflection
-									sf2d_draw_texture_scale_blend(boxarttexnum, offset3D[topfb].boxart+boxartXpos+boxartXmovepos, 264, 1, -0.75, SET_ALPHA(color_data->color, 0xC0));
-									boxartXpos += 144;
-								}
-							}
-							if (applaunchprep) {
-								if (cursorPosition >= 0) {
-									boxartnum = cursorPosition;
-									ChangeBoxArtNo();
-									sf2d_draw_texture_part(topbgtex, offset3D[topfb].boxart+136, 63, offset3D[topfb].boxart+104, 63, 128, 115*2);
-									// Draw moving box art
-									sf2d_draw_texture(boxarttexnum, offset3D[topfb].boxart+136, boxartYmovepos);
-									// Draw moving box art's reflection
-									sf2d_draw_texture_scale_blend(boxarttexnum, offset3D[topfb].boxart+136, boxartreflYmovepos, 1, -0.75, SET_ALPHA(color_data->color, 0xC0));
-								} else if (!settings.twl.forwarder && cursorPosition == -1) {
-									sf2d_draw_texture_part(topbgtex, offset3D[topfb].boxart+136, 63, offset3D[topfb].boxart+104, 63, 128, 115*2);
-									sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart+136, boxartYmovepos); // Draw moving box art
-									sf2d_draw_texture_scale_blend(slot1boxarttex, offset3D[topfb].boxart+136, boxartreflYmovepos, 1, -0.75, SET_ALPHA(color_data->color, 0xC0)); // Draw moving box art's reflection
-								}
-							}
-						}
-					} else {
-						if (!settings.romselect.toplayout) {
-							boxartXpos = 136;
-							if (!settings.twl.forwarder && pagenum == 0) {
-								if (cursorPosition < 2) {
-									sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart+boxartXpos+boxartXmovepos, 240/2 - slot1boxarttex->height/2); // Draw box art
-									sf2d_draw_texture_scale_blend(slot1boxarttex, offset3D[topfb].boxart+boxartXpos+boxartXmovepos, 264, 1, -0.75, SET_ALPHA(color_data->color, 0xC0)); // Draw box art's reflection
-								}
-							} else {
-								int text_width = sftd_get_text_width(font, 12, noromtext1);
-								sftd_draw_textf(font, offset3D[topfb].boxart+((400-text_width)/2), 96, RGBA8(255, 255, 255, 255), 12, noromtext1);
-								text_width = sftd_get_text_width(font, 12, noromtext2);
-								sftd_draw_textf(font, offset3D[topfb].boxart+((400-text_width)/2), 112, RGBA8(255, 255, 255, 255), 12, noromtext2);
-							}
-						} else {
-							if (settings.twl.forwarder && pagenum == 0) {
-								int text_width = sftd_get_text_width(font, 12, noromtext1);
-								sftd_draw_textf(font, offset3D[topfb].boxart+((400-text_width)/2), 96, RGBA8(255, 255, 255, 255), 12, noromtext1);
-								text_width = sftd_get_text_width(font, 12, noromtext2);
-								sftd_draw_textf(font, offset3D[topfb].boxart+((400-text_width)/2), 112, RGBA8(255, 255, 255, 255), 12, noromtext2);
-							}
-						}
-					}
-					if (settings.ui.topborder) {
-						sf2d_draw_texture_blend(toptex, 400/2 - toptex->width/2, 240/2 - toptex->height/2, menucolor);
-						sftd_draw_text(font, 328, 3, RGBA8(0, 0, 0, 255), 12, RetTime(false).c_str());
-						DrawDate(282, 3, RGBA8(0, 0, 0, 255), 12);
-					} else {
-						sftd_draw_text(font, 328, 3, RGBA8(255, 255, 255, 255), 12, RetTime(false).c_str());
-						DrawDate(282, 3, RGBA8(255, 255, 255, 255), 12);
-					}
-
-					draw_volume_slider(voltex);
-					sf2d_draw_texture(batteryIcon, 371, 2);
-					if (!settings.ui.name.empty()) {
-						sftd_draw_textf(font, 34, 3, SET_ALPHA(color_data->color, 255), 12, settings.ui.name.c_str());
-					}
-					// sftd_draw_textf(font, 2, 2, RGBA8(0, 0, 0, 255), 12, temptext); // Debug text
-					sf2d_draw_texture(shoulderLtex, 0, LshoulderYpos);
-					// sftd_draw_textf(font, 17, LshoulderYpos+5, RGBA8(0, 0, 0, 255), 11, Lshouldertext);
-					sf2d_draw_texture(shoulderRtex, 328, RshoulderYpos);
-					// sftd_draw_textf(font, 332, RshoulderYpos+5, RGBA8(0, 0, 0, 255), 11, Rshouldertext);
-					// Draw the "Prev" and "Next" text for X/Y.
-					u32 lr_color = (pagenum != 0 && file_count <= (size_t)-pagenum*20)
-							? RGBA8(0, 0, 0, 255)
-							: RGBA8(127, 127, 127, 255);
-					sftd_draw_text(font, 17, LshoulderYpos+5, lr_color, 11, "Prev. Page");
-
-					lr_color = (file_count > (size_t)20+pagenum*20)
-							? RGBA8(0, 0, 0, 255)
-							: RGBA8(127, 127, 127, 255);
-					sftd_draw_text(font, 332, RshoulderYpos+5, lr_color, 11, "Next Page");
-
-					sf2d_draw_rectangle(0, 0, 400, 240, RGBA8(0, 0, 0, fadealpha)); // Fade in/out effect
-					sf2d_end_frame();
-				}
-			}
-		} else if (screenmode == SCREEN_MODE_SETTINGS) {
-			if (colortexloaded) {
-				sf2d_free_texture(topbgtex);
-				topbgtex = NULL;
-				colortexloaded = false;
-			}
-			settingsDrawTopScreen();
-		}
-					
-		if(hHeld & KEY_L){
-			if (LshoulderYpos != 223)
-			{LshoulderYpos += 1;}
-		} else {
-			if (LshoulderYpos != 220)
-			{LshoulderYpos -= 1;}
-		}
-		if(hHeld & KEY_R){
-			if (RshoulderYpos != 223)
-			{RshoulderYpos += 1;}
-		} else {
-			if (RshoulderYpos != 220)
-			{RshoulderYpos -= 1;}
-		}
-		
-		/* if(hHeld & KEY_Y){
-			if (YbuttonYpos != 223)
-			{YbuttonYpos += 1;}
-		} else {
-			if (YbuttonYpos != 220)
-			{YbuttonYpos -= 1;}
-		}
-		if(hHeld & KEY_X){
-			if (XbuttonYpos != 223)
-			{XbuttonYpos += 1;}
-		} else {
-			if (XbuttonYpos != 220)
-			{XbuttonYpos -= 1;}
-		} */
-		
-		if (fadein) {
-			fadealpha -= 31;
-			if (fadealpha < 0) {
-				fadealpha = 0;
-				fadein = false;
-				titleboxXmovetimer = 0;
-			}
-		}
-		
-		if (fadeout) {
-			fadealpha += 31;
-			if (fadealpha > 255) {
-				fadealpha = 255;
-				musicbool = false;
-				if(screenmode == SCREEN_MODE_SETTINGS) {
-					screenmode = SCREEN_MODE_ROM_SELECT;
-					fadeout = false;
-					fadein = true;
-
-					// Poll for Slot-1 changes.
-					gamecardPoll(true);
-
-					// Force banner text reload in case
-					// the Slot-1 cartridge was changed
-					// or the UI language was changed.
-					bannertextloaded = false;
-					
-					// Reload language
-					langInit();
-					
-					// Clear matching_files vector
-					if(matching_files.size() != 0) {
-						matching_files.clear(); // Clear filter
-						snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size()); // Reload counter
-						snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size()); // Reload counter for FlashCard
-						boxarttexloaded = false; // Reload boxarts
-						bnricontexloaded = false; // Reload banner icons
-					
-						/** This is better than a glitched screen */
-						sf2d_start_frame(GFX_TOP, GFX_LEFT);
-						sf2d_end_frame();
-						sf2d_swapbuffers();
-					}
-					if (settings.ui.theme == 2) {
-						/** This is better than a glitched screen */
-						sf2d_start_frame(GFX_TOP, GFX_LEFT);
-						sf2d_end_frame();
-						sf2d_swapbuffers();
-						
-						menu_ctrlset = CTRL_SET_MENU;
-						woodmenu_cursorPosition = 4;
-						char path[256];
-						if (cursorPosition < 0)
-							cursorPosition = 0;
-						// Reload 1st icon
-						if (settings.twl.forwarder) {
-							const char *tempfile = fcfiles.at(0).c_str();
-							snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/flashcard/%s.bin", tempfile);
-						} else {
-							const char *tempfile = files.at(0).c_str();
-							snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
-						}
-						if (access(path, F_OK) != -1) {
-							LoadBNRIcon_R4Theme(path);
-						} else {
-							LoadBNRIcon_R4Theme(NULL);
-						}
-					} else if (settings.ui.theme == 1) {
-						/** This is better than a glitched screen */
-						sf2d_start_frame(GFX_TOP, GFX_LEFT);
-						sf2d_end_frame();
-						sf2d_swapbuffers();
-						
-						menu_ctrlset = CTRL_SET_MENU;
-						titleboxXmovepos = 0;
-						boxartXmovepos = 0;
-						if (cursorPosition < 0)
-							cursorPosition = 0;
-					} else {
-						cursorPosition = 0+pagenum*20; // This is to reset cursor position after switching from R4 theme.
-						storedcursorPosition = cursorPosition; // This is to reset cursor position after switching from R4 theme.
-						titleboxXmovepos = 0;
-						boxartXmovepos = 0;
-						char path[256];
-						// Reload 1st icon
-						if (settings.twl.forwarder) {
-							const char *tempfile = fcfiles.at(0+pagenum*20).c_str();
-							snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/flashcard/%s.bin", tempfile);
-						} else {
-							const char *tempfile = files.at(0+pagenum*20).c_str();
-							snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
-						}
-						if (access(path, F_OK) != -1) {
-							LoadBNRIcon_R4Theme(path);
-						} else {
-							LoadBNRIcon_R4Theme(NULL);
-						}
-						// Reload 1st box art
-						LoadBoxArt_WoodTheme(0-pagenum*20);
-						menu_ctrlset = CTRL_SET_GAMESEL;
-					}
-				} else if (gbarunnervalue == 1) {
-					if (logEnabled)	LogFM("Main", "Switching to NTR/TWL-mode");
-					applaunchon = true;
-				}
-			}
-		}
-		
-		if (playwrongsounddone) {
-			if (hHeld & KEY_LEFT || hHeld & KEY_RIGHT) {} else {
-				soundwaittimer += 1;
-				if (soundwaittimer == 2) {
-					soundwaittimer = 0;
-					playwrongsounddone = false;
-				}
-			}
-		}
-
-		if (titleboxXmoveleft) {
-			titleboxXmovetimer += 1;
-			if (titleboxXmovetimer == 10) {
-				titleboxXmovetimer = 0;
-				titleboxXmoveleft = false;
-			} else if (titleboxXmovetimer == 9) {
-				// Delay a frame
-				bannertextloaded = false;			
-				storedcursorPosition = cursorPosition;
-				if (dspfirmfound) { sfx_stop->stop(); }
-				if (dspfirmfound) { sfx_stop->play(); }
-			} else if (titleboxXmovetimer == 8) {
-				titleboxXmovepos += 8;
-				boxartXmovepos += 18;
-				startbordermovepos = 1;
-				startborderscalesize = 0.97;
-				cursorPositionset = false;
-			} else if (titleboxXmovetimer == 2) {
-				titleboxXmovepos += 8;
-				boxartXmovepos += 18;
-				if (dspfirmfound) { sfx_select->stop(); }
-				if (dspfirmfound) { sfx_select->play(); }
-				// Load the previous box art
-				if ( cursorPosition == 3+pagenum*20 ||
-				cursorPosition == 6+pagenum*20 ||
-				cursorPosition == 9+pagenum*20 ||
-				cursorPosition == 12+pagenum*20 ||
-				cursorPosition == 15+pagenum*20 ||
-				cursorPosition == 18+pagenum*20 ) {
-					boxartnum = cursorPosition-1;
-					LoadBoxArt();
-					boxartnum--;
-					LoadBoxArt();
-					boxartnum--;
-					LoadBoxArt();
-				}
-				if ( cursorPosition == 6+pagenum*20 ||
-				cursorPosition == 12+pagenum*20 ||
-				cursorPosition == 18+pagenum*20 ) {
-					boxartXmovepos = -144*7;
-					boxartXmovepos += 18*2;
-				}
-			} else {
-				if (!cursorPositionset) {
-					cursorPosition--;
-					cursorPositionset = true;
-				}
-				if (pagenum == 0) {
-					if (cursorPosition != -3) {
-						titleboxXmovepos += 8;
-						boxartXmovepos += 18;
-					} else {
-						titleboxXmovetimer = 0;
-						titleboxXmoveleft = false;
-						cursorPositionset = false;
-						cursorPosition++;
-						if (!playwrongsounddone) {
-							if (dspfirmfound) {
-								sfx_wrong->stop();
-								sfx_wrong->play();
-							}
-							playwrongsounddone = true;
-						}
-					}
-				} else {
-					if (cursorPosition != -1+pagenum*20) {
-						titleboxXmovepos += 8;
-						boxartXmovepos += 18;
-					} else {
-						titleboxXmovetimer = 0;
-						titleboxXmoveleft = false;
-						cursorPositionset = false;
-						cursorPosition++;
-						if (!playwrongsounddone) {
-							if (dspfirmfound) {
-								sfx_wrong->stop();
-								sfx_wrong->play();
-							}
-							playwrongsounddone = true;
-						}
-					}
-				}
-			}
-		} else if(titleboxXmoveright) {
-			titleboxXmovetimer += 1;
-			if (titleboxXmovetimer == 10) {
-				titleboxXmovetimer = 0;
-				titleboxXmoveright = false;
-			} else if (titleboxXmovetimer == 9) {
-				// Delay a frame
-				bannertextloaded = false;
-				storedcursorPosition = cursorPosition;
-				if (dspfirmfound) { sfx_stop->stop(); }
-				if (dspfirmfound) { sfx_stop->play(); }
-				// Load the next box art
-				if ( cursorPosition == 4+pagenum*20 ||
-				cursorPosition == 7+pagenum*20 ||
-				cursorPosition == 10+pagenum*20 ||
-				cursorPosition == 13+pagenum*20 ||
-				cursorPosition == 16+pagenum*20 ||
-				cursorPosition == 19+pagenum*20 ) {
-					boxartnum = cursorPosition+2;
-					LoadBoxArt();
-					boxartnum++;
-					LoadBoxArt();
-					boxartnum++;
-					LoadBoxArt();
-				}
-				if ( cursorPosition == 7+pagenum*20 ||
-				cursorPosition == 13+pagenum*20 ||
-				cursorPosition == 19+pagenum*20 ) {
-					boxartXmovepos = -144;
-				}
-			} else if (titleboxXmovetimer == 8) {
-				titleboxXmovepos -= 8;
-				boxartXmovepos -= 18;
-				startbordermovepos = 1;
-				startborderscalesize = 0.97;
-				cursorPositionset = false;
-			} else if (titleboxXmovetimer == 2) {
-				titleboxXmovepos -= 8;
-				boxartXmovepos -= 18;
-				if (dspfirmfound) { sfx_select->stop(); }
-				if (dspfirmfound) { sfx_select->play(); }
-			} else {
-				if (!cursorPositionset) {
-					cursorPosition++;
-					cursorPositionset = true;
-				}
-				if (cursorPosition != filenum) {
-					titleboxXmovepos -= 8;
-					boxartXmovepos -= 18;
-				} else {
-					titleboxXmovetimer = 0;
-					titleboxXmoveright = false;
-					cursorPositionset = false;
-					cursorPosition--;
-					if (!playwrongsounddone) {
-						if (dspfirmfound) {
-							sfx_wrong->stop();
-							sfx_wrong->play();
-						}
-						playwrongsounddone = true;
-					}
-				}
-			}
-		}
-		if (applaunchprep) {
-			rad += 0.50f;
-			boxartYmovepos -= 6;
-			boxartreflYmovepos += 2;
-			titleboxYmovepos -= 6;
-			ndsiconYmovepos -= 6;
-			if (titleboxYmovepos == -240) {
-				if (screenmodeswitch) {
-					musicbool = false;
-					screenmode = SCREEN_MODE_SETTINGS;
-					settingsResetSubScreenMode();
-					rad = 0.0f;
-					boxartYmovepos = 63;
-					boxartreflYmovepos = 264;
-					titleboxYmovepos = 120;
-					ndsiconYmovepos = 133;
-					fadein = true;
-					screenmodeswitch = false;
-					applaunchprep = false;
-				} else {
-					if (logEnabled)	LogFM("Main.applaunchprep", "Switching to NTR/TWL-mode");
-					applaunchon = true;
-				}
-			}
-			fadealpha += 6;
-			if (fadealpha > 255) {
-				fadealpha = 255;
-			}
-		}
-
-		//if (updatebotscreen) {
-			if (screenmode == SCREEN_MODE_ROM_SELECT) {
-				if (!colortexloaded_bot) {
-					settingsUnloadTextures();
-					dotcircletex = sfil_load_PNG_file(color_data->dotcircleloc, SF2D_PLACE_RAM); // Dots forming a circle
-					startbordertex = sfil_load_PNG_file(color_data->startborderloc, SF2D_PLACE_RAM); // "START" border
-					if (settings.ui.theme == 2) {
-						switch (settings.ui.subtheme) {
-							case 0:
-							default:
-								bottomtex = sfil_load_JPEG_file("romfs:/graphics/wood/gbatemp/lower_screen.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								break;
-							case 1:
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/wood/black/lower_screen.png", SF2D_PLACE_RAM); // Bottom of menu
-								break;
-							case 2:
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/wood/Adv.Evo/lower_screen.png", SF2D_PLACE_RAM); // Bottom of menu
-								break;
-							case 3:
-								bottomtex = sfil_load_JPEG_file("romfs:/graphics/wood/dstwo pink/lower_screen.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								break;
-						}
-					} else if (settings.ui.theme == 1) {
-						switch (settings.ui.subtheme) {
-							case 0:
-							default:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme01/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme01/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 1:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme02/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme02/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 2:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme03/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme03/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 3:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme04/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme04/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 4:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme05/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme05/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 5:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme06/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme06/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 6:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme07/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme07/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 7:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme08/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme08/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 8:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme09/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme09/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 9:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme10/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme10/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 10:
-								iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme11/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme11/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-							case 11:
-								iconstex = sfil_load_PNG_file("romfs:/graphics/r4/theme12/icons.png", SF2D_PLACE_RAM); // Bottom of menu
-								bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme12/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
-								break;
-						}
-					} else {
-						bottomtex = sfil_load_PNG_file(bottomloc, SF2D_PLACE_RAM); // Bottom of menu
-					}
-					colortexloaded_bot = true;
-				}
-				sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-				
-				if (settings.ui.theme == 2) {
-					if (wood_ndsiconscaletimer == 60) {
-						// Scale icon at 30fps
-						if (wood_ndsiconscalelag == 1) {
-							if (wood_ndsiconscaledown) {
-								wood_ndsiconscalemovepos -= 1;
-								wood_ndsiconscalesize -= 0.06f;
-								if (wood_ndsiconscalemovepos == 0)
-									wood_ndsiconscaledown = false;
-							} else {
-								wood_ndsiconscalemovepos += 1;
-								wood_ndsiconscalesize += 0.06f;
-								if (wood_ndsiconscalemovepos == 4)
-									wood_ndsiconscaledown = true;
-							}
-							wood_ndsiconscalelag = 0;
-						} else {
-							wood_ndsiconscalelag = 1;
-						}
-					} else {
-						wood_ndsiconscaletimer += 1;
-						wood_ndsiconscalemovepos = 0;
-						wood_ndsiconscalesize = 0.00f;
-						wood_ndsiconscaledown = false;
-					}
-				
-					sf2d_draw_texture(bottomtex, 320/2 - bottomtex->width/2, 240/2 - bottomtex->height/2);
-					if (menu_ctrlset == CTRL_SET_MENU) {
-						// Poll for Slot-1 changes.
-						bool forcePoll = false;
-						bool doSlot1Update = false;
-						if (gamecardIsInserted() && gamecardGetType() == CARD_TYPE_UNKNOWN) {
-							// Card is inserted, but we don't know its type.
-							// Force an update.
-							forcePoll = true;
-						}
-						bool s1chg = gamecardPoll(forcePoll);
-						if (s1chg) {
-							// Update Slot-1 if:
-							// - forcePoll is false
-							// - forcePoll is true, and card is no longer unknown.
-							doSlot1Update = (!forcePoll || gamecardGetType() != CARD_TYPE_UNKNOWN);
-						}
-						if (doSlot1Update) {
-							// Slot-1 card has changed.
-							if (cursorPosition == -1) {
-								// Reload the banner text.
-								bannertextloaded = false;
-							}
-						}
-						sf2d_texture *cardicontex = gamecardGetIcon();
-						if (!cardicontex)
-							cardicontex = iconnulltex;
-
-						int Ypos = 26;
-						filenameYpos = 36;
-						if (woodmenu_cursorPosition == 0) {
-							sf2d_draw_rectangle(0, Ypos-4, 320, 40, SET_ALPHA(color_data->color, 127));
-							sf2d_draw_texture_part_scale(sdicontex, 8-wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos+Ypos, bnriconframenum*32, 0, 32, 32, 1.00+wood_ndsiconscalesize, 1.00+wood_ndsiconscalesize);
-						} else
-							sf2d_draw_texture_part(sdicontex, 8, Ypos, bnriconframenum*32, 0, 32, 32);
-						sftd_draw_textf(font, 46, filenameYpos, RGBA8(255, 255, 255, 255), 12, "Games (SD Card)");
-						Ypos += 39;
-						filenameYpos += 39;
-						if (woodmenu_cursorPosition == 1) {
-							sf2d_draw_rectangle(0, Ypos-4, 320, 40, SET_ALPHA(color_data->color, 127));
-							sf2d_draw_texture_part_scale(flashcardicontex, 8-wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos+Ypos, bnriconframenum*32, 0, 32, 32, 1.00+wood_ndsiconscalesize, 1.00+wood_ndsiconscalesize);
-						} else
-							sf2d_draw_texture_part(flashcardicontex, 8, Ypos, bnriconframenum*32, 0, 32, 32);
-						sftd_draw_textf(font, 46, filenameYpos, RGBA8(255, 255, 255, 255), 12, "Games (Flashcard)");
-						Ypos += 39;
-						filenameYpos += 39;
-						if (woodmenu_cursorPosition == 2) {
-							sf2d_draw_rectangle(0, Ypos-4, 320, 40, SET_ALPHA(color_data->color, 127));
-							sf2d_draw_texture_part_scale(cardicontex, 8-wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos+Ypos, bnriconframenum*32, 0, 32, 32, 1.00+wood_ndsiconscalesize, 1.00+wood_ndsiconscalesize);
-						} else
-							sf2d_draw_texture_part(cardicontex, 8, Ypos, bnriconframenum*32, 0, 32, 32);
-						sftd_draw_textf(font, 46, filenameYpos, RGBA8(255, 255, 255, 255), 12, "Launch Slot-1 card");
-						Ypos += 39;
-						filenameYpos += 39;
-						if (woodmenu_cursorPosition == 3) {
-							sf2d_draw_rectangle(0, Ypos-4, 320, 40, SET_ALPHA(color_data->color, 127));
-							sf2d_draw_texture_part_scale(gbaicontex, 8-wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos+Ypos, bnriconframenum*32, 0, 32, 32, 1.00+wood_ndsiconscalesize, 1.00+wood_ndsiconscalesize);
-						} else
-							sf2d_draw_texture_part(gbaicontex, 8, Ypos, bnriconframenum*32, 0, 32, 32);
-						sftd_draw_textf(font, 46, filenameYpos, RGBA8(255, 255, 255, 255), 12, "Start GBARunner2");
-						Ypos += 39;
-						filenameYpos += 39;
-						if (woodmenu_cursorPosition == 4) {
-							sf2d_draw_rectangle(0, Ypos-4, 320, 40, SET_ALPHA(color_data->color, 127));
-							sf2d_draw_texture_part_scale(smallsettingsicontex, 8-wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos+Ypos, bnriconframenum*32, 0, 32, 32, 1.00+wood_ndsiconscalesize, 1.00+wood_ndsiconscalesize);
-						} else
-							sf2d_draw_texture_part(smallsettingsicontex, 8, Ypos, bnriconframenum*32, 0, 32, 32);
-						sftd_draw_wtextf(font, 46, filenameYpos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_TEXT));
-					} else {
-						int Ypos = 26;
-						filenameYpos = 36;
-						for (filenum = pagenum*20; filenum < pagemax; filenum++) {
-							bnriconnum = filenum;
-							ChangeBNRIconNo();
-							if (cursorPosition == filenum) {
-								sf2d_draw_rectangle(0, Ypos-4+filenameYmovepos*39, 320, 40, SET_ALPHA(color_data->color, 127));
-							}
-
-							// Get the current filename and convert it to wstring.
-							const char *filename = (settings.twl.forwarder
-									? fcfiles.at(filenum).c_str()
-									: files.at(filenum).c_str());
-							wstring wstr = utf8_to_wstring(filename);
-							sftd_draw_wtext(font, 46, filenameYpos+filenameYmovepos*39, RGBA8(255, 255, 255, 255), 12, wstr.c_str());
-
-							if (cursorPosition == filenum)
-								sf2d_draw_texture_part_scale(bnricontexnum, 8-wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos+Ypos+filenameYmovepos*39, bnriconframenum*32, 0, 32, 32, 1.00+wood_ndsiconscalesize, 1.00+wood_ndsiconscalesize);
-							else
-								sf2d_draw_texture_part(bnricontexnum, 8, Ypos+filenameYmovepos*39, bnriconframenum*32, 0, 32, 32);
-							Ypos += 39;
-							filenameYpos += 39;
-						}
-						sf2d_draw_texture_part(bottomtex, 0, 0, 0, 0, 320, 22);
-						sf2d_draw_texture_part(bottomtex, 0, 217, 0, 217, 320, 23);
-						if (settings.twl.forwarder)
-							sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Games (Flashcard)");
-						else
-							sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Games (SD Card)");
-						
-						const size_t file_count = (settings.twl.forwarder ? fcfiles.size() : files.size());
-						
-						char romsel_counter1[16];
-						char romsel_counter2[16];
-						snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", cursorPosition+1);		
-						// if(matching_files.size() == 0){
-							snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", file_count);
-						// }else{
-						// 	snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", matching_files.size());
-						// }
-						
-						if (settings.ui.counter) {
-							if (file_count < 100) {
-								sftd_draw_text(font, 276, 2, RGBA8(255, 255, 255, 255), 12, romsel_counter1);
-								sftd_draw_text(font, 295, 2, RGBA8(255, 255, 255, 255), 12, "/");
-								sftd_draw_text(font, 300, 2, RGBA8(255, 255, 255, 255), 12, romsel_counter2);
-							} else {
-								sftd_draw_text(font, 276, 2, RGBA8(255, 255, 255, 255), 12, romsel_counter1);
-								sftd_draw_text(font, 303, 2, RGBA8(255, 255, 255, 255), 12, "/");
-								sftd_draw_text(font, 308, 2, RGBA8(255, 255, 255, 255), 12, romsel_counter2);
-							}
-						}
-					}
-				} else if (settings.ui.theme == 1) {
-					if (menu_ctrlset == CTRL_SET_MENU) {
-						sf2d_draw_texture(iconstex, 320/2 - iconstex->width/2, 240/2 - iconstex->height/2);
-						if (r4menu_cursorPosition == 0) {
-							sf2d_draw_rectangle(12, 77, 92, 91, SET_ALPHA(color_data->color, 255));
-							sf2d_draw_texture_part(iconstex, 14, 79, 14, 79, 88, 87);
-							static const char selectiontext[] = "Games";
-							const int text_width = sftd_get_text_width(font, 14, selectiontext);
-							sftd_draw_textf(font, (320-text_width)/2, 220, RGBA8(255, 255, 255, 255), 14, selectiontext);
-						} else 	if (r4menu_cursorPosition == 1) {
-							sf2d_draw_rectangle(115, 77, 92, 91, SET_ALPHA(color_data->color, 255));
-							sf2d_draw_texture_part(iconstex, 117, 79, 117, 79, 88, 87);
-							static const char selectiontext[] = "Launch Slot-1 card";
-							const int text_width = sftd_get_text_width(font, 14, selectiontext);
-							sftd_draw_textf(font, (320-text_width)/2, 220, RGBA8(255, 255, 255, 255), 14, selectiontext);
-						} else 	if (r4menu_cursorPosition == 2) {
-							sf2d_draw_rectangle(217, 77, 92, 91, SET_ALPHA(color_data->color, 255));
-							sf2d_draw_texture_part(iconstex, 219, 79, 219, 79, 88, 87);
-							static const char selectiontext[] = "Start GBARunner2";
-							const int text_width = sftd_get_text_width(font, 14, selectiontext);
-							sftd_draw_textf(font, (320-text_width)/2, 220, RGBA8(255, 255, 255, 255), 14, selectiontext);
-						}
-						DrawDate(2, 220, RGBA8(255, 255, 255, 255), 14);
-						sftd_draw_text(font, 276, 220, RGBA8(255, 255, 255, 255), 14, RetTime(true).c_str());
-					} else {
-						sf2d_draw_texture(bottomtex, 320/2 - bottomtex->width/2, 240/2 - bottomtex->height/2);
-						if (!bannertextloaded) {
-							char path[256];
-							bnriconnum = cursorPosition;
-							if (settings.twl.forwarder) {
-								const char *tempfile = fcfiles.at(bnriconnum).c_str();
-								snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/flashcard/%s.bin", tempfile);
-							} else {
-								const char *tempfile = files.at(bnriconnum).c_str();
-								snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
-							}
-							if (access(path, F_OK) != -1) {
-								LoadBNRIcon_R4Theme(path);
-							} else {
-								LoadBNRIcon_R4Theme(NULL);
-							}
-						}
-						sf2d_draw_rectangle(80, 31, 192, 42, RGBA8(255, 255, 255, 255));
-						sf2d_draw_texture(dboxtex_iconbox, 47, 31);
-						sf2d_draw_texture_part(bnricontex[0], 52, 36, bnriconframenum*32, 0, 32, 32);
-						
-						if (!bannertextloaded) {
-							char path[256];
-							if (settings.twl.forwarder) {
-								// if(matching_files.size() == 0){
-									if (fcfiles.size() != 0) {
-										romsel_filename = fcfiles.at(cursorPosition).c_str();
-										romsel_filename_w = utf8_to_wstring(romsel_filename);
-									} else {
-										romsel_filename = " ";
-										romsel_filename_w = utf8_to_wstring(romsel_filename);
-									}
-								/* }else{
-									if (matching_files.size() != 0) {
-										romsel_filename = matching_files.at(storedcursorPosition).c_str();
-										romsel_filename_w = utf8_to_wstring(romsel_filename);
-									} else {
-										romsel_filename = " ";
-										romsel_filename_w = utf8_to_wstring(romsel_filename);
-									}
-								} */
-									snprintf(path, sizeof(path), "%s/%s.bin", fcbnriconfolder, romsel_filename);
-								} else {
-								// if(matching_files.size() == 0){
-									if (files.size() != 0) {
-										romsel_filename = files.at(cursorPosition).c_str();
-										romsel_filename_w = utf8_to_wstring(romsel_filename);
-									} else {
-										romsel_filename = " ";
-										romsel_filename_w = utf8_to_wstring(romsel_filename);
-									}
-									snprintf(path, sizeof(path), "%s/%s.bin", bnriconfolder, romsel_filename);
-								/* }else {
-									if (matching_files.size() != 0) {
-										romsel_filename = matching_files.at(storedcursorPosition).c_str();
-										romsel_filename_w = utf8_to_wstring(romsel_filename);
-									} else {
-										romsel_filename = " ";
-										romsel_filename_w = utf8_to_wstring(romsel_filename);
-									}
-									snprintf(path, sizeof(path), "%s/%s.bin", bnriconfolder, romsel_filename); */
-								}
-
-							if (access(path, F_OK) == -1) {
-								// Banner file is not available.
-								strcpy(path, "romfs:/notextbanner");
-							}
-							FILE *f_bnr = fopen(path, "rb");
-							if (f_bnr) {
-								romsel_gameline = grabText(f_bnr, language);
-								fclose(f_bnr);
-							} else {
-								// Unable to open the banner file.
-								romsel_gameline.clear();
-								romsel_gameline.push_back(latin1_to_wstring("ERROR:"));
-								romsel_gameline.push_back(latin1_to_wstring("Unable to open the cached banner."));
-							}
-							bannertextloaded = true;
-						}
-						if (cursorPosition >= 0) {
-							int y = 32, dy = 12;
-							// Print the banner text, center-aligned.
-							const size_t banner_lines = std::min(3U, romsel_gameline.size());
-							for (size_t i = 0; i < banner_lines; i++, y += dy) {
-								const int text_width = sftd_get_wtext_width(font_b, 12, romsel_gameline[i].c_str());
-								sftd_draw_wtext(font_b, 84+(192-text_width)/2, y, RGBA8(0, 0, 0, 255), 12, romsel_gameline[i].c_str());
-							}
-						}
-					}
-				} else {
-					if (settings.ui.custombot == 1)
-						sf2d_draw_texture(bottomtex, 320/2 - bottomtex->width/2, 240/2 - bottomtex->height/2);
-					else
-						sf2d_draw_texture_blend(bottomtex, 320/2 - bottomtex->width/2, 240/2 - bottomtex->height/2, menucolor);
-
-					if (fadealpha == 0) {
-						sf2d_draw_texture(bubbletex, 0, 0);
-						// if (dspfirmfound) { sfx_menuselect->play(); }
-						bool drawBannerText = true;
-						if (cursorPosition == -2) {
-							const wchar_t *curn2text = TR(STR_SETTINGS_TEXT);
-							const int text_width = sftd_get_wtext_width(font_b, 18, curn2text);
-							sftd_draw_wtextf(font_b, (320-text_width)/2, 38, RGBA8(0, 0, 0, 255), 18, curn2text);
-							drawBannerText = false;
-						} else if (cursorPosition == -1) {
-							if (settings.twl.forwarder) {
-								static const char add_games_text[] = "Add Games";
-								const int text_width = sftd_get_text_width(font_b, 18, add_games_text);
-								sftd_draw_text(font_b, (320-text_width)/2, 38, RGBA8(0, 0, 0, 255), 18, add_games_text);
-								drawBannerText = false;
-							} else {
-								// Get the text from the Slot 1 cartridge.
-								if (!bannertextloaded) {
-									romsel_gameline = gamecardGetText();
-									const char *productCode = gamecardGetProductCode();
-									if (!romsel_gameline.empty() && productCode) {
-										// Display the product code and revision.
-										// FIXME: Figure out a way to get the revision for CTR cards.
-										char buf[48];
-										if (gamecardGetType() != CARD_TYPE_CTR) {
-											snprintf(buf, sizeof(buf), "Slot-1: %s, Rev.%02u", productCode, gamecardGetRevision());
-										} else {
-											snprintf(buf, sizeof(buf), "Slot-1: %s", productCode);
-										}
-										romsel_filename_w = latin1_to_wstring(buf);
-									} else {
-										romsel_filename_w.clear();
-									}
-								}
-
-								if (romsel_gameline.empty()) {
-									const wchar_t *msg;
-									if (gamecardIsInserted()) {
-										// Game card is inserted, but unrecognized.
-										// It may be a blocked flashcard.
-										msg = TR(STR_UNKOWN);
-									} else {
-										// No game card is inserted.
-										msg = TR(STR_NO_CARTRIDGE);
-									}
-									const int text_width = sftd_get_wtext_width(font_b, 18, msg);
-									sftd_draw_wtext(font_b, (320-text_width)/2, 38, RGBA8(0, 0, 0, 255), 18, msg);
-									drawBannerText = false;
-								}
-							}
-						} else {
-							if (!bannertextloaded) {
-								char path[256];
-								if (settings.twl.forwarder) {
-									if(matching_files.size() == 0){
-										if (fcfiles.size() != 0) {
-											romsel_filename = fcfiles.at(storedcursorPosition).c_str();
-											romsel_filename_w = utf8_to_wstring(romsel_filename);
-										} else {
-											romsel_filename = " ";
-											romsel_filename_w = utf8_to_wstring(romsel_filename);
-										}
-									}else{
-										if (matching_files.size() != 0) {
-											romsel_filename = matching_files.at(storedcursorPosition).c_str();
-											romsel_filename_w = utf8_to_wstring(romsel_filename);
-										} else {
-											romsel_filename = " ";
-											romsel_filename_w = utf8_to_wstring(romsel_filename);
-										}
-									}
-									snprintf(path, sizeof(path), "%s/%s.bin", fcbnriconfolder, romsel_filename);
-								} else {
-									if(matching_files.size() == 0){
-										if (files.size() != 0) {
-											romsel_filename = files.at(storedcursorPosition).c_str();
-											romsel_filename_w = utf8_to_wstring(romsel_filename);
-										} else {
-											romsel_filename = " ";
-											romsel_filename_w = utf8_to_wstring(romsel_filename);
-										}
-										snprintf(path, sizeof(path), "%s/%s.bin", bnriconfolder, romsel_filename);
-									}else {
-										if (matching_files.size() != 0) {
-											romsel_filename = matching_files.at(storedcursorPosition).c_str();
-											romsel_filename_w = utf8_to_wstring(romsel_filename);
-										} else {
-											romsel_filename = " ";
-											romsel_filename_w = utf8_to_wstring(romsel_filename);
-										}
-										snprintf(path, sizeof(path), "%s/%s.bin", bnriconfolder, romsel_filename);
-									}									
-								}
-
-								if (access(path, F_OK) == -1) {
-									// Banner file is not available.
-									strcpy(path, "romfs:/notextbanner");
-								}
-								bnriconnum = cursorPosition;
-								FILE *f_bnr = fopen(path, "rb");
-								if (f_bnr) {
-									romsel_gameline = grabText(f_bnr, language);
-									fclose(f_bnr);
-								} else {
-									// Unable to open the banner file.
-									romsel_gameline.clear();
-									romsel_gameline.push_back(latin1_to_wstring("ERROR:"));
-									romsel_gameline.push_back(latin1_to_wstring("Unable to open the cached banner."));
-								}
-								bannertextloaded = true;
-							}
-						}
-
-						if (drawBannerText) {
-							int y, dy;
-							//top dialog = 100px tall
-							if (settings.ui.filename) {
-								sftd_draw_wtext(font, 10, 8, RGBA8(127, 127, 127, 255), 12, romsel_filename_w.c_str());
-								y = (100-(19*romsel_gameline.size()))/2 + 4;
-								//y = 24; dy = 19;
-								dy = 19;
-							} else {
-								y = (100-(22*romsel_gameline.size()))/2;
-								//y = 16; dy = 22;
-								dy = 22;
-							}
-
-							// Print the banner text, center-aligned.
-							const size_t banner_lines = std::min(3U, romsel_gameline.size());
-							for (size_t i = 0; i < banner_lines; i++, y += dy) {
-								const int text_width = sftd_get_wtext_width(font_b, 16, romsel_gameline[i].c_str());
-								sftd_draw_wtext(font_b, (320-text_width)/2, y, RGBA8(0, 0, 0, 255), 16, romsel_gameline[i].c_str());
-							}
-
-							if (cursorPosition >= 0 && settings.ui.counter) {
-								char romsel_counter1[16];
-								snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", storedcursorPosition+1);
-								const char *p_romsel_counter;
-								if (settings.twl.forwarder) {
-									p_romsel_counter = romsel_counter2fc;
-								} else {
-									p_romsel_counter = romsel_counter2sd;
-								}
-								if (file_count < 100) {
-									sftd_draw_textf(font, 8, 96, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
-									sftd_draw_textf(font, 27, 96, RGBA8(0, 0, 0, 255), 12, "/");
-									sftd_draw_textf(font, 32, 96, RGBA8(0, 0, 0, 255), 12, p_romsel_counter);
-								} else {
-									sftd_draw_textf(font, 8, 96, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
-									sftd_draw_textf(font, 35, 96, RGBA8(0, 0, 0, 255), 12, "/");
-									sftd_draw_textf(font, 40, 96, RGBA8(0, 0, 0, 255), 12, p_romsel_counter);
-								}
-							}
-						}
-					} else {
-						sf2d_draw_texture(bottomlogotex, 320/2 - bottomlogotex->width/2, 40);
-					}
-
-					if(!is3DSX) {
-						const wchar_t *home_text = TR(STR_RETURN_TO_HOME_MENU);
-						const int home_width = sftd_get_wtext_width(font, 13, home_text) + 16;
-						const int home_x = (320-home_width)/2;
-						sf2d_draw_texture(homeicontex, home_x, 220); // Draw HOME icon
-						sftd_draw_wtext(font, home_x+16, 221, RGBA8(0, 0, 0, 255), 13, home_text);
-					}
-
-					if (pagenum == 0) {
-						if (settings.ui.iconsize) {
-							sf2d_draw_texture_scale(bracetex, -74+titleboxXmovepos*1.25, 108, 1.25, 1.25);
-							sf2d_draw_texture_scale(settingsicontex, -40+setsboxXpos+titleboxXmovepos*1.25, 111, 1.25, 1.25);
-						} else {
-							sf2d_draw_texture(bracetex, -32+titleboxXmovepos, 116);
-							sf2d_draw_texture(settingsicontex, setsboxXpos+titleboxXmovepos, 119);
-						}
-
-						if (!settings.twl.forwarder) {
-							// Poll for Slot-1 changes.
-							bool forcePoll = false;
-							bool doSlot1Update = false;
-							if (gamecardIsInserted() && gamecardGetType() == CARD_TYPE_UNKNOWN) {
-								// Card is inserted, but we don't know its type.
-								// Force an update.
-								forcePoll = true;
-							}
-							bool s1chg = gamecardPoll(forcePoll);
-							if (s1chg) {
-								// Update Slot-1 if:
-								// - forcePoll is false
-								// - forcePoll is true, and card is no longer unknown.
-								doSlot1Update = (!forcePoll || gamecardGetType() != CARD_TYPE_UNKNOWN);
-							}
-							if (doSlot1Update) {
-								// Slot-1 card has changed.
-								if (cursorPosition == -1) {
-									// Reload the banner text.
-									bannertextloaded = false;
-								}
-							}
-
-							if (settings.ui.iconsize)
-								sf2d_draw_texture_scale(carttex(), -24+cartXpos+titleboxXmovepos*1.25, 111, 1.25, 1.25);
-							else
-								sf2d_draw_texture(carttex(), cartXpos+titleboxXmovepos, 120);
-							sf2d_texture *cardicontex = gamecardGetIcon();
-							if (!cardicontex)
-								cardicontex = iconnulltex;
-							if (settings.ui.iconsize)
-								sf2d_draw_texture_part_scale(cardicontex, -4+cartXpos+titleboxXmovepos*1.25, 127, bnriconframenum*32, 0, 32, 32, 1.25, 1.25);
-							else
-								sf2d_draw_texture_part(cardicontex, 16+cartXpos+titleboxXmovepos, 133, bnriconframenum*32, 0, 32, 32);
-						} else {
-							// Get flash cart games.
-							if (settings.ui.iconsize)
-								sf2d_draw_texture_scale(getfcgameboxtex, -24+cartXpos+titleboxXmovepos*1.25, 111, 1.25, 1.25);
-							else
-								sf2d_draw_texture(getfcgameboxtex, cartXpos+titleboxXmovepos, 119);
-						}
-					} else {
-						sf2d_draw_texture(bracetex, 32+cartXpos+titleboxXmovepos, 116);
-					}
-
-					if (settings.ui.iconsize) {
-						titleboxXpos = 120;
-						ndsiconXpos = 140;
-					} else {
-						titleboxXpos = 128;
-						ndsiconXpos = 144;
-					}
-					//filenameYpos = 0;
-					for (filenum = pagenum*20; filenum < pagemax; filenum++) {
-						if (settings.ui.iconsize) {
-							sf2d_draw_texture_scale(boxfulltex, titleboxXpos+titleboxXmovepos*1.25, 112, 1.25, 1.25);
-							titleboxXpos += 80;
-
-							bnriconnum = filenum;
-							ChangeBNRIconNo();
-							sf2d_draw_texture_part_scale(bnricontexnum, ndsiconXpos+titleboxXmovepos*1.25, 127, bnriconframenum*32, 0, 32, 32, 1.25, 1.25);
-							ndsiconXpos += 80;
-						} else {
-							sf2d_draw_texture(boxfulltex, titleboxXpos+titleboxXmovepos, 120);
-							titleboxXpos += 64;
-
-							bnriconnum = filenum;
-							ChangeBNRIconNo();
-							sf2d_draw_texture_part(bnricontexnum, ndsiconXpos+titleboxXmovepos, 133, bnriconframenum*32, 0, 32, 32);
-							ndsiconXpos += 64;
-						}
-					}
-
-					if (settings.ui.iconsize) {
-						sf2d_draw_texture_scale(bracetex, 15+ndsiconXpos+titleboxXmovepos*1.25, 108, -1.25, 1.25);
-					} else {
-						sf2d_draw_texture_scale(bracetex, 15+ndsiconXpos+titleboxXmovepos, 116, -1, 1);
-					}
-					if (!applaunchprep) {
-						if (titleboxXmovetimer == 0) {
-							startbordermovepos = 0;
-							startborderscalesize = 1.0;
-						}
-						if (!settings.twl.forwarder && cursorPosition == -1 && !gamecardIsInserted()) {
-							// Slot-1 selected, but no cartridge is present.
-							// Don't print "START" and the cursor border.
-						} else {
-							if (!is3DSX || cursorPosition == -2) {
-								// Print "START" and the cursor border.
-								if (settings.ui.iconsize) {
-									sf2d_draw_texture_scale(startbordertex, 120+startbordermovepos, 108+startbordermovepos, startborderscalesize+0.25, startborderscalesize+0.25);
-									const wchar_t *start_text = TR(STR_START);
-									const int start_width = sftd_get_wtext_width(font_b, 16, start_text);
-									sftd_draw_wtext(font_b, (320-start_width)/2, 183, RGBA8(255, 255, 255, 255), 16, start_text);
-								} else {
-									sf2d_draw_texture_scale(startbordertex, 128+startbordermovepos, 116+startbordermovepos, startborderscalesize, startborderscalesize);
-									const wchar_t *start_text = TR(STR_START);
-									const int start_width = sftd_get_wtext_width(font_b, 12, start_text);
-									sftd_draw_wtext(font_b, (320-start_width)/2, 177, RGBA8(255, 255, 255, 255), 12, start_text);
-								}
-							}
-						}
-					} else {
-						if (settings.ui.custombot)
-							sf2d_draw_texture_part(bottomtex, 128, 116, 128, 116, 64, 80);
-						else
-							sf2d_draw_texture_part_blend(bottomtex, 128, 116, 128, 116, 64, 80, SET_ALPHA(menucolor, 255));  // Cover selected game/app
-						if (cursorPosition == -2) {
-							sf2d_draw_texture(settingsicontex, 128, titleboxYmovepos-1); // Draw settings box that moves up
-						} else if (cursorPosition == -1) {
-							if (settings.twl.forwarder)
-								sf2d_draw_texture(getfcgameboxtex, 128, titleboxYmovepos-1);
-							else {
-								// Draw selected Slot-1 game that moves up
-								sf2d_draw_texture(carttex(), 128, titleboxYmovepos);
-								sf2d_texture *cardicontex = gamecardGetIcon();
-								if (!cardicontex)
-									cardicontex = iconnulltex;
-								sf2d_draw_texture(cardicontex, 144, ndsiconYmovepos);
-							}
-						} else {
-							sf2d_draw_texture(boxfulltex, 128, titleboxYmovepos); // Draw selected game/app that moves up
-							if (!applaunchicon) {
-								bnriconnum = cursorPosition;
-								ChangeBNRIconNo();
-								bnricontexlaunch = bnricontexnum;
-								applaunchicon = true;
-							}
-							sf2d_draw_texture_part(bnricontexlaunch, 144, ndsiconYmovepos, bnriconframenum*32, 0, 32, 32);
-						}
-						sf2d_draw_texture_rotate(dotcircletex, 160, 152, rad);  // Dots moving in circles
-					}
-					if (menudbox_Ypos != -240) {
-						// Draw the menu dialog box.
-						drawMenuDialogBox();
-					}
-				}
-			} else if (screenmode == SCREEN_MODE_SETTINGS) {
-				if (colortexloaded_bot) {
-					sf2d_free_texture(dotcircletex);
-					dotcircletex = NULL;
-					sf2d_free_texture(startbordertex);
-					startbordertex = NULL;
-					sf2d_free_texture(bottomtex);
-					bottomtex = NULL;
-					colortexloaded_bot = false;
-				}
-				settingsDrawBottomScreen();
-			}
-		if (settings.ui.theme == 0)
-			sf2d_draw_rectangle(0, 0, 320, 240, RGBA8(0, 0, 0, fadealpha)); // Fade in/out effect
-
-		sf2d_end_frame();
-		// }
-		
-		sf2d_swapbuffers();
-
-
-		/* if (titleboxXmovetimer == 0) {
-			updatebotscreen = false;
-		} */
-		if (screenmode == SCREEN_MODE_ROM_SELECT) {
-			/* if (filenum == 0) {	// If no ROMs are found
-				romselect_layout = 1;
-				updatebotscreen = true;
-			} */
-			if (settings.ui.theme == 2) {
-				if (menu_ctrlset == CTRL_SET_MENU) {
-					if (hDown & KEY_A) {
-						switch (woodmenu_cursorPosition) {
-							case 0:
-							default:
-								menu_ctrlset = CTRL_SET_GAMESEL;
-								if (settings.twl.forwarder) {
-									settings.twl.forwarder = false;
-									cursorPosition = 0;
-									pagenum = 0;
-									boxarttexloaded = false; // Reload boxarts
-									bnricontexloaded = false; // Reload banner icons
-									bannertextloaded = false;
-								}
-								break;
-							case 1:
-								menu_ctrlset = CTRL_SET_GAMESEL;
-								if (!settings.twl.forwarder) {
-									settings.twl.forwarder = true;
-									cursorPosition = 0;
-									pagenum = 0;
-									boxarttexloaded = false; // Reload boxarts
-									bnricontexloaded = false; // Reload banner icons
-									bannertextloaded = false;
-								}
-								break;
-							case 2:
-								if (!is3DSX) {
-									settings.twl.launchslot1 = true;
-									settings.twl.forwarder = false;
-									if (logEnabled)	LogFM("Main", "Switching to NTR/TWL-mode");
-									applaunchon = true;
-								}
-								break;
-							case 3:
-								if (!is3DSX) {
-									gbarunnervalue = 1;
-									settings.ui.romfolder = "_nds";									
-									rom = "GBARunner2.nds";
-									if (settings.twl.forwarder)
-										settings.twl.launchslot1 = true;
-									else
-										settings.twl.launchslot1 = false;
-									if (logEnabled)	LogFM("Main", "Switching to NTR/TWL-mode");
-									applaunchon = true;
-								}
-								break;
-							case 4:
-								sf2d_set_3D(1);
-								screenmode = SCREEN_MODE_SETTINGS;
-								settingsResetSubScreenMode();
-								break;
-						}
-						wood_ndsiconscaletimer = 0;
-					} else if(hDown & KEY_DOWN){
-						woodmenu_cursorPosition++;
-						if (woodmenu_cursorPosition > 4) {
-							woodmenu_cursorPosition = 4;
-						}
-						wood_ndsiconscaletimer = 0;
-					} else if(hDown & KEY_UP){
-						woodmenu_cursorPosition--;
-						if (woodmenu_cursorPosition < 0) {
-							woodmenu_cursorPosition = 0;
-						}
-						wood_ndsiconscaletimer = 0;
-					}
-				} else {
-					if(cursorPosition < 0) {
-						filenameYmovepos = 0;
-						titleboxXmovepos -= 64;
-						boxartXmovepos -= 18*8;
-						cursorPosition = 0;
-						// updatebotscreen = true;
-					}
-					if(hDown & KEY_A){
-						if (!is3DSX) {
-							if (settings.twl.forwarder) {
-								settings.twl.launchslot1 = true;
-								// if(matching_files.size() == 0){
-									rom = fcfiles.at(cursorPosition).c_str();
-								// }else {
-							// 	rom = matching_files.at(cursorPosition).c_str();
-							// }
-							} else {
-								settings.twl.launchslot1 = false;
-								// if(matching_files.size() == 0){
-									rom = files.at(cursorPosition).c_str();
-								// }else {
-								// 	rom = matching_files.at(cursorPosition).c_str();
-								// }
-								sav = ReplaceAll(rom, ".nds", ".sav");
-							}
-							if (logEnabled)	LogFM("Main", "Switching to NTR/TWL-mode");
-							applaunchon = true;
-						}
-						wood_ndsiconscaletimer = 0;
-					} else if(hDown & KEY_L){
-						if ((size_t)pagenum != 0 && file_count <= (size_t)0-pagenum*20) {
-							pagenum--;
-							bannertextloaded = false;
-							cursorPosition = 0+pagenum*20;
-							bnricontexloaded = false;
-							boxarttexloaded = false;
-						}
-					} else if(hDown & KEY_R){
-						if (file_count > (size_t)pagemax) {
-							pagenum++;
-							bannertextloaded = false;
-							cursorPosition = 0+pagenum*20;
-							bnricontexloaded = false;
-							boxarttexloaded = false;
-						}
-					} else if(hDown & KEY_DOWN){
-						cursorPosition++;
-						if (cursorPosition >= pagemax) {
-							cursorPosition = 0+pagenum*20;
-						}
-						wood_downpressed = true;
-						wood_ndsiconscaletimer = 0;
-						bannertextloaded = false;
-					} else if((hDown & KEY_UP) && (filenum > 1)){
-						cursorPosition--;
-						if (cursorPosition < 0+pagenum*20) {
-							cursorPosition = pagemax-1;
-						}
-						wood_uppressed = true;
-						wood_ndsiconscaletimer = 0;
-						bannertextloaded = false;
-					} else if (hDown & KEY_B) {
-						menu_ctrlset = CTRL_SET_MENU;
-						wood_ndsiconscaletimer = 0;
-					}
-					if (filenum > 4) {
-						if (cursorPosition > 2+pagenum*20)
-							filenameYmovepos = -cursorPosition+2+pagenum*20;
-						else
-							filenameYmovepos = 0;
-					}
-				}
-			} else if (settings.ui.theme == 1) {
-				if (menu_ctrlset == CTRL_SET_MENU) {
-					if (hDown & KEY_A) {
-						switch (r4menu_cursorPosition) {
-							case 0:
-							default:
-								menu_ctrlset = CTRL_SET_GAMESEL;
-								updatetopscreen = true;
-								break;
-							case 1:
-								if (!is3DSX) {
-									settings.twl.launchslot1 = true;
-									settings.twl.forwarder = false;
-									if (logEnabled)	LogFM("Main", "Switching to NTR/TWL-mode");
-									applaunchon = true;
-								}
-								break;
-							case 2:
-								if (!is3DSX) {
-									gbarunnervalue = 1;
-									settings.ui.romfolder = "_nds";									
-									rom = "GBARunner2.nds";
-									if (settings.twl.forwarder)
-										settings.twl.launchslot1 = true;
-									else
-										settings.twl.launchslot1 = false;
-									if (logEnabled)	LogFM("Main", "Switching to NTR/TWL-mode");
-									applaunchon = true;
-								}
-								break;
-						}
-					} else if (hDown & KEY_RIGHT) {
-						r4menu_cursorPosition++;
-						if (r4menu_cursorPosition > 2) {
-							r4menu_cursorPosition = 2;
-						}
-					} else if (hDown & KEY_LEFT) {
-						r4menu_cursorPosition--;
-						if (r4menu_cursorPosition < 0) {
-							r4menu_cursorPosition = 0;
-						}
-					} else if (hDown & KEY_SELECT) {
-						sf2d_set_3D(1);
-						screenmode = SCREEN_MODE_SETTINGS;
-						settingsResetSubScreenMode();
-						updatetopscreen = true;
-					}
-				} else {
-					if(cursorPosition < 0) {
-						filenameYmovepos = 0;
-						titleboxXmovepos -= 64;
-						boxartXmovepos -= 18*8;
-						cursorPosition = 0;
-						updatetopscreen = true;
-					}
-					if(hDown & KEY_L) {
-						settings.twl.forwarder = !settings.twl.forwarder;
-						cursorPosition = 0;
-						pagenum = 0;
-						boxarttexloaded = false; // Reload boxarts
-						bnricontexloaded = false; // Reload banner icons
-						bannertextloaded = false;
-						updatetopscreen = true;
-					}
-					if(hDown & KEY_A){
-						if (!is3DSX) {
-							if (settings.twl.forwarder) {
-								settings.twl.launchslot1 = true;
-								// if(matching_files.size() == 0){
-									rom = fcfiles.at(cursorPosition).c_str();
-								// }else {
-							// 	rom = matching_files.at(cursorPosition).c_str();
-							// }
-							} else {
-								settings.twl.launchslot1 = false;
-								// if(matching_files.size() == 0){
-									rom = files.at(cursorPosition).c_str();
-								// }else {
-								// 	rom = matching_files.at(cursorPosition).c_str();
-								// }
-								sav = ReplaceAll(rom, ".nds", ".sav");
-							}
-							if (logEnabled)	LogFM("Main", "Switching to NTR/TWL-mode");
-							applaunchon = true;
-						}
-					} else if(hDown & KEY_DOWN){
-						cursorPosition++;
-						if (cursorPosition == filenum) {
-							filenameYmovepos = 0;
-							cursorPosition = 0;
-						}
-						bannertextloaded = false;
-						updatetopscreen = true;
-					} else if((hDown & KEY_UP) && (filenum > 1)){
-						if (cursorPosition == 0) {
-							cursorPosition = filenum;
-						}
-						cursorPosition--;
-						bannertextloaded = false;
-						updatetopscreen = true;
-					} else if ((hDown & KEY_LEFT) && (filenum > 10)) {
-						cursorPosition -= 10;
-						if (cursorPosition < 0) {
-							cursorPosition = 0;
-						}
-						bannertextloaded = false;			
-						updatetopscreen = true;
-					} else if ((hDown & KEY_RIGHT) && (filenum > 10)) {
-						cursorPosition += 10;
-						if (cursorPosition >= filenum) {
-							cursorPosition = filenum-1;
-						}
-						bannertextloaded = false;			
-						updatetopscreen = true;
-					} else if (hDown & KEY_B) {
-						menu_ctrlset = CTRL_SET_MENU;
-						updatetopscreen = true;
-					}
-					if (filenum > 15) {
-						/* if (cursorPosition > filenum-8) {}
-						else */ if (cursorPosition > 7)
-							filenameYmovepos = -cursorPosition+7;
-						else
-							filenameYmovepos = 0;
-					}
-				}
-			} else {
-				startbordermovepos = 0;
-				startborderscalesize = 1.0;
-				if (!noromsfound && file_count == 0) {
-					// No ROMs were found.
-					cursorPosition = -1;
-					storedcursorPosition = cursorPosition;
-					titleboxXmovepos = +64;
-					boxartXmovepos = 0;
-					// updatebotscreen = true;
-					noromsfound = true;
-				}
-				if(titleboxXmovetimer == 0 && menu_ctrlset == CTRL_SET_GAMESEL) {
-					if(hDown & KEY_R) {
-						menuaction_nextpage = true;
-					} else if(hDown & KEY_L) {
-						menuaction_prevpage = true;
-					}
-					if(hDown & KEY_Y) {
-						if (dspfirmfound) {
-							sfx_switch->stop();	// Prevent freezing
-							sfx_switch->play();
-						}
-						settings.ui.iconsize = !settings.ui.iconsize;
-					}
-					hidTouchRead(&touch);
-					if(hDown & KEY_TOUCH){
-						if (touch.px >= 128 && touch.px <= 192 && touch.py >= 112 && touch.py <= 192) {
-							menuaction_launch = true;
-						} else if (touch.px < 128 && touch.py >= 118 && touch.py <= 180  && menudbox_Ypos == -240) {
-							//titleboxXmovepos -= 64;
-							if (!titleboxXmoveright) {
-								titleboxXmoveleft = true;
-							}
-							// updatebotscreen = true;
-						} else if (touch.px > 192 && touch.py >= 118 && touch.py <= 180  && menudbox_Ypos == -240) {
-							//titleboxXmovepos -= 64;
-							if (!titleboxXmoveleft) {
-								if (cursorPosition == -1) {
-									if (filenum == 0) {
-										if (!playwrongsounddone) {
-											if (dspfirmfound) {
-												sfx_wrong->stop();
-												sfx_wrong->play();
-											}
-											playwrongsounddone = true;
-										}
-									} else {
-										titleboxXmoveright = true;
-									}
-								} else {
-									titleboxXmoveright = true;
-								}
-							}
-							// updatebotscreen = true;
-						}
-					} else if(hDown & KEY_A){
-						menuaction_launch = true;
-					} else if(hHeld & KEY_RIGHT && menudbox_Ypos == -240){
-						//titleboxXmovepos -= 64;
-						if (!titleboxXmoveleft) {
-							if (cursorPosition == -1) {
-								if (filenum == 0) {
-									if (!playwrongsounddone) {
-										if (dspfirmfound) {
-											sfx_wrong->stop();
-											sfx_wrong->play();
-										}
-										playwrongsounddone = true;
-									}
-								} else {
-									titleboxXmoveright = true;
-								}
-							} else {
-								titleboxXmoveright = true;
-							}
-						}
-						// updatebotscreen = true;
-					} else if(hHeld & KEY_LEFT && menudbox_Ypos == -240){
-						//titleboxXmovepos += 64;
-						if (!titleboxXmoveright) {
-							titleboxXmoveleft = true;
-						}
-						// updatebotscreen = true;
-					} else if (hDown & KEY_START) {
-						// Switch to the "Start" menu.
-						menudboxmode = DBOX_MODE_OPTIONS;
-						if (!showdialogbox_menu) {
-							if (menudbox_Ypos == -240) {
-								showdialogbox_menu = true;
-								menu_ctrlset = CTRL_SET_DBOX;
-								// Reset the cursor positions.
-								startmenu_cursorPosition = 0;
-								gamesettings_cursorPosition = 0;
-							}
-						}
-					} else if (hDown & KEY_SELECT) {
-						// Switch to per-game settings.
-						menudboxmode = DBOX_MODE_SETTINGS;
-						if (!showdialogbox_menu) {
-							if (cursorPosition >= 0 && menudbox_Ypos == -240) {
-								if (settings.twl.forwarder) {
-									if(matching_files.size() == 0){
-										rom = fcfiles.at(cursorPosition).c_str();
-									} else {
-										rom = matching_files.at(cursorPosition).c_str();
-									}
-								} else {
-									if(matching_files.size() == 0){
-										rom = files.at(cursorPosition).c_str();
-									} else {
-										rom = matching_files.at(cursorPosition).c_str();
-									}
-								}
-								LoadPerGameSettings();
-								showdialogbox_menu = true;
-								menu_ctrlset = CTRL_SET_DBOX;
-								// Reset the cursor positions.
-								startmenu_cursorPosition = 0;
-								gamesettings_cursorPosition = 0;
-							}
-						}
-					}
-					
-					if (menuaction_nextpage) {
-						// Don't run the action again 'til R is pressed again
-						menuaction_nextpage = false;
-						if (file_count > (size_t)pagemax) {
-							pagenum++;
-							bannertextloaded = false;
-							cursorPosition = 0+pagenum*20;
-							storedcursorPosition = cursorPosition;
-							titleboxXmovepos = 0;
-							boxartXmovepos = 0;
-							// noromsfound = false;
-							bnricontexloaded = false;
-							boxarttexloaded = false;
-							if (dspfirmfound) {
-								sfx_switch->stop();	// Prevent freezing
-								sfx_switch->play();
-							}
-							// updatebotscreen = true;
-						}
-					} else if (menuaction_prevpage) {
-						// Don't run the action again 'til L is pressed again
-						menuaction_prevpage = false;
-						if ((size_t)pagenum != 0 && file_count <= (size_t)0-pagenum*20) {
-							pagenum--;
-							bannertextloaded = false;
-							cursorPosition = 0+pagenum*20;
-							storedcursorPosition = cursorPosition;
-							titleboxXmovepos = 0;
-							boxartXmovepos = 0;
-							// noromsfound = false;
-							bnricontexloaded = false;
-							boxarttexloaded = false;
-							if (dspfirmfound) {
-								sfx_switch->stop();	// Prevent freezing
-								sfx_switch->play();
-							}
-							// updatebotscreen = true;
-						}
-					} else if (menuaction_launch) { menuaction_launch = false;	// Don't run the action again 'til A is pressed again
-						if (!is3DSX || cursorPosition == -2) {
-							bool playlaunchsound = true;
-							if (titleboxXmovetimer == 0) {
-								if(cursorPosition == -2) {
-									titleboxXmovetimer = 1;
-									screenmodeswitch = true;
-									applaunchprep = true;
-								} else if(cursorPosition == -1) {
-									if (!settings.twl.forwarder && !gamecardIsInserted()) {
-										// Slot-1 is selected, but no
-										// cartridge is present.
-										if (!playwrongsounddone) {
-											if (dspfirmfound) {
-												sfx_wrong->stop();
-												sfx_wrong->play();
-											}
-											playwrongsounddone = true;
-										}
-										playlaunchsound = false;
-									} else {
-										titleboxXmovetimer = 1;
-										settings.twl.launchslot1 = true;
-										if (settings.twl.forwarder) {
-											keepsdvalue = true;
-											rom = "_nds/twloader.nds";
-										}
-										applaunchprep = true;
-									}
-								} else {
-									titleboxXmovetimer = 1;
-									if (settings.twl.forwarder) {
-										settings.twl.launchslot1 = true;
-										if(matching_files.size() == 0){
-											rom = fcfiles.at(cursorPosition).c_str();
-										}else {
-											rom = matching_files.at(cursorPosition).c_str();
-										}
-									} else {
-										settings.twl.launchslot1 = false;
-										if(matching_files.size() == 0){
-											rom = files.at(cursorPosition).c_str();
-										}else {
-											rom = matching_files.at(cursorPosition).c_str();
-										}
-										sav = ReplaceAll(rom, ".nds", ".sav");
-									}
-									applaunchprep = true;
-								}
-							}
-							if (playlaunchsound && dspfirmfound) {
-								bgm_menu->stop();
-								sfx_launch->play();
-							}
-						} else {
-							if (!playwrongsounddone) {
-								if (dspfirmfound) {
-									sfx_wrong->stop();
-									sfx_wrong->play();
-								}
-								playwrongsounddone = true;
-							}
-						}
-					}
-					
-				} else if(menu_ctrlset == CTRL_SET_DBOX) {
-					hidTouchRead(&touch);
-					
-					if (menudboxmode == DBOX_MODE_OPTIONS) {
-						if (hDown & KEY_SELECT) {
-							if (cursorPosition >= 0) {
-								// Switch to game-specific settings.
-								menudboxmode = DBOX_MODE_SETTINGS;
-							}
-						} else if (hDown & KEY_RIGHT) {
-							if (startmenu_cursorPosition % 2 != 1 &&
-							    startmenu_cursorPosition != 5)
-							{
-								// Move right.
-								startmenu_cursorPosition++;
-							}
-						} else if (hDown & KEY_LEFT) {
-							if (startmenu_cursorPosition % 2 != 0) {
-								// Move left.
-								startmenu_cursorPosition--;
-							}
-						} else if (hDown & KEY_DOWN) {
-							if (startmenu_cursorPosition < 4) {
-								startmenu_cursorPosition += 2;
-							}
-	
-						} else if (hDown & KEY_UP) {
-							if (startmenu_cursorPosition > 1) {
-								startmenu_cursorPosition -= 2;
-							}
-						} else if(hDown & KEY_TOUCH){
-							if (touch.px >= 23 && touch.px <= 155 && touch.py >= 31 && touch.py <= 65) { // Game location button
-								startmenu_cursorPosition = 0;
-								menudboxaction_switchloc = true;
-							}else if (touch.px >= 161 && touch.px <= 293 && touch.py >= 31 && touch.py <= 65){ // Box art button
-								startmenu_cursorPosition = 1;
-								settings.romselect.toplayout = !settings.romselect.toplayout;
-								if (dspfirmfound) {
-									sfx_switch->stop();	// Prevent freezing
-									sfx_switch->play();
-								}
-							}else if (touch.px >= 23 && touch.px <= 155 && touch.py >= 71 && touch.py <= 105){ // Start GBARunner2 button
-								startmenu_cursorPosition = 2;
-								if (!is3DSX) {
-									gbarunnervalue = 1;
-									settings.ui.romfolder = "_nds";
-									rom = "GBARunner2.nds";
-									if (settings.twl.forwarder) {
-										settings.twl.launchslot1 = true;
-									} else {
-										settings.twl.launchslot1 = false;
-									}
-									fadeout = true;
-									if (dspfirmfound) {
-										bgm_menu->stop();
-										sfx_launch->play();
-									}
-								} else {
-									if (!playwrongsounddone) {
-										if (dspfirmfound) {
-											sfx_wrong->stop();
-											sfx_wrong->play();
-										}
-										playwrongsounddone = true;
-									}
-								}
-							}else if (touch.px >= 161 && touch.px <= 293 && touch.py >= 71 && touch.py <= 105){ // Top border button
-								startmenu_cursorPosition = 3;
-								settings.ui.topborder = !settings.ui.topborder;
-							}else if (touch.px >= 23 && touch.px <= 155 && touch.py >= 111 && touch.py <= 145){ // Unset donor ROM button
-								startmenu_cursorPosition = 4;
-								bootstrapini.SetString(bootstrapini_ndsbootstrap, "ARM7_DONOR_PATH", "");
-								bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
-								showdialogbox_menu = false;
-								menudbox_movespeed = 1;
-								menu_ctrlset = CTRL_SET_GAMESEL;
-							}else if (touch.px >= 161 && touch.px <= 293 && touch.py >= 111 && touch.py <= 145){ // Search button
-								startmenu_cursorPosition = 5; // Only this is making sometimes to not show the light texture								
-								if(matching_files.size() != 0){
-									matching_files.clear();
-									snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
-									snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size());
-								}
-								
-								std::string gameName = keyboardInput(TR(STR_START_SEARCH_HINT));
-								if (logEnabled)	LogFMA("Main.search","Text written", gameName.c_str());
-								
-								if(!settings.twl.forwarder){
-									// SD CARD
-									for (auto iter = files.cbegin(); iter != files.cend(); ++iter) {
-										if (iter->size() < gameName.size()) {
-											// Filename we're checking is shorter than the search term,
-											// so it can't match.
-											continue;
-										}
-										// Use C string comparison for case-insensitive checks.
-										if (strcasestr(iter->c_str(), gameName.c_str()) != NULL) {
-											// String matches.
-											matching_files.push_back(*iter);
-										}
-									}
-								}else{
-									// FLASHCARD
-									for (auto iter = fcfiles.cbegin(); iter != fcfiles.cend(); ++iter) {
-										if (iter->size() < gameName.size()) {
-											// Filename we're checking is shorter than the search term,
-											// so it can't match.
-											continue;
-										}
-										// Use C string comparison for case-insensitive checks.
-										if (strcasestr(iter->c_str(), gameName.c_str()) != NULL) {
-											// String matches.
-											matching_files.push_back(*iter);
-										}
-									}
-								}							
-
-								if (matching_files.size() != 0) {
-									/** Prepare some stuff to show correctly the filtered roms */
-									pagenum = 0; // Go to page 0
-									cursorPosition = 0; // Move the cursor to 0
-									storedcursorPosition = cursorPosition; // Move the cursor to 0
-									titleboxXmovepos = 0; // Move the cursor to 0
-									boxartXmovepos = 0; // Move the cursor to 0
-									snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", matching_files.size()); // Reload counter
-									boxarttexloaded = false; // Reload boxarts
-									bnricontexloaded = false; // Reload banner icons
-								}
-								sf2d_draw_texture(dboxtex_button, 161, menudbox_Ypos + 111); // Light the button to print it always
-								showdialogbox_menu = false;
-								menudbox_movespeed = 1;
-								menu_ctrlset = CTRL_SET_GAMESEL;			
-							}else if (touch.px >= 233 && touch.px <= 299 && touch.py >= (menudbox_Ypos + 191) && touch.py <= (menudbox_Ypos + 217)){ // Back button
-								showdialogbox_menu = false;
-								menudbox_movespeed = 1;
-								menu_ctrlset = CTRL_SET_GAMESEL;
-							}
-						} else if (hDown & KEY_A) {
-							switch (startmenu_cursorPosition) {
-								case 0:
-								default:
-									menudboxaction_switchloc = true;
-									break;
-								case 1:
-									settings.romselect.toplayout = !settings.romselect.toplayout;
-									if (dspfirmfound) {
-										sfx_switch->stop();	// Prevent freezing
-										sfx_switch->play();
-									}
-									break;
-								case 2:
-									if (!is3DSX) {
-										gbarunnervalue = 1;
-										settings.ui.romfolder = "_nds";
-										rom = "GBARunner2.nds";
-										if (settings.twl.forwarder) {
-											settings.twl.launchslot1 = true;
-										} else {
-											settings.twl.launchslot1 = false;
-										}
-										fadeout = true;
-										if (dspfirmfound) {
-											bgm_menu->stop();
-											sfx_launch->play();
-										}
-									} else {
-										if (!playwrongsounddone) {
-											if (dspfirmfound) {
-												sfx_wrong->stop();
-												sfx_wrong->play();
-											}
-											playwrongsounddone = true;
-										}
-									}
-									break;
-								case 3:
-									settings.ui.topborder = !settings.ui.topborder;
-									break;
-								case 4:
-									// Unset donor ROM path
-									bootstrapini.SetString(bootstrapini_ndsbootstrap, "ARM7_DONOR_PATH", "");
-									bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
-									showdialogbox_menu = false;
-									menudbox_movespeed = 1;
-									menu_ctrlset = CTRL_SET_GAMESEL;
-									break;
-								case 5: {
-									// Search
-									if(matching_files.size() != 0){
-										matching_files.clear();
-										snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
-									}
-									
-									std::string gameName = keyboardInput(TR(STR_START_SEARCH_HINT));
-									if (logEnabled)	LogFMA("Main.search","Text written", gameName.c_str());
-									
-									for (auto iter = files.cbegin(); iter != files.cend(); ++iter) {
-										if (iter->size() < gameName.size()) {
-											// Filename we're checking is shorter than the search term,
-											// so it can't match.
-											continue;
-										}
-
-										// Check if the game name contains the search term.
-										// (Case-insensitive search.)
-										if (strcasestr(iter->c_str(), gameName.c_str()) != NULL) {
-											// String matches.
-											matching_files.push_back(*iter);
-										}
-									}
-
-									if (matching_files.size() != 0) {
-										/** Prepare some stuff to show correctly the filtered roms */
-										pagenum = 0; // Go to page 0
-										cursorPosition = 0; // Move the cursor to 0
-										storedcursorPosition = cursorPosition; // Move the cursor to 0
-										titleboxXmovepos = 0; // Move the cursor to 0
-										boxartXmovepos = 0; // Move the cursor to 0
-										snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", matching_files.size()); // Reload counter
-										boxarttexloaded = false; // Reload boxarts
-										bnricontexloaded = false; // Reload banner icons
-									}
-									showdialogbox_menu = false;
-									menudbox_movespeed = 1;
-									menu_ctrlset = CTRL_SET_GAMESEL;
-									break;
-								}
-							}
-						} else if (hDown & (KEY_B | KEY_START)) {
-							showdialogbox_menu = false;
-							menudbox_movespeed = 1;
-							menu_ctrlset = CTRL_SET_GAMESEL;
-						}
-					} else if (menudboxmode == DBOX_MODE_SETTINGS) {
-						hidTouchRead(&touch);
-						
-						if (hDown & KEY_START) {
-							// Switch to the "Start" menu.
-							if (settings.twl.forwarder) {
-								if(matching_files.size() == 0){
-									rom = fcfiles.at(cursorPosition).c_str();
-								} else {
-									rom = matching_files.at(cursorPosition).c_str();
-								}
-							} else {
-								if (matching_files.size() == 0) {
-									rom = files.at(cursorPosition).c_str();
-								}else{
-									rom = matching_files.at(cursorPosition).c_str();
-								}
-								
-							}
-							SavePerGameSettings();
-							menudboxmode = DBOX_MODE_OPTIONS;
-						} else if (hDown & KEY_RIGHT) {
-							if (gamesettings_cursorPosition == 0) {
-								gamesettings_cursorPosition = 1;
-							} else if (gamesettings_cursorPosition == 2) {
-								gamesettings_cursorPosition = 3;
-							}
-						} else if (hDown & KEY_LEFT) {
-							if (gamesettings_cursorPosition == 1) {
-								gamesettings_cursorPosition = 0;
-							} else if (gamesettings_cursorPosition == 3) {
-								gamesettings_cursorPosition = 2;
-							}
-						} else if (hDown & KEY_DOWN) {
-							if (gamesettings_cursorPosition == 0) {
-								gamesettings_cursorPosition = 2;
-							} else if (gamesettings_cursorPosition == 1) {
-								gamesettings_cursorPosition = 3;
-							} else if (gamesettings_cursorPosition == 2) {
-								gamesettings_cursorPosition = 4;
-							}
-						} else if (hDown & KEY_UP) {
-							if (gamesettings_cursorPosition == 2) {
-								gamesettings_cursorPosition = 0;
-							} else if (gamesettings_cursorPosition == 3) {
-								gamesettings_cursorPosition = 1;
-							} else if (gamesettings_cursorPosition == 4) {
-								gamesettings_cursorPosition = 2;
-							}
-						} else if(hDown & KEY_TOUCH){
-							if (touch.px >= 23 && touch.px <= 155 && touch.py >= 89 && touch.py <= 123) { // ARM9 CPU Speed
-								gamesettings_cursorPosition = 0;
-								settings.pergame.cpuspeed++;
-								if(settings.pergame.cpuspeed == 2)
-									settings.pergame.cpuspeed = -1;
-								if (dspfirmfound) {
-									sfx_select->stop();	// Prevent freezing
-									sfx_select->play();
-								}
-							}else if (touch.px >= 161 && touch.px <= 293 && touch.py >= 89 && touch.py <= 123){ // VRAM boost
-								gamesettings_cursorPosition = 1;
-								settings.pergame.extvram++;
-								if(settings.pergame.extvram == 2)
-									settings.pergame.extvram = -1;
-								if (dspfirmfound) {
-									sfx_select->stop();	// Prevent freezing
-									sfx_select->play();
-								}
-							}else if (touch.px >= 23 && touch.px <= 155 && touch.py >= 129 && touch.py <= 163){ // Lock ARM9 SCFG_EXT
-								gamesettings_cursorPosition = 2;
-								settings.pergame.lockarm9scfgext++;
-								if(settings.pergame.lockarm9scfgext == 2)
-									settings.pergame.lockarm9scfgext = -1;
-								if (dspfirmfound) {
-									sfx_select->stop();	// Prevent freezing
-									sfx_select->play();
-								}
-							}else if (touch.px >= 161 && touch.px <= 293 && touch.py >= 129 && touch.py <= 163){ // Set as donor ROM
-								gamesettings_cursorPosition = 3;
-								if (settings.twl.forwarder) {
-									if(matching_files.size() == 0){
-										rom = fcfiles.at(cursorPosition).c_str();
-									} else {
-										rom = matching_files.at(cursorPosition).c_str();
-									}
-								} else {
-									if(matching_files.size() == 0){
-										rom = files.at(cursorPosition).c_str();
-									}else{
-										rom = matching_files.at(cursorPosition).c_str();
-									}
-									bootstrapini.SetString(bootstrapini_ndsbootstrap, "ARM7_DONOR_PATH", fat+settings.ui.romfolder+slashchar+rom);
-									bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
-								}
-								showdialogbox_menu = false;
-								menudbox_movespeed = 1;
-								menu_ctrlset = CTRL_SET_GAMESEL;
-							}else if (touch.px >= 23 && touch.px <= 155 && touch.py >= 169 && touch.py <= 203){ // Set LED Color
-								gamesettings_cursorPosition = 4;								
-
-								RGB[0] = keyboardInputInt("Red color: max is 255");
-								RGB[1] = keyboardInputInt("Green color: max is 255");
-								RGB[2] = keyboardInputInt("Blue color: max is 255");
-								
-								settings.pergame.red = RGB[0];
-								settings.pergame.green = RGB[1];
-								settings.pergame.blue = RGB[2];
-								
-							}else if (touch.px >= 233 && touch.px <= 299 && touch.py >= (menudbox_Ypos + 191) && touch.py <= (menudbox_Ypos + 217)){ // Back button
-								if (settings.twl.forwarder) {
-									if(matching_files.size() == 0){
-										rom = fcfiles.at(cursorPosition).c_str();
-									} else {
-										rom = matching_files.at(cursorPosition).c_str();
-									}
-								} else {
-									if(matching_files.size() == 0){
-										rom = files.at(cursorPosition).c_str();
-									}else{
-										rom = matching_files.at(cursorPosition).c_str();
-									}
-								}
-								SavePerGameSettings();
-								showdialogbox_menu = false;
-								menudbox_movespeed = 1;
-								menu_ctrlset = CTRL_SET_GAMESEL;
-							}
-						}else if (hDown & KEY_A) {
-							switch (gamesettings_cursorPosition) {
-								case 0:
-								default:
-									settings.pergame.cpuspeed++;
-									if(settings.pergame.cpuspeed == 2)
-										settings.pergame.cpuspeed = -1;
-									if (dspfirmfound) {
-										sfx_select->stop();	// Prevent freezing
-										sfx_select->play();
-									}
-									break;
-								case 1:
-									settings.pergame.extvram++;
-									if(settings.pergame.extvram == 2)
-										settings.pergame.extvram = -1;
-									if (dspfirmfound) {
-										sfx_select->stop();	// Prevent freezing
-										sfx_select->play();
-									}
-									break;
-								case 2:
-									settings.pergame.lockarm9scfgext++;
-									if(settings.pergame.lockarm9scfgext == 2)
-										settings.pergame.lockarm9scfgext = -1;
-									if (dspfirmfound) {
-										sfx_select->stop();	// Prevent freezing
-										sfx_select->play();
-									}
-									break;
-								case 3:
-									if (settings.twl.forwarder) {
-										if(matching_files.size() == 0){
-											rom = fcfiles.at(cursorPosition).c_str();
-										}else{
-											rom = matching_files.at(cursorPosition).c_str();
-										}
-									} else {
-										if(matching_files.size() == 0){
-											rom = files.at(cursorPosition).c_str();
-										}else{
-											rom = matching_files.at(cursorPosition).c_str();
-										}
-										bootstrapini.SetString(bootstrapini_ndsbootstrap, "ARM7_DONOR_PATH", fat+settings.ui.romfolder+slashchar+rom);
-										bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
-									}
-									showdialogbox_menu = false;
-									menudbox_movespeed = 1;
-									menu_ctrlset = CTRL_SET_GAMESEL;
-									break;
-								case 4:
-									RGB[0] = keyboardInputInt("Red color: max is 255");
-									RGB[1] = keyboardInputInt("Green color: max is 255");
-									RGB[2] = keyboardInputInt("Blue color: max is 255");
-									
-									settings.pergame.red = RGB[0];
-									settings.pergame.green = RGB[1];
-									settings.pergame.blue = RGB[2];
-									break;
-							}
-						} else if (hDown & (KEY_B | KEY_SELECT)) {
-							if (settings.twl.forwarder) {
-								if(matching_files.size() == 0){
-									rom = fcfiles.at(cursorPosition).c_str();
-								}else{
-									rom = matching_files.at(cursorPosition).c_str();
-								}
-							} else {
-								if(matching_files.size() == 0){
-									rom = files.at(cursorPosition).c_str();
-								}else{
-									rom = matching_files.at(cursorPosition).c_str();
-								}
-							}
-							SavePerGameSettings();
-							showdialogbox_menu = false;
-							menudbox_movespeed = 1;
-							menu_ctrlset = CTRL_SET_GAMESEL;
-						}
-					}
-					
-					if (menudboxaction_switchloc) { menudboxaction_switchloc = false;
-						if (dspfirmfound) {
-							sfx_switch->stop();	// Prevent freezing
-							sfx_switch->play();
-						}
-						matching_files.clear();
-						pagenum = 0;
-						bannertextloaded = false;
-						cursorPosition = 0;
-						storedcursorPosition = cursorPosition;
-						titleboxXmovepos = 0;
-						boxartXmovepos = 0;
-						noromsfound = false;
-						settings.twl.forwarder = !settings.twl.forwarder;
-						bnricontexloaded = false;
-						boxarttexloaded = false;
-						if (dspfirmfound) {
-							sfx_switch->stop();	// Prevent freezing
-							sfx_switch->play();
-						}
-						// updatebotscreen = true;
-						
-						if (!settings.twl.forwarder) {
-							// Poll for Slot-1 changes.
-							gamecardPoll(true);
-
-							// Load the Slot-1 boxart.
-							// NOTE: This is needed here; otherwise, the
-							// boxart won't be visible for a few frames
-							// when switching from flashcard to SD.
-							loadSlot1BoxArt();
-						}
-					}
-					
-				}
-			}
-		} else if (screenmode == SCREEN_MODE_SETTINGS) {
-			settingsMoveCursor(hDown);
-		}
-		
-		if (applaunchon) {
-			if (settings.twl.forwarder && gbarunnervalue == 0) {
-				CIniFile setfcrompathini(sdmc+settings.ui.fcromfolder+slashchar+rom);
-				std::string rominini = setfcrompathini.GetString(fcrompathini_flashcardrom, fcrompathini_rompath, "");
-				// TODO: Enum values for flash card type.
-				if (keepsdvalue) {
-					switch (settings.twl.flashcard) {
-						case 0:
-						case 1:
-						case 3:
-						default: {
-							CIniFile fcrompathini("sdmc:/_nds/YSMenu.ini");
-							fcrompathini.SetString("YSMENU", "AUTO_BOOT", slashchar+rom);
-							fcrompathini.SaveIniFile("sdmc:/_nds/YSMenu.ini");
-							break;
-						}
-
-						case 2:
-						case 4:
-						case 5: {
-							CIniFile fcrompathini("sdmc:/_nds/lastsave.ini");
-							fcrompathini.SetString("Save Info", "lastLoaded", woodfat+rom);
-							fcrompathini.SaveIniFile("sdmc:/_nds/lastsave.ini");
-							break;
-						}
-
-						case 6: {
-							CIniFile fcrompathini("sdmc:/_nds/dstwoautoboot.ini");
-							fcrompathini.SetString("Dir Info", "fullName", dstwofat+rom);
-							fcrompathini.SaveIniFile("sdmc:/_nds/dstwoautoboot.ini");
-							break;
-						}
-					}
-				} else {
-					CIniFile setfcrompathini(sdmc+settings.ui.fcromfolder+rom);
-					switch (settings.twl.flashcard) {
-						case 0:
-						case 1:
-						case 3:
-						default: {
-							CIniFile fcrompathini("sdmc:/_nds/YSMenu.ini");
-							fcrompathini.SetString("YSMENU", "AUTO_BOOT", slashchar+rominini);
-							fcrompathini.SetString("YSMENU", "DEFAULT_DMA", "true");
-							fcrompathini.SetString("YSMENU", "DEFAULT_RESET", "false");
-							fcrompathini.SaveIniFile("sdmc:/_nds/YSMenu.ini");
-							break;
-						}
-
-						case 2:
-						case 4:
-						case 5: {
-							CIniFile fcrompathini("sdmc:/_nds/lastsave.ini");
-							fcrompathini.SetString("Save Info", "lastLoaded", woodfat+rominini);
-							fcrompathini.SaveIniFile("sdmc:/_nds/lastsave.ini");
-							break;
-						}
-
-						case 6: {
-							CIniFile fcrompathini("sdmc:/_nds/dstwoautoboot.ini");
-							fcrompathini.SetString("Dir Info", "fullName", dstwofat+rominini);
-							fcrompathini.SaveIniFile("sdmc:/_nds/dstwoautoboot.ini");
-							break;
-						}
-					}
-				}
-			} else if (settings.twl.forwarder && gbarunnervalue == 1) {
-				if (settings.twl.forwarder) {
-					switch (settings.twl.flashcard) {
-						case 0:
-						case 1:
-						case 3:
-						default: {
-							CIniFile fcrompathini("sdmc:/_nds/YSMenu.ini");
-							fcrompathini.SetString("YSMENU", "AUTO_BOOT", slashchar+rom);
-							fcrompathini.SetString("YSMENU", "DEFAULT_DMA", "true");
-							fcrompathini.SetString("YSMENU", "DEFAULT_RESET", "false");
-							fcrompathini.SaveIniFile("sdmc:/_nds/YSMenu.ini");
-							break;
-						}
-
-						case 2:
-						case 4:
-						case 5: {
-							CIniFile fcrompathini("sdmc:/_nds/lastsave.ini");
-							fcrompathini.SetString("Save Info", "lastLoaded", woodfat+rom);
-							fcrompathini.SaveIniFile("sdmc:/_nds/lastsave.ini");
-							break;
-						}
-
-						case 6: {
-							CIniFile fcrompathini("sdmc:/_nds/dstwoautoboot.ini");
-							fcrompathini.SetString("Dir Info", "fullName", dstwofat+rom);
-							fcrompathini.SaveIniFile("sdmc:/_nds/dstwoautoboot.ini");
-							break;
-						}
-					}
-				}
-			}
-
-			// Save settings.
-			saveOnExit = false;
-			SaveSettings();
-			SetPerGameSettings();
-			SaveBootstrapConfig();
-
-			// Prepare for the app launch.
-			u64 tid = TWLNAND_TID;
-			FS_MediaType mediaType = MEDIATYPE_NAND;
-			bool switchToTwl = true;	
-			
-			if (!settings.twl.forwarder && settings.twl.launchslot1) {
-				// CTR cards should be launched directly.
-				// TODO: TWL cards should also be launched directly,
-				// but APT_PrepareToDoApplicationJump() ends up
-				// rebooting to the home screen for NTR/TWL...
-				if (gamecardGetType() == CARD_TYPE_CTR) {
-					u64 ctr_tid = gamecardGetTitleID();
-					if (ctr_tid != 0) {
-						tid = ctr_tid;
-						mediaType = MEDIATYPE_GAME_CARD;
-						switchToTwl = false;
-					}
-				}
-			}
-
-			if (switchToTwl) {
-				// Switching to TWL.
-				// Activate the rainbow LED and shut off the screen.
-				// TODO: Allow rainbow LED even in CTR? (It'll stay
-				// cycling as long as no event causes it to change.)
-				if (cursorPosition >= 0 && gbarunnervalue == 0) {
-					if (settings.twl.forwarder) {
-						if(matching_files.size() == 0){
-							rom = fcfiles.at(cursorPosition).c_str();
-						}else{
-							rom = matching_files.at(cursorPosition).c_str();
-						}
-					} else {
-						if(matching_files.size() == 0){
-							rom = files.at(cursorPosition).c_str();
-						} else {
-							rom = matching_files.at(cursorPosition).c_str();
-						}
-					}
-					LoadPerGameSettings();
-				}
-				if((RGB[0] < 0) && (RGB[1] < 0) && (RGB[2] < 0)){
-					// If RGB in pergame is less than 0, use standard rainbowled patern
-					if (settings.twl.rainbowled) {
-						RainbowLED();
-					}
-				}else{
-					// Use pergame led
-					PergameLed();
-				}
-				screenoff();
-			}
-
-			// Buffers for APT_DoApplicationJump().
-			u8 param[0x300];
-			u8 hmac[0x20];
-			// Clear both buffers
-			memset(param, 0, sizeof(param));
-			memset(hmac, 0, sizeof(hmac));
-
-			APT_PrepareToDoApplicationJump(0, tid, mediaType);
-			// Tell APT to trigger the app launch and set the status of this app to exit
-			APT_DoApplicationJump(param, sizeof(param), hmac);
-			break;
-		}
-	//}	// run
-	}	// aptMainLoop
-
-	// Unregister the "returned from HOME Menu" handler.
-	aptUnhook(&rfhm_cookie);
-	if (logEnabled) LogFM("Main", "returned from HOME Menu handler unregistered");
-
-	if (saveOnExit) {
-		// Save settings.
-		SaveSettings();
-		SetPerGameSettings();
-		SaveBootstrapConfig();
-	}
-	if (logEnabled) LogFM("Main.saveOnExit", "Settings are saved");
-
-	// Unload settings screen textures.
-	settingsUnloadTextures();
-	if (logEnabled) LogFM("Main.settingsUnloadTextures", "Settings textures unloaded");
-
-	if (colortexloaded) sf2d_free_texture(topbgtex);
-	if (logEnabled) LogFM("Main", "topbgtex freed");
-	sf2d_free_texture(toptex);
-	for (int i = 0; i < 6; i++) {
-		sf2d_free_texture(voltex[i]);
-	}
-
-	sf2d_free_texture(shoulderLtex);
-	sf2d_free_texture(shoulderRtex);
-	if (logEnabled) LogFM("Main", "Shoulder textures freed");
-
-	if (settings.ui.theme == 0) {
-		sf2d_free_texture(batterychrgtex);
-		for (int i = 0; i < 6; i++) {
-			sf2d_free_texture(batterytex[i]);
-		}
-		if (logEnabled) LogFM("Main", "DSi Menu battery textures freed");
-	}
-	if (settings.ui.theme == 1) sf2d_free_texture(iconstex);
-	if (colortexloaded) sf2d_free_texture(bottomtex);
-	sf2d_free_texture(sdicontex);
-	sf2d_free_texture(flashcardicontex);
-	sf2d_free_texture(gbaicontex);
-	sf2d_free_texture(smallsettingsicontex);
-	sf2d_free_texture(iconnulltex);
-	sf2d_free_texture(homeicontex);
-	sf2d_free_texture(bottomlogotex);
-	sf2d_free_texture(bubbletex);
-	sf2d_free_texture(settingsicontex);
-	sf2d_free_texture(getfcgameboxtex);
-	sf2d_free_texture(cartnulltex);
-	sf2d_free_texture(cartntrtex);
-	sf2d_free_texture(carttwltex);
-	if (settings.ui.theme == 0) gamecardClearCache();
-	sf2d_free_texture(boxfulltex);
-	if (colortexloaded && settings.ui.theme == 0) {
-		sf2d_free_texture(dotcircletex);
-		sf2d_free_texture(startbordertex);
-	}
-
-	// Free the arrays.
-	if (bnricontexloaded) {
-		for (int i = 0; i < 20; i++) {
-			sf2d_free_texture(bnricontex[i]);
-			free(boxartpath[i]);
-		}
-	}
-	if (boxarttexloaded) {
-		sf2d_free_texture(slot1boxarttex);
-		for (int i = 0; i < 6; i++) {
-			sf2d_free_texture(boxarttex[i]);
-		}
-	}
-
-	// Remaining common textures.
-	sf2d_free_texture(dboxtex_iconbox);
-	sf2d_free_texture(dboxtex_button);
-	sf2d_free_texture(dboxtex_buttonback);
-	sf2d_free_texture(dialogboxtex);
-	sf2d_free_texture(settingslogotex);
-
-	// Clear the translations cache.
-	langClear();
-
-	// Shut down audio.
-	delete bgm_menu;
-	//delete bgm_settings;
-	delete sfx_launch;
-	delete sfx_select;
-	delete sfx_stop;
-	delete sfx_switch;
-	delete sfx_wrong;
-	delete sfx_back;
-	if (dspfirmfound) {
-		ndspExit();
-	}
-
-	sftd_free_font(font);
-	sftd_free_font(font_b);
-	if (logEnabled) LogFM("Main", "Fonts freed");
-	sftd_fini();
-	sf2d_fini();
-
-	acExit();
-	hidExit();
-	srvExit();
-	romfsExit();
-	sdmcExit();
-	ptmuxExit();
-	ptmuExit();
-	amExit();
-	cfguExit();
-	aptExit();
-	if (logEnabled) LogFM("Main", "All services are closed and returned to HOME Menu");
-	return 0;
+    if (logEnabled) {
+        LogFMA("Main.GUI version", "Successful reading version", settings_vertext);
+    }
+
+    LoadSettings();
+    bootstrapPath = settings.twl.bootstrapfile ? "fat:/_nds/release-bootstrap.nds" : "fat:/_nds/unofficial-bootstrap.nds";
+    if (logEnabled) {
+        LogFMA("Main.bootstrapPath", "Using path:", bootstrapPath.c_str());
+    }
+    LoadBootstrapConfig();
+
+    // Store bootstrap version
+    checkBootstrapVersion();
+
+    // Initialize translations.
+    langInit();
+
+    LoadColor();
+    LoadMenuColor();
+    LoadBottomImage();
+
+    // Dialog box textures.
+    dialogboxtex = sfil_load_PNG_file("romfs:/graphics/dialogbox.png", SF2D_PLACE_RAM); // Dialog box
+    dboxtex_iconbox = sfil_load_PNG_file("romfs:/graphics/dbox/iconbox.png", SF2D_PLACE_RAM); // Icon box
+    dboxtex_button = sfil_load_PNG_file("romfs:/graphics/dbox/button.png", SF2D_PLACE_RAM); // Icon box
+    dboxtex_buttonback = sfil_load_PNG_file("romfs:/graphics/dbox/button_back.png", SF2D_PLACE_RAM); // Icon box
+
+    sf2d_texture* toplogotex = NULL;        // Top of R4 menu
+    sf2d_texture* toptex = sfil_load_PNG_file("romfs:/graphics/top.png", SF2D_PLACE_RAM); // Top DSi-Menu border
+    sf2d_texture* topbgtex; // Top background, behind the DSi-Menu border
+
+    // Volume slider textures.
+    voltex[0] = sfil_load_PNG_file("romfs:/graphics/volume0.png", SF2D_PLACE_RAM); // Show no volume
+    voltex[1] = sfil_load_PNG_file("romfs:/graphics/volume1.png", SF2D_PLACE_RAM); // Volume low above 0
+    voltex[2] = sfil_load_PNG_file("romfs:/graphics/volume2.png", SF2D_PLACE_RAM); // Volume medium
+    voltex[3] = sfil_load_PNG_file("romfs:/graphics/volume3.png", SF2D_PLACE_RAM); // Hight volume
+    voltex[4] = sfil_load_PNG_file("romfs:/graphics/volume4.png", SF2D_PLACE_RAM); // 100%
+    voltex[5] = sfil_load_PNG_file("romfs:/graphics/volume5.png", SF2D_PLACE_RAM); // No DSP firm found
+
+    shoulderLtex = sfil_load_PNG_file("romfs:/graphics/shoulder_L.png", SF2D_PLACE_RAM); // L shoulder
+    shoulderRtex = sfil_load_PNG_file("romfs:/graphics/shoulder_R.png", SF2D_PLACE_RAM); // R shoulder
+
+    // Battery level textures.
+    batterychrgtex = sfil_load_PNG_file("romfs:/graphics/battery_charging.png", SF2D_PLACE_RAM);
+    batterytex[0] = sfil_load_PNG_file("romfs:/graphics/battery0.png", SF2D_PLACE_RAM);
+    batterytex[1] = sfil_load_PNG_file("romfs:/graphics/battery1.png", SF2D_PLACE_RAM);
+    batterytex[2] = sfil_load_PNG_file("romfs:/graphics/battery2.png", SF2D_PLACE_RAM);
+    batterytex[3] = sfil_load_PNG_file("romfs:/graphics/battery3.png", SF2D_PLACE_RAM);
+    batterytex[4] = sfil_load_PNG_file("romfs:/graphics/battery4.png", SF2D_PLACE_RAM);
+    batterytex[5] = sfil_load_PNG_file("romfs:/graphics/battery5.png", SF2D_PLACE_RAM);
+
+    sf2d_texture* iconstex = NULL;      // Bottom of menu (3 icons)
+    sf2d_texture* bottomtex = NULL;     // Bottom of menu
+    sf2d_texture* sdicontex = sfil_load_PNG_file("romfs:/graphics/wood/sd.png", SF2D_PLACE_RAM);
+    sf2d_texture* flashcardicontex = sfil_load_PNG_file("romfs:/graphics/wood/flashcard.png", SF2D_PLACE_RAM);
+    sf2d_texture* gbaicontex = sfil_load_PNG_file("romfs:/graphics/wood/gba.png", SF2D_PLACE_RAM);
+    sf2d_texture* smallsettingsicontex = sfil_load_PNG_file("romfs:/graphics/wood/settings.png", SF2D_PLACE_RAM);
+    sf2d_texture* iconnulltex = sfil_load_PNG_file("romfs:/graphics/icon_null.png", SF2D_PLACE_RAM); // Slot-1 cart icon if no cart is present
+    sf2d_texture* homeicontex = sfil_load_PNG_file("romfs:/graphics/homeicon.png", SF2D_PLACE_RAM); // HOME icon
+    sf2d_texture* bottomlogotex = sfil_load_PNG_file("romfs:/graphics/bottom_logo.png", SF2D_PLACE_RAM); // TWLoader logo on bottom screen
+    sf2d_texture* dotcircletex = NULL;  // Dots forming a circle
+    sf2d_texture* startbordertex = NULL;    // "START" border
+    sf2d_texture* settingsicontex = sfil_load_PNG_file("romfs:/graphics/settingsbox.png", SF2D_PLACE_RAM); // Settings box on bottom screen
+    sf2d_texture* getfcgameboxtex = sfil_load_PNG_file("romfs:/graphics/getfcgamebox.png", SF2D_PLACE_RAM);
+    cartnulltex = sfil_load_PNG_file("romfs:/graphics/cart_null.png", SF2D_PLACE_RAM); // NTR cartridge
+    cartntrtex = sfil_load_PNG_file("romfs:/graphics/cart_ntr.png", SF2D_PLACE_RAM); // NTR cartridge
+    carttwltex = sfil_load_PNG_file("romfs:/graphics/cart_twl.png", SF2D_PLACE_RAM); // TWL cartridge
+    cartctrtex = sfil_load_PNG_file("romfs:/graphics/cart_ctr.png", SF2D_PLACE_RAM); // CTR cartridge
+    sf2d_texture* boxfulltex = sfil_load_PNG_file("romfs:/graphics/box_full.png", SF2D_PLACE_RAM); // (DSiWare) box on bottom screen
+    sf2d_texture* bracetex = sfil_load_PNG_file("romfs:/graphics/brace.png", SF2D_PLACE_RAM); // Brace (C-shaped thingy)
+    sf2d_texture* bubbletex = sfil_load_PNG_file("romfs:/graphics/bubble.png", SF2D_PLACE_RAM); // Text bubble
+
+    if (logEnabled) {
+        LogFM("Main.sf2d_textures", "Textures load successfully");
+    }
+
+    dspfirmfound = false;
+    if (access("sdmc:/3ds/dspfirm.cdc", F_OK) != -1) {
+        ndspInit();
+        dspfirmfound = true;
+        if (logEnabled) {
+            LogFM("Main.dspfirm", "DSP Firm found!");
+        }
+    } else {
+        if (logEnabled) {
+            LogFM("Main.dspfirm", "DSP Firm not found");
+        }
+    }
+
+    bool musicbool = false;
+    if (access("sdmc:/_nds/twloader/music.wav", F_OK) != -1) {
+        musicpath = "sdmc:/_nds/twloader/music.wav";
+        if (logEnabled) {
+            LogFM("Main.music", "Custom music file found!");
+        }
+    } else {
+        if (logEnabled) {
+            LogFM("Main.dspfirm", "No music file found");
+        }
+    }
+
+    // Load the sound effects if DSP is available.
+    if (dspfirmfound) {
+        bgm_menu = new sound(musicpath);
+        //bgm_settings = new sound("sdmc:/_nds/twloader/music/settings.wav");
+        sfx_launch = new sound("romfs:/sounds/launch.wav", 2, false);
+        sfx_select = new sound("romfs:/sounds/select.wav", 2, false);
+        sfx_stop = new sound("romfs:/sounds/stop.wav", 2, false);
+        sfx_switch = new sound("romfs:/sounds/switch.wav", 2, false);
+        sfx_wrong = new sound("romfs:/sounds/wrong.wav", 2, false);
+        sfx_back = new sound("romfs:/sounds/back.wav", 2, false);
+    }
+
+    // Scan the ROM directories.
+    scanRomDirectories();
+
+    char romsel_counter2sd[16]; // Number of ROMs on the SD card.
+    snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
+    if (logEnabled) {
+        LogFMA("Main. ROM scanning", "Number of ROMs on the SD card detected", romsel_counter2sd);
+    }
+
+    char romsel_counter2fc[16]; // Number of ROMs on the flash card.
+    snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size());
+    if (logEnabled) {
+        LogFMA("Main. ROM scanning", "Number of ROMs on the flashcard detected", romsel_counter2fc);
+    }
+
+    // Download box art
+    if (checkWifiStatus()) {
+        downloadBoxArt();
+    }
+
+    // Cache banner data for ROMs on the SD card.
+    // TODO: Re-cache if it's 0 bytes?
+    if (logEnabled) {
+        Log("********************************************************\n");
+    }
+    for (bnriconnum = 0; bnriconnum < (int)files.size(); bnriconnum++) {
+        static const char title[] = "Now checking banner data (SD Card)...";
+        char romsel_counter1[16];
+        snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", bnriconnum + 1);
+        const char* tempfile = files.at(bnriconnum).c_str();
+
+        wstring tempfile_w = utf8_to_wstring(tempfile);
+        sftd_draw_wtext(font, 12, 64, RGBA8(0, 0, 0, 255), 12, tempfile_w.c_str());
+
+        char nds_path[256];
+        snprintf(nds_path, sizeof(nds_path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), tempfile);
+        FILE* f_nds_file = fopen(nds_path, "rb");
+        if (!f_nds_file) {
+            continue;
+        }
+        if (logEnabled) {
+            LogFMA("Main. Banner scanning", "Trying to read banner from file", nds_path);
+        }
+
+        if (cacheBanner(f_nds_file, tempfile, font, dialogboxtex, title, romsel_counter1, romsel_counter2sd) == 0) {
+            if (logEnabled) {
+                LogFM("Main. Banner scanning", "Done!");
+            }
+        } else {
+            if (logEnabled) {
+                LogFM("Main. Banner scanning", "Error!");
+            }
+        }
+
+        fclose(f_nds_file);
+    }
+
+    if (checkWifiStatus()) {
+        if (settings.ui.autodl && (checkUpdate() == 0) && !is3DSX) {
+            DownloadTWLoaderCIAs();
+        }
+
+        switch (settings.ui.autoupdate) {
+            case 2:
+                UpdateBootstrapUnofficial();
+                break;
+            case 1:
+                UpdateBootstrapRelease();
+                break;
+            default:
+                break;
+        }
+    }
+
+    DialogBoxDisappear(" ", 0);
+    sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+    sf2d_end_frame();
+    sf2d_swapbuffers();
+
+    int filenum = 0;
+    bool noromsfound = false;
+
+    bool cursorPositionset = false;
+
+    int soundwaittimer = 0;
+    bool playwrongsounddone = false;
+
+    bool colortexloaded = false;
+    bool colortexloaded_bot = false;
+    bool bnricontexloaded = false;
+    bool boxarttexloaded = false;
+
+    bool updatetopscreen = true;
+    bool screenmodeswitch = false;
+    bool applaunchicon = false;
+
+    float rad = 0.0f;
+
+    int boxartXpos;
+    int boxartXmovepos = 0;
+
+    int filenameYpos;
+    int filenameYmovepos = 0;
+    int setsboxXpos = 0;
+    int cartXpos = 64;
+    int boxartYmovepos = 63;
+    int boxartreflYmovepos = 264;
+    int ndsiconXpos;
+    int ndsiconYmovepos = 133;
+    int wood_ndsiconscaletimer = 0;
+    int wood_ndsiconscalelag = 0;
+    int wood_ndsiconscalemovepos = 0;
+    float wood_ndsiconscalesize = 0.00f;
+    bool wood_ndsiconscaledown = false;
+
+    int startbordermovepos = 0;
+    float startborderscalesize = 1.0f;
+
+    if (settings.ui.theme >= 1) {
+        menu_ctrlset = CTRL_SET_MENU;
+    }
+    sf2d_set_3D(1);
+
+    // Loop as long as the status is not exit
+    const bool isTWLNANDInstalled = checkTWLNANDSide();
+    // Save by default if the TWLNAND-side title is installed.
+    // Otherwise, we don't want to save anything.
+    bool saveOnExit = isTWLNANDInstalled;
+    while (run && aptMainLoop()) {
+        //while(run) {
+        // Scan hid shared memory for input events
+        hidScanInput();
+
+        const u32 hDown = hidKeysDown();
+        const u32 hHeld = hidKeysHeld();
+
+        // Check if the TWLNAND-side title is installed.
+        if (!isTWLNANDInstalled) {
+            static const char twlnand_msg[] =
+                "The TWLNAND-side title has not been installed.\n"
+                "Please install the TWLNAND-side CIA:\n"
+                "\n"
+                "/_nds/twloader/cias/TWLoader - TWLNAND side.cia\n"
+                "\n"
+                "\n"
+                "\n"
+                "\n"
+                "\n"
+                "\n"
+                "\n"
+                "\n"
+                "\n"
+                "\n"
+                "\n"
+                "\n"
+                "                 Press the HOME button to exit.";
+            DialogBoxAppear(twlnand_msg, 0);
+            sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+            sf2d_draw_texture(dialogboxtex, 0, 0);
+            sftd_draw_text(font, 12, 16, RGBA8(0, 0, 0, 255), 12, twlnand_msg);
+            sf2d_end_frame();
+            sf2d_swapbuffers();
+            continue;
+        }
+
+        offset3D[0].topbg = CONFIG_3D_SLIDERSTATE * -12.0f;
+        offset3D[1].topbg = CONFIG_3D_SLIDERSTATE * 12.0f;
+        offset3D[0].boxart = CONFIG_3D_SLIDERSTATE * -5.0f;
+        offset3D[1].boxart = CONFIG_3D_SLIDERSTATE * 5.0f;
+        offset3D[0].disabled = CONFIG_3D_SLIDERSTATE * -3.0f;
+        offset3D[1].disabled = CONFIG_3D_SLIDERSTATE * 3.0f;
+
+        if (showdialogbox_menu) {
+            if (menudbox_movespeed <= 1) {
+                if (menudbox_Ypos >= 0) {
+                    menudbox_movespeed = 0;
+                    menudbox_Ypos = 0;
+                } else {
+                    menudbox_movespeed = 1;
+                }
+            } else {
+                menudbox_movespeed -= 0.2;
+                menudbox_bgalpha += 5;
+            }
+            menudbox_Ypos += menudbox_movespeed;
+        } else {
+            if (menudbox_Ypos <= -240 || menudbox_Ypos >= 240) {
+                menudbox_movespeed = 22;
+                menudbox_Ypos = -240;
+            } else {
+                menudbox_movespeed += 1;
+                menudbox_bgalpha -= 5;
+                if (menudbox_bgalpha <= 0) {
+                    menudbox_bgalpha = 0;
+                }
+                menudbox_Ypos += menudbox_movespeed;
+            }
+        }
+
+
+        if (storedcursorPosition < 0) {
+            storedcursorPosition = 0;
+        }
+
+        size_t file_count = (settings.twl.forwarder ? fcfiles.size() : files.size());
+
+        if (matching_files.size() != 0) {
+            file_count = matching_files.size();
+        }
+        const int pagemax = std::min((20 + pagenum * 20), (int)file_count);
+        const int pagemax_ba = std::min((21 + pagenum * 20), (int)file_count);
+
+        if (screenmode == SCREEN_MODE_ROM_SELECT) {
+            if (!colortexloaded) {
+                if (settings.ui.theme == 2) {
+                    switch (settings.ui.subtheme) {
+                        case 0:
+                        default:
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/wood/gbatemp/upper_screen.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 1:
+                            topbgtex = sfil_load_PNG_file("romfs:/graphics/wood/black/upper_screen.png", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 2:
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/wood/Adv.Evo/upper_screen.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 3:
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/wood/dstwo pink/upper_screen.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                    }
+                } else if (settings.ui.theme == 1) {
+                    switch (settings.ui.subtheme) {
+                        case 0:
+                        default:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme01/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme01/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 1:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme02/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme02/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 2:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme03/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme03/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 3:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme04/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme04/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 4:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme05/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme05/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 5:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme06/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme06/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 6:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme07/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme07/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 7:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme08/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme08/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 8:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme09/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme09/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 9:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme10/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme10/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 10:
+                            toplogotex = sfil_load_JPEG_file("romfs:/graphics/r4/theme11/logo.jpg", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_JPEG_file("romfs:/graphics/r4/theme11/bckgrd_1.jpg", SF2D_PLACE_RAM); // Top background
+                            break;
+                        case 11:
+                            toplogotex = sfil_load_PNG_file("romfs:/graphics/r4/theme12/logo.png", SF2D_PLACE_RAM); // Top logo
+                            topbgtex = sfil_load_PNG_file("romfs:/graphics/r4/theme12/bckgrd_1.png", SF2D_PLACE_RAM); // Top background
+                            break;
+                    }
+                } else {
+                    topbgtex = sfil_load_PNG_file(color_data->topbgloc, SF2D_PLACE_RAM);    // Top background, behind the DSi-Menu border
+                }
+                settingsUnloadTextures();
+                colortexloaded = true;
+            }
+            if (!bnricontexloaded) {
+                if (!settings.twl.forwarder) {
+                    /* sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+                    sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Now loading banner icons (SD Card)...");
+                    sf2d_end_frame();
+                    sf2d_swapbuffers(); */
+                    char path[256];
+                    if (matching_files.size() == 0) {
+                        for (bnriconnum = pagenum * 20; bnriconnum < pagemax; bnriconnum++) {
+                            if (bnriconnum < (int)files.size()) {
+                                const char* tempfile = files.at(bnriconnum).c_str();
+                                snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
+                                LoadBNRIcon(path);
+                            } else {
+                                LoadBNRIcon(NULL);
+                            }
+                        }
+                    } else {
+                        for (bnriconnum = pagenum * 20; bnriconnum < pagemax; bnriconnum++) {
+                            if (bnriconnum < (int)matching_files.size()) {
+                                const char* tempfile = matching_files.at(bnriconnum).c_str();
+                                snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
+                                LoadBNRIcon(path);
+                            } else {
+                                LoadBNRIcon(NULL);
+                            }
+                        }
+                    }
+                } else {
+                    /* sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+                    sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Now loading banner icons (Flashcard)...");
+                    sf2d_end_frame();
+                    sf2d_swapbuffers(); */
+                    char path[256];
+                    if (matching_files.size() == 0) {
+                        for (bnriconnum = pagenum * 20; bnriconnum < pagemax; bnriconnum++) {
+                            if (bnriconnum < (int)fcfiles.size()) {
+                                const char* tempfile = fcfiles.at(bnriconnum).c_str();
+                                snprintf(path, sizeof(path), "%s/%s.bin", fcbnriconfolder, tempfile);
+                                if (access(path, F_OK) != -1) {
+                                    LoadBNRIcon(path);
+                                } else {
+                                    LoadBNRIcon(NULL);
+                                }
+                            } else {
+                                LoadBNRIcon(NULL);
+                            }
+                        }
+                    } else {
+                        for (bnriconnum = pagenum * 20; bnriconnum < pagemax; bnriconnum++) {
+                            if (bnriconnum < (int)matching_files.size()) {
+                                const char* tempfile = matching_files.at(bnriconnum).c_str();
+                                snprintf(path, sizeof(path), "%s/%s.bin", fcbnriconfolder, tempfile);
+                                if (access(path, F_OK) != -1) {
+                                    LoadBNRIcon(path);
+                                } else {
+                                    LoadBNRIcon(NULL);
+                                }
+                            } else {
+                                LoadBNRIcon(NULL);
+                            }
+                        }
+                    }
+                }
+
+                bnricontexloaded = true;
+                bnriconnum = 0 + pagenum * 20;
+            }
+            if (!boxarttexloaded) {
+                if (!settings.twl.forwarder) {
+                    /* sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+                    sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Now storing box art filenames (SD Card)...");
+                    sf2d_end_frame();
+                    sf2d_swapbuffers(); */
+                    char path[256];
+                    if (matching_files.size() == 0) {
+                        for (boxartnum = pagenum * 20; boxartnum < pagemax_ba; boxartnum++) {
+                            if (boxartnum < (int)files.size()) {
+                                const char* tempfile = files.at(boxartnum).c_str();
+                                snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), tempfile);
+                                FILE* f_nds_file = fopen(path, "rb");
+                                if (!f_nds_file) {
+                                    // Can't open the NDS file.
+                                    StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                                    continue;
+                                }
+
+                                char ba_TID[5];
+                                grabTID(f_nds_file, ba_TID);
+                                ba_TID[4] = 0;
+                                fclose(f_nds_file);
+
+                                // example: SuperMario64DS.nds.png
+                                snprintf(path, sizeof(path), "%s/%s.png", boxartfolder, tempfile);
+                                if (access(path, F_OK) != -1) {
+                                    StoreBoxArtPath(path);
+                                } else {
+                                    // example: ASME.png
+                                    snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
+                                    if (access(path, F_OK) != -1) {
+                                        StoreBoxArtPath(path);
+                                    } else {
+                                        StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                                    }
+                                }
+                            } else {
+                                StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                            }
+                        }
+                    } else {
+                        for (boxartnum = pagenum * 20; boxartnum < pagemax_ba; boxartnum++) {
+                            if (boxartnum < (int)matching_files.size()) {
+                                const char* tempfile = matching_files.at(boxartnum).c_str();
+                                snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), tempfile);
+                                FILE* f_nds_file = fopen(path, "rb");
+                                if (!f_nds_file) {
+                                    // Can't open the NDS file.
+                                    StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                                    continue;
+                                }
+
+                                char ba_TID[5];
+                                grabTID(f_nds_file, ba_TID);
+                                ba_TID[4] = 0;
+                                fclose(f_nds_file);
+
+                                // example: SuperMario64DS.nds.png
+                                snprintf(path, sizeof(path), "%s/%s.png", boxartfolder, tempfile);
+                                if (access(path, F_OK) != -1) {
+                                    StoreBoxArtPath(path);
+                                } else {
+                                    // example: ASME.png
+                                    snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
+                                    if (access(path, F_OK) != -1) {
+                                        StoreBoxArtPath(path);
+                                    } else {
+                                        StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                                    }
+                                }
+                            } else {
+                                StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                            }
+                        }
+                    }
+                } else {
+                    /* sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+                    sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Now storing box art filenames (Flashcard)...");
+                    sf2d_end_frame();
+                    sf2d_swapbuffers(); */
+                    char path[256];
+                    if (matching_files.size() == 0) {
+                        for (boxartnum = pagenum * 20; boxartnum < pagemax; boxartnum++) {
+                            if (boxartnum < (int)fcfiles.size()) {
+                                const char* tempfile = fcfiles.at(boxartnum).c_str();
+                                snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), tempfile);
+
+                                CIniFile setfcrompathini(path);
+                                std::string ba_TIDini = setfcrompathini.GetString(fcrompathini_flashcardrom, fcrompathini_tid, "");
+                                if (ba_TIDini.size() < 4) {
+                                    // TID is too short.
+                                    StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                                    continue;
+                                }
+
+                                char ba_TID[5];
+                                strcpy(ba_TID, ba_TIDini.c_str());
+                                ba_TID[4] = 0;
+
+                                // example: SuperMario64DS.nds.png
+                                snprintf(path, sizeof(path), "%s/%s.png", fcboxartfolder, tempfile);
+                                if (access(path, F_OK) != -1) {
+                                    StoreBoxArtPath(path);
+                                } else {
+                                    // example: ASME.png
+                                    snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
+                                    if (access(path, F_OK) != -1) {
+                                        StoreBoxArtPath(path);
+                                    } else {
+                                        StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                                    }
+                                }
+                            } else {
+                                StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                            }
+                        }
+                    } else {
+                        for (boxartnum = pagenum * 20; boxartnum < pagemax; boxartnum++) {
+                            if (boxartnum < (int)matching_files.size()) {
+                                const char* tempfile = matching_files.at(boxartnum).c_str();
+                                snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), tempfile);
+
+                                CIniFile setfcrompathini(path);
+                                std::string ba_TIDini = setfcrompathini.GetString(fcrompathini_flashcardrom, fcrompathini_tid, "");
+                                if (ba_TIDini.size() < 4) {
+                                    // TID is too short.
+                                    StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                                    continue;
+                                }
+
+                                char ba_TID[5];
+                                strcpy(ba_TID, ba_TIDini.c_str());
+                                ba_TID[4] = 0;
+
+                                // example: SuperMario64DS.nds.png
+                                snprintf(path, sizeof(path), "%s/%s.png", fcboxartfolder, tempfile);
+                                if (access(path, F_OK) != -1) {
+                                    StoreBoxArtPath(path);
+                                } else {
+                                    // example: ASME.png
+                                    snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
+                                    if (access(path, F_OK) != -1) {
+                                        StoreBoxArtPath(path);
+                                    } else {
+                                        StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                                    }
+                                }
+                            } else {
+                                StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+                            }
+                        }
+                    }
+                }
+
+                // Load up to 6 boxarts.
+                for (boxartnum = pagenum * 20; boxartnum < 6 + pagenum * 20; boxartnum++) {
+                    LoadBoxArt();
+                }
+                boxarttexloaded = true;
+                boxartnum = 0 + pagenum * 20;
+            }
+
+            if (settings.ui.theme == 2) {   // akMenu/Wood theme
+                for (int topfb = GFX_LEFT; topfb <= GFX_RIGHT; topfb++) {
+                    sf2d_start_frame(GFX_TOP, (gfx3dSide_t)topfb);
+                    sf2d_draw_texture(topbgtex, 40, 0);
+                    if (menu_ctrlset == CTRL_SET_MENU) {
+                        if (!settings.romselect.toplayout && woodmenu_cursorPosition == 2) {
+                            // Load the boxart for the Slot-1 cartridge if necessary.
+                            loadSlot1BoxArt();
+                            // Draw box art
+                            switch (settings.ui.subtheme) {
+                                case 0:
+                                default:
+                                    sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart + 40 + 14, 62);
+                                    break;
+                                case 1:
+                                case 2:
+                                    sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart + 40 + 176, 113);
+                                    break;
+                                case 3:
+                                    sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart + 40 + 164, 38);
+                                    break;
+                            }
+                        }
+                    } else {
+                        if (!settings.romselect.toplayout) {
+                            if (!bannertextloaded) {
+                                LoadBoxArt_WoodTheme(cursorPosition - pagenum * 20);
+                                bannertextloaded = true;
+                            }
+                            boxartnum = 0;
+                            ChangeBoxArtNo();
+                            // Draw box art
+                            switch (settings.ui.subtheme) {
+                                case 0:
+                                default:
+                                    sf2d_draw_texture(boxarttexnum, offset3D[topfb].boxart + 40 + 14, 62);
+                                    break;
+                                case 1:
+                                case 2:
+                                    sf2d_draw_texture(boxarttexnum, offset3D[topfb].boxart + 40 + 176, 113);
+                                    break;
+                                case 3:
+                                    sf2d_draw_texture(boxarttexnum, offset3D[topfb].boxart + 40 + 164, 38);
+                                    break;
+                            }
+                        }
+                    }
+                    switch (settings.ui.subtheme) {
+                        case 0:
+                        default:
+                            sftd_draw_text(font_b, 40 + 200, 148, RGBA8(16, 0, 0, 223), 22, RetTime(true).c_str());
+                            DrawDateF(22 + 197, 198, FORMAT_MY, RGBA8(16, 0, 0, 223), 22);
+                            break;
+                        case 1:
+                            sftd_draw_text(font_b, 40 + 184, 8, RGBA8(255, 255, 255, 255), 33, RetTime(true).c_str());
+                            DrawDateF(40 + 182, 78, FORMAT_MY, RGBA8(255, 255, 255, 255), 22);
+                            break;
+                        case 2:
+                            sftd_draw_text(font_b, 40 + 16, 76, RGBA8(255, 255, 255, 255), 33, RetTime(true).c_str());
+                            DrawDateF(40 + 69, 204, FORMAT_MY, RGBA8(255, 255, 255, 255), 19);
+                            break;
+                        case 3:
+                            sftd_draw_text(font_b, 40 + 176, 172, RGBA8(255, 255, 255, 255), 33, RetTime(true).c_str());
+                            break;
+                    }
+                    sf2d_draw_rectangle(0, 0, 40, 240, RGBA8(0, 0, 0, 255)); // Left black bar
+                    sf2d_draw_rectangle(360, 0, 40, 240, RGBA8(0, 0, 0, 255)); // Right black bar
+                    sf2d_end_frame();
+                }
+            } else if (settings.ui.theme == 1) {    // R4 theme
+                if (updatetopscreen) {
+                    sf2d_start_frame(GFX_TOP, GFX_LEFT);
+                    if (menu_ctrlset != CTRL_SET_MENU) {
+                        sf2d_draw_texture(topbgtex, 40, 0);
+                        filenameYpos = 15;
+                        const int file_count = (settings.twl.forwarder ? fcfiles.size() : files.size());
+                        for (filenum = 0; filenum < file_count; filenum++) {
+                            u32 color;
+                            if (cursorPosition == filenum) {
+                                color = SET_ALPHA(color_data->color, 255);
+                            } else {
+                                color = RGBA8(255, 255, 255, 255);
+                            }
+
+                            // Get the current filename and convert it to wstring.
+                            const char* filename = (settings.twl.forwarder
+                                                    ? fcfiles.at(filenum).c_str()
+                                                    : files.at(filenum).c_str());
+                            wstring wstr = utf8_to_wstring(filename);
+                            sftd_draw_wtext(font, 42, filenameYpos + filenameYmovepos * 15, color, 12, wstr.c_str());
+
+                            filenameYpos += 15;
+                        }
+
+                        sf2d_draw_texture_part(topbgtex, 40, 0, 0, 0, 320, 15);
+                        const char* title = (settings.twl.forwarder
+                                             ? "Games (Flashcard)"
+                                             : "Games (SD Card)");
+                        sftd_draw_textf(font, 42, 0, RGBA8(0, 0, 0, 255), 12, title);
+
+                        char romsel_counter1[16];
+                        char romsel_counter2[16];
+                        snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", cursorPosition + 1);
+                        // if(matching_files.size() == 0){
+                        snprintf(romsel_counter2, sizeof(romsel_counter2), "%d", file_count);
+                        // }else{
+                        //  snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", matching_files.size());
+                        // }
+
+                        if (settings.ui.counter) {
+                            if (file_count < 100) {
+                                sftd_draw_text(font, 40 + 276, 0, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
+                                sftd_draw_text(font, 40 + 295, 0, RGBA8(0, 0, 0, 255), 12, "/");
+                                sftd_draw_text(font, 40 + 300, 0, RGBA8(0, 0, 0, 255), 12, romsel_counter2);
+                            } else {
+                                sftd_draw_text(font, 40 + 276, 0, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
+                                sftd_draw_text(font, 40 + 303, 0, RGBA8(0, 0, 0, 255), 12, "/");
+                                sftd_draw_text(font, 40 + 308, 0, RGBA8(0, 0, 0, 255), 12, romsel_counter2);
+                            }
+                        }
+                    } else {
+                        sf2d_draw_texture(toplogotex, 40, 0);
+                    }
+                    sf2d_draw_rectangle(0, 0, 40, 240, RGBA8(0, 0, 0, 255)); // Left black bar
+                    sf2d_draw_rectangle(360, 0, 40, 240, RGBA8(0, 0, 0, 255)); // Right black bar
+                    sf2d_end_frame();
+                    updatetopscreen = false;
+                }
+            } else {    // DSi-Menu theme
+                if (!settings.twl.forwarder) {
+                    // Load the boxart for the Slot-1 cartridge if necessary.
+                    loadSlot1BoxArt();
+                }
+
+                if (!musicbool) {
+                    if (dspfirmfound) {
+                        bgm_menu->play();
+                    }
+                    musicbool = true;
+                }
+                if (settings.twl.forwarder) {
+                    noromtext1 = "No games found!";
+                    noromtext2 = "Select \"Add Games\" to get started.";
+                } else {
+                    noromtext1 = "No games found!";
+                    noromtext2 = " ";
+                }
+
+                update_battery_level(batterychrgtex, batterytex);
+                for (int topfb = GFX_LEFT; topfb <= GFX_RIGHT; topfb++) {
+                    sf2d_start_frame(GFX_TOP, (gfx3dSide_t)topfb);
+                    sf2d_draw_texture_scale(topbgtex, offset3D[topfb].topbg - 12, 0, 1.32, 1);
+                    if (filenum != 0) { // If ROMs are found, then display box art
+                        if (!settings.romselect.toplayout) {
+                            boxartXpos = 136;
+                            if (!settings.twl.forwarder && pagenum == 0) {
+                                if (cursorPosition < 2) {
+                                    sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart + boxartXpos - 144 + boxartXmovepos, 240 / 2 - slot1boxarttex->height / 2); // Draw box art
+                                    sf2d_draw_texture_scale_blend(slot1boxarttex, offset3D[topfb].boxart + boxartXpos - 144 + boxartXmovepos, 264, 1, -0.75, SET_ALPHA(color_data->color, 0xC0)); // Draw box art's reflection
+                                }
+                            }
+                            for (boxartnum = pagenum * 20; boxartnum < pagemax; boxartnum++) {
+                                if (boxartnum < 9 + pagenum * 20) {
+                                    ChangeBoxArtNo();
+                                    // Draw box art
+                                    sf2d_draw_texture(boxarttexnum, offset3D[topfb].boxart + boxartXpos + boxartXmovepos, 240 / 2 - boxarttexnum->height / 2);
+                                    // Draw box art's reflection
+                                    sf2d_draw_texture_scale_blend(boxarttexnum, offset3D[topfb].boxart + boxartXpos + boxartXmovepos, 264, 1, -0.75, SET_ALPHA(color_data->color, 0xC0));
+                                    boxartXpos += 144;
+                                }
+                            }
+                            if (applaunchprep) {
+                                if (cursorPosition >= 0) {
+                                    boxartnum = cursorPosition;
+                                    ChangeBoxArtNo();
+                                    sf2d_draw_texture_part(topbgtex, offset3D[topfb].boxart + 136, 63, offset3D[topfb].boxart + 104, 63, 128, 115 * 2);
+                                    // Draw moving box art
+                                    sf2d_draw_texture(boxarttexnum, offset3D[topfb].boxart + 136, boxartYmovepos);
+                                    // Draw moving box art's reflection
+                                    sf2d_draw_texture_scale_blend(boxarttexnum, offset3D[topfb].boxart + 136, boxartreflYmovepos, 1, -0.75, SET_ALPHA(color_data->color, 0xC0));
+                                } else if (!settings.twl.forwarder && cursorPosition == -1) {
+                                    sf2d_draw_texture_part(topbgtex, offset3D[topfb].boxart + 136, 63, offset3D[topfb].boxart + 104, 63, 128, 115 * 2);
+                                    sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart + 136, boxartYmovepos); // Draw moving box art
+                                    sf2d_draw_texture_scale_blend(slot1boxarttex, offset3D[topfb].boxart + 136, boxartreflYmovepos, 1, -0.75, SET_ALPHA(color_data->color, 0xC0)); // Draw moving box art's reflection
+                                }
+                            }
+                        }
+                    } else {
+                        if (!settings.romselect.toplayout) {
+                            boxartXpos = 136;
+                            if (!settings.twl.forwarder && pagenum == 0) {
+                                if (cursorPosition < 2) {
+                                    sf2d_draw_texture(slot1boxarttex, offset3D[topfb].boxart + boxartXpos + boxartXmovepos, 240 / 2 - slot1boxarttex->height / 2); // Draw box art
+                                    sf2d_draw_texture_scale_blend(slot1boxarttex, offset3D[topfb].boxart + boxartXpos + boxartXmovepos, 264, 1, -0.75, SET_ALPHA(color_data->color, 0xC0)); // Draw box art's reflection
+                                }
+                            } else {
+                                int text_width = sftd_get_text_width(font, 12, noromtext1);
+                                sftd_draw_textf(font, offset3D[topfb].boxart + ((400 - text_width) / 2), 96, RGBA8(255, 255, 255, 255), 12, noromtext1);
+                                text_width = sftd_get_text_width(font, 12, noromtext2);
+                                sftd_draw_textf(font, offset3D[topfb].boxart + ((400 - text_width) / 2), 112, RGBA8(255, 255, 255, 255), 12, noromtext2);
+                            }
+                        } else {
+                            if (settings.twl.forwarder && pagenum == 0) {
+                                int text_width = sftd_get_text_width(font, 12, noromtext1);
+                                sftd_draw_textf(font, offset3D[topfb].boxart + ((400 - text_width) / 2), 96, RGBA8(255, 255, 255, 255), 12, noromtext1);
+                                text_width = sftd_get_text_width(font, 12, noromtext2);
+                                sftd_draw_textf(font, offset3D[topfb].boxart + ((400 - text_width) / 2), 112, RGBA8(255, 255, 255, 255), 12, noromtext2);
+                            }
+                        }
+                    }
+                    if (settings.ui.topborder) {
+                        sf2d_draw_texture_blend(toptex, 400 / 2 - toptex->width / 2, 240 / 2 - toptex->height / 2, menucolor);
+                        sftd_draw_text(font, 328, 3, RGBA8(0, 0, 0, 255), 12, RetTime(false).c_str());
+                        DrawDate(282, 3, RGBA8(0, 0, 0, 255), 12);
+                    } else {
+                        sftd_draw_text(font, 328, 3, RGBA8(255, 255, 255, 255), 12, RetTime(false).c_str());
+                        DrawDate(282, 3, RGBA8(255, 255, 255, 255), 12);
+                    }
+
+                    draw_volume_slider(voltex);
+                    sf2d_draw_texture(batteryIcon, 371, 2);
+                    if (!settings.ui.name.empty()) {
+                        sftd_draw_textf(font, 34, 3, SET_ALPHA(color_data->color, 255), 12, settings.ui.name.c_str());
+                    }
+                    // sftd_draw_textf(font, 2, 2, RGBA8(0, 0, 0, 255), 12, temptext); // Debug text
+                    sf2d_draw_texture(shoulderLtex, 0, LshoulderYpos);
+                    // sftd_draw_textf(font, 17, LshoulderYpos+5, RGBA8(0, 0, 0, 255), 11, Lshouldertext);
+                    sf2d_draw_texture(shoulderRtex, 328, RshoulderYpos);
+                    // sftd_draw_textf(font, 332, RshoulderYpos+5, RGBA8(0, 0, 0, 255), 11, Rshouldertext);
+                    // Draw the "Prev" and "Next" text for X/Y.
+                    u32 lr_color = (pagenum != 0 && file_count <= (size_t) - pagenum * 20)
+                                   ? RGBA8(0, 0, 0, 255)
+                                   : RGBA8(127, 127, 127, 255);
+                    sftd_draw_text(font, 17, LshoulderYpos + 5, lr_color, 11, "Prev. Page");
+
+                    lr_color = (file_count > (size_t)20 + pagenum * 20)
+                               ? RGBA8(0, 0, 0, 255)
+                               : RGBA8(127, 127, 127, 255);
+                    sftd_draw_text(font, 332, RshoulderYpos + 5, lr_color, 11, "Next Page");
+
+                    sf2d_draw_rectangle(0, 0, 400, 240, RGBA8(0, 0, 0, fadealpha)); // Fade in/out effect
+                    sf2d_end_frame();
+                }
+            }
+        } else if (screenmode == SCREEN_MODE_SETTINGS) {
+            if (colortexloaded) {
+                sf2d_free_texture(topbgtex);
+                topbgtex = NULL;
+                colortexloaded = false;
+            }
+            settingsDrawTopScreen();
+        }
+
+        if (hHeld & KEY_L) {
+            if (LshoulderYpos != 223) {
+                LshoulderYpos += 1;
+            }
+        } else {
+            if (LshoulderYpos != 220) {
+                LshoulderYpos -= 1;
+            }
+        }
+        if (hHeld & KEY_R) {
+            if (RshoulderYpos != 223) {
+                RshoulderYpos += 1;
+            }
+        } else {
+            if (RshoulderYpos != 220) {
+                RshoulderYpos -= 1;
+            }
+        }
+
+        /* if(hHeld & KEY_Y){
+            if (YbuttonYpos != 223)
+            {YbuttonYpos += 1;}
+        } else {
+            if (YbuttonYpos != 220)
+            {YbuttonYpos -= 1;}
+        }
+        if(hHeld & KEY_X){
+            if (XbuttonYpos != 223)
+            {XbuttonYpos += 1;}
+        } else {
+            if (XbuttonYpos != 220)
+            {XbuttonYpos -= 1;}
+        } */
+
+        if (fadein) {
+            fadealpha -= 31;
+            if (fadealpha < 0) {
+                fadealpha = 0;
+                fadein = false;
+                titleboxXmovetimer = 0;
+            }
+        }
+
+        if (fadeout) {
+            fadealpha += 31;
+            if (fadealpha > 255) {
+                fadealpha = 255;
+                musicbool = false;
+                if (screenmode == SCREEN_MODE_SETTINGS) {
+                    screenmode = SCREEN_MODE_ROM_SELECT;
+                    fadeout = false;
+                    fadein = true;
+
+                    // Poll for Slot-1 changes.
+                    gamecardPoll(true);
+
+                    // Force banner text reload in case
+                    // the Slot-1 cartridge was changed
+                    // or the UI language was changed.
+                    bannertextloaded = false;
+
+                    // Reload language
+                    langInit();
+
+                    // Clear matching_files vector
+                    if (matching_files.size() != 0) {
+                        matching_files.clear(); // Clear filter
+                        snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size()); // Reload counter
+                        snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size()); // Reload counter for FlashCard
+                        boxarttexloaded = false; // Reload boxarts
+                        bnricontexloaded = false; // Reload banner icons
+
+                        /** This is better than a glitched screen */
+                        sf2d_start_frame(GFX_TOP, GFX_LEFT);
+                        sf2d_end_frame();
+                        sf2d_swapbuffers();
+                    }
+                    if (settings.ui.theme == 2) {
+                        /** This is better than a glitched screen */
+                        sf2d_start_frame(GFX_TOP, GFX_LEFT);
+                        sf2d_end_frame();
+                        sf2d_swapbuffers();
+
+                        menu_ctrlset = CTRL_SET_MENU;
+                        woodmenu_cursorPosition = 4;
+                        char path[256];
+                        if (cursorPosition < 0) {
+                            cursorPosition = 0;
+                        }
+                        // Reload 1st icon
+                        if (settings.twl.forwarder) {
+                            const char* tempfile = fcfiles.at(0).c_str();
+                            snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/flashcard/%s.bin", tempfile);
+                        } else {
+                            const char* tempfile = files.at(0).c_str();
+                            snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
+                        }
+                        if (access(path, F_OK) != -1) {
+                            LoadBNRIcon_R4Theme(path);
+                        } else {
+                            LoadBNRIcon_R4Theme(NULL);
+                        }
+                    } else if (settings.ui.theme == 1) {
+                        /** This is better than a glitched screen */
+                        sf2d_start_frame(GFX_TOP, GFX_LEFT);
+                        sf2d_end_frame();
+                        sf2d_swapbuffers();
+
+                        menu_ctrlset = CTRL_SET_MENU;
+                        titleboxXmovepos = 0;
+                        boxartXmovepos = 0;
+                        if (cursorPosition < 0) {
+                            cursorPosition = 0;
+                        }
+                    } else {
+                        cursorPosition = 0 + pagenum * 20; // This is to reset cursor position after switching from R4 theme.
+                        storedcursorPosition = cursorPosition; // This is to reset cursor position after switching from R4 theme.
+                        titleboxXmovepos = 0;
+                        boxartXmovepos = 0;
+                        char path[256];
+                        // Reload 1st icon
+                        if (settings.twl.forwarder) {
+                            const char* tempfile = fcfiles.at(0 + pagenum * 20).c_str();
+                            snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/flashcard/%s.bin", tempfile);
+                        } else {
+                            const char* tempfile = files.at(0 + pagenum * 20).c_str();
+                            snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
+                        }
+                        if (access(path, F_OK) != -1) {
+                            LoadBNRIcon_R4Theme(path);
+                        } else {
+                            LoadBNRIcon_R4Theme(NULL);
+                        }
+                        // Reload 1st box art
+                        LoadBoxArt_WoodTheme(0 - pagenum * 20);
+                        menu_ctrlset = CTRL_SET_GAMESEL;
+                    }
+                } else if (gbarunnervalue == 1) {
+                    if (logEnabled) {
+                        LogFM("Main", "Switching to NTR/TWL-mode");
+                    }
+                    applaunchon = true;
+                }
+            }
+        }
+
+        if (playwrongsounddone) {
+            if (hHeld & KEY_LEFT || hHeld & KEY_RIGHT) {} else {
+                soundwaittimer += 1;
+                if (soundwaittimer == 2) {
+                    soundwaittimer = 0;
+                    playwrongsounddone = false;
+                }
+            }
+        }
+
+        if (titleboxXmoveleft) {
+            titleboxXmovetimer += 1;
+            if (titleboxXmovetimer == 10) {
+                titleboxXmovetimer = 0;
+                titleboxXmoveleft = false;
+            } else if (titleboxXmovetimer == 9) {
+                // Delay a frame
+                bannertextloaded = false;
+                storedcursorPosition = cursorPosition;
+                if (dspfirmfound) {
+                    sfx_stop->stop();
+                }
+                if (dspfirmfound) {
+                    sfx_stop->play();
+                }
+            } else if (titleboxXmovetimer == 8) {
+                titleboxXmovepos += 8;
+                boxartXmovepos += 18;
+                startbordermovepos = 1;
+                startborderscalesize = 0.97;
+                cursorPositionset = false;
+            } else if (titleboxXmovetimer == 2) {
+                titleboxXmovepos += 8;
+                boxartXmovepos += 18;
+                if (dspfirmfound) {
+                    sfx_select->stop();
+                }
+                if (dspfirmfound) {
+                    sfx_select->play();
+                }
+                // Load the previous box art
+                if (cursorPosition == 3 + pagenum * 20 ||
+                        cursorPosition == 6 + pagenum * 20 ||
+                        cursorPosition == 9 + pagenum * 20 ||
+                        cursorPosition == 12 + pagenum * 20 ||
+                        cursorPosition == 15 + pagenum * 20 ||
+                        cursorPosition == 18 + pagenum * 20) {
+                    boxartnum = cursorPosition - 1;
+                    LoadBoxArt();
+                    boxartnum--;
+                    LoadBoxArt();
+                    boxartnum--;
+                    LoadBoxArt();
+                }
+                if (cursorPosition == 6 + pagenum * 20 ||
+                        cursorPosition == 12 + pagenum * 20 ||
+                        cursorPosition == 18 + pagenum * 20) {
+                    boxartXmovepos = -144 * 7;
+                    boxartXmovepos += 18 * 2;
+                }
+            } else {
+                if (!cursorPositionset) {
+                    cursorPosition--;
+                    cursorPositionset = true;
+                }
+                if (pagenum == 0) {
+                    if (cursorPosition != -3) {
+                        titleboxXmovepos += 8;
+                        boxartXmovepos += 18;
+                    } else {
+                        titleboxXmovetimer = 0;
+                        titleboxXmoveleft = false;
+                        cursorPositionset = false;
+                        cursorPosition++;
+                        if (!playwrongsounddone) {
+                            if (dspfirmfound) {
+                                sfx_wrong->stop();
+                                sfx_wrong->play();
+                            }
+                            playwrongsounddone = true;
+                        }
+                    }
+                } else {
+                    if (cursorPosition != -1 + pagenum * 20) {
+                        titleboxXmovepos += 8;
+                        boxartXmovepos += 18;
+                    } else {
+                        titleboxXmovetimer = 0;
+                        titleboxXmoveleft = false;
+                        cursorPositionset = false;
+                        cursorPosition++;
+                        if (!playwrongsounddone) {
+                            if (dspfirmfound) {
+                                sfx_wrong->stop();
+                                sfx_wrong->play();
+                            }
+                            playwrongsounddone = true;
+                        }
+                    }
+                }
+            }
+        } else if (titleboxXmoveright) {
+            titleboxXmovetimer += 1;
+            if (titleboxXmovetimer == 10) {
+                titleboxXmovetimer = 0;
+                titleboxXmoveright = false;
+            } else if (titleboxXmovetimer == 9) {
+                // Delay a frame
+                bannertextloaded = false;
+                storedcursorPosition = cursorPosition;
+                if (dspfirmfound) {
+                    sfx_stop->stop();
+                }
+                if (dspfirmfound) {
+                    sfx_stop->play();
+                }
+                // Load the next box art
+                if (cursorPosition == 4 + pagenum * 20 ||
+                        cursorPosition == 7 + pagenum * 20 ||
+                        cursorPosition == 10 + pagenum * 20 ||
+                        cursorPosition == 13 + pagenum * 20 ||
+                        cursorPosition == 16 + pagenum * 20 ||
+                        cursorPosition == 19 + pagenum * 20) {
+                    boxartnum = cursorPosition + 2;
+                    LoadBoxArt();
+                    boxartnum++;
+                    LoadBoxArt();
+                    boxartnum++;
+                    LoadBoxArt();
+                }
+                if (cursorPosition == 7 + pagenum * 20 ||
+                        cursorPosition == 13 + pagenum * 20 ||
+                        cursorPosition == 19 + pagenum * 20) {
+                    boxartXmovepos = -144;
+                }
+            } else if (titleboxXmovetimer == 8) {
+                titleboxXmovepos -= 8;
+                boxartXmovepos -= 18;
+                startbordermovepos = 1;
+                startborderscalesize = 0.97;
+                cursorPositionset = false;
+            } else if (titleboxXmovetimer == 2) {
+                titleboxXmovepos -= 8;
+                boxartXmovepos -= 18;
+                if (dspfirmfound) {
+                    sfx_select->stop();
+                }
+                if (dspfirmfound) {
+                    sfx_select->play();
+                }
+            } else {
+                if (!cursorPositionset) {
+                    cursorPosition++;
+                    cursorPositionset = true;
+                }
+                if (cursorPosition != filenum) {
+                    titleboxXmovepos -= 8;
+                    boxartXmovepos -= 18;
+                } else {
+                    titleboxXmovetimer = 0;
+                    titleboxXmoveright = false;
+                    cursorPositionset = false;
+                    cursorPosition--;
+                    if (!playwrongsounddone) {
+                        if (dspfirmfound) {
+                            sfx_wrong->stop();
+                            sfx_wrong->play();
+                        }
+                        playwrongsounddone = true;
+                    }
+                }
+            }
+        }
+        if (applaunchprep) {
+            rad += 0.50f;
+            boxartYmovepos -= 6;
+            boxartreflYmovepos += 2;
+            titleboxYmovepos -= 6;
+            ndsiconYmovepos -= 6;
+            if (titleboxYmovepos == -240) {
+                if (screenmodeswitch) {
+                    musicbool = false;
+                    screenmode = SCREEN_MODE_SETTINGS;
+                    settingsResetSubScreenMode();
+                    rad = 0.0f;
+                    boxartYmovepos = 63;
+                    boxartreflYmovepos = 264;
+                    titleboxYmovepos = 120;
+                    ndsiconYmovepos = 133;
+                    fadein = true;
+                    screenmodeswitch = false;
+                    applaunchprep = false;
+                } else {
+                    if (logEnabled) {
+                        LogFM("Main.applaunchprep", "Switching to NTR/TWL-mode");
+                    }
+                    applaunchon = true;
+                }
+            }
+            fadealpha += 6;
+            if (fadealpha > 255) {
+                fadealpha = 255;
+            }
+        }
+
+        //if (updatebotscreen) {
+        if (screenmode == SCREEN_MODE_ROM_SELECT) {
+            if (!colortexloaded_bot) {
+                settingsUnloadTextures();
+                dotcircletex = sfil_load_PNG_file(color_data->dotcircleloc, SF2D_PLACE_RAM); // Dots forming a circle
+                startbordertex = sfil_load_PNG_file(color_data->startborderloc, SF2D_PLACE_RAM); // "START" border
+                if (settings.ui.theme == 2) {
+                    switch (settings.ui.subtheme) {
+                        case 0:
+                        default:
+                            bottomtex = sfil_load_JPEG_file("romfs:/graphics/wood/gbatemp/lower_screen.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            break;
+                        case 1:
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/wood/black/lower_screen.png", SF2D_PLACE_RAM); // Bottom of menu
+                            break;
+                        case 2:
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/wood/Adv.Evo/lower_screen.png", SF2D_PLACE_RAM); // Bottom of menu
+                            break;
+                        case 3:
+                            bottomtex = sfil_load_JPEG_file("romfs:/graphics/wood/dstwo pink/lower_screen.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            break;
+                    }
+                } else if (settings.ui.theme == 1) {
+                    switch (settings.ui.subtheme) {
+                        case 0:
+                        default:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme01/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme01/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 1:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme02/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme02/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 2:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme03/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme03/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 3:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme04/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme04/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 4:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme05/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme05/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 5:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme06/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme06/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 6:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme07/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme07/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 7:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme08/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme08/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 8:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme09/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme09/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 9:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme10/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme10/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 10:
+                            iconstex = sfil_load_JPEG_file("romfs:/graphics/r4/theme11/icons.jpg", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme11/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                        case 11:
+                            iconstex = sfil_load_PNG_file("romfs:/graphics/r4/theme12/icons.png", SF2D_PLACE_RAM); // Bottom of menu
+                            bottomtex = sfil_load_PNG_file("romfs:/graphics/r4/theme12/bckgrd_2.png", SF2D_PLACE_RAM); // Bottom of rom select
+                            break;
+                    }
+                } else {
+                    bottomtex = sfil_load_PNG_file(bottomloc, SF2D_PLACE_RAM); // Bottom of menu
+                }
+                colortexloaded_bot = true;
+            }
+            sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+
+            if (settings.ui.theme == 2) {
+                if (wood_ndsiconscaletimer == 60) {
+                    // Scale icon at 30fps
+                    if (wood_ndsiconscalelag == 1) {
+                        if (wood_ndsiconscaledown) {
+                            wood_ndsiconscalemovepos -= 1;
+                            wood_ndsiconscalesize -= 0.06f;
+                            if (wood_ndsiconscalemovepos == 0) {
+                                wood_ndsiconscaledown = false;
+                            }
+                        } else {
+                            wood_ndsiconscalemovepos += 1;
+                            wood_ndsiconscalesize += 0.06f;
+                            if (wood_ndsiconscalemovepos == 4) {
+                                wood_ndsiconscaledown = true;
+                            }
+                        }
+                        wood_ndsiconscalelag = 0;
+                    } else {
+                        wood_ndsiconscalelag = 1;
+                    }
+                } else {
+                    wood_ndsiconscaletimer += 1;
+                    wood_ndsiconscalemovepos = 0;
+                    wood_ndsiconscalesize = 0.00f;
+                    wood_ndsiconscaledown = false;
+                }
+
+                sf2d_draw_texture(bottomtex, 320 / 2 - bottomtex->width / 2, 240 / 2 - bottomtex->height / 2);
+                if (menu_ctrlset == CTRL_SET_MENU) {
+                    // Poll for Slot-1 changes.
+                    bool forcePoll = false;
+                    bool doSlot1Update = false;
+                    if (gamecardIsInserted() && gamecardGetType() == CARD_TYPE_UNKNOWN) {
+                        // Card is inserted, but we don't know its type.
+                        // Force an update.
+                        forcePoll = true;
+                    }
+                    bool s1chg = gamecardPoll(forcePoll);
+                    if (s1chg) {
+                        // Update Slot-1 if:
+                        // - forcePoll is false
+                        // - forcePoll is true, and card is no longer unknown.
+                        doSlot1Update = (!forcePoll || gamecardGetType() != CARD_TYPE_UNKNOWN);
+                    }
+                    if (doSlot1Update) {
+                        // Slot-1 card has changed.
+                        if (cursorPosition == -1) {
+                            // Reload the banner text.
+                            bannertextloaded = false;
+                        }
+                    }
+                    sf2d_texture* cardicontex = gamecardGetIcon();
+                    if (!cardicontex) {
+                        cardicontex = iconnulltex;
+                    }
+
+                    int Ypos = 26;
+                    filenameYpos = 36;
+                    if (woodmenu_cursorPosition == 0) {
+                        sf2d_draw_rectangle(0, Ypos - 4, 320, 40, SET_ALPHA(color_data->color, 127));
+                        sf2d_draw_texture_part_scale(sdicontex, 8 - wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos + Ypos, bnriconframenum * 32, 0, 32, 32, 1.00 + wood_ndsiconscalesize, 1.00 + wood_ndsiconscalesize);
+                    } else {
+                        sf2d_draw_texture_part(sdicontex, 8, Ypos, bnriconframenum * 32, 0, 32, 32);
+                    }
+                    sftd_draw_textf(font, 46, filenameYpos, RGBA8(255, 255, 255, 255), 12, "Games (SD Card)");
+                    Ypos += 39;
+                    filenameYpos += 39;
+                    if (woodmenu_cursorPosition == 1) {
+                        sf2d_draw_rectangle(0, Ypos - 4, 320, 40, SET_ALPHA(color_data->color, 127));
+                        sf2d_draw_texture_part_scale(flashcardicontex, 8 - wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos + Ypos, bnriconframenum * 32, 0, 32, 32, 1.00 + wood_ndsiconscalesize, 1.00 + wood_ndsiconscalesize);
+                    } else {
+                        sf2d_draw_texture_part(flashcardicontex, 8, Ypos, bnriconframenum * 32, 0, 32, 32);
+                    }
+                    sftd_draw_textf(font, 46, filenameYpos, RGBA8(255, 255, 255, 255), 12, "Games (Flashcard)");
+                    Ypos += 39;
+                    filenameYpos += 39;
+                    if (woodmenu_cursorPosition == 2) {
+                        sf2d_draw_rectangle(0, Ypos - 4, 320, 40, SET_ALPHA(color_data->color, 127));
+                        sf2d_draw_texture_part_scale(cardicontex, 8 - wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos + Ypos, bnriconframenum * 32, 0, 32, 32, 1.00 + wood_ndsiconscalesize, 1.00 + wood_ndsiconscalesize);
+                    } else {
+                        sf2d_draw_texture_part(cardicontex, 8, Ypos, bnriconframenum * 32, 0, 32, 32);
+                    }
+                    sftd_draw_textf(font, 46, filenameYpos, RGBA8(255, 255, 255, 255), 12, "Launch Slot-1 card");
+                    Ypos += 39;
+                    filenameYpos += 39;
+                    if (woodmenu_cursorPosition == 3) {
+                        sf2d_draw_rectangle(0, Ypos - 4, 320, 40, SET_ALPHA(color_data->color, 127));
+                        sf2d_draw_texture_part_scale(gbaicontex, 8 - wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos + Ypos, bnriconframenum * 32, 0, 32, 32, 1.00 + wood_ndsiconscalesize, 1.00 + wood_ndsiconscalesize);
+                    } else {
+                        sf2d_draw_texture_part(gbaicontex, 8, Ypos, bnriconframenum * 32, 0, 32, 32);
+                    }
+                    sftd_draw_textf(font, 46, filenameYpos, RGBA8(255, 255, 255, 255), 12, "Start GBARunner2");
+                    Ypos += 39;
+                    filenameYpos += 39;
+                    if (woodmenu_cursorPosition == 4) {
+                        sf2d_draw_rectangle(0, Ypos - 4, 320, 40, SET_ALPHA(color_data->color, 127));
+                        sf2d_draw_texture_part_scale(smallsettingsicontex, 8 - wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos + Ypos, bnriconframenum * 32, 0, 32, 32, 1.00 + wood_ndsiconscalesize, 1.00 + wood_ndsiconscalesize);
+                    } else {
+                        sf2d_draw_texture_part(smallsettingsicontex, 8, Ypos, bnriconframenum * 32, 0, 32, 32);
+                    }
+                    sftd_draw_wtextf(font, 46, filenameYpos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_TEXT));
+                } else {
+                    int Ypos = 26;
+                    filenameYpos = 36;
+                    for (filenum = pagenum * 20; filenum < pagemax; filenum++) {
+                        bnriconnum = filenum;
+                        ChangeBNRIconNo();
+                        if (cursorPosition == filenum) {
+                            sf2d_draw_rectangle(0, Ypos - 4 + filenameYmovepos * 39, 320, 40, SET_ALPHA(color_data->color, 127));
+                        }
+
+                        // Get the current filename and convert it to wstring.
+                        const char* filename = (settings.twl.forwarder
+                                                ? fcfiles.at(filenum).c_str()
+                                                : files.at(filenum).c_str());
+                        wstring wstr = utf8_to_wstring(filename);
+                        sftd_draw_wtext(font, 46, filenameYpos + filenameYmovepos * 39, RGBA8(255, 255, 255, 255), 12, wstr.c_str());
+
+                        if (cursorPosition == filenum) {
+                            sf2d_draw_texture_part_scale(bnricontexnum, 8 - wood_ndsiconscalemovepos, -wood_ndsiconscalemovepos + Ypos + filenameYmovepos * 39, bnriconframenum * 32, 0, 32, 32, 1.00 + wood_ndsiconscalesize, 1.00 + wood_ndsiconscalesize);
+                        } else {
+                            sf2d_draw_texture_part(bnricontexnum, 8, Ypos + filenameYmovepos * 39, bnriconframenum * 32, 0, 32, 32);
+                        }
+                        Ypos += 39;
+                        filenameYpos += 39;
+                    }
+                    sf2d_draw_texture_part(bottomtex, 0, 0, 0, 0, 320, 22);
+                    sf2d_draw_texture_part(bottomtex, 0, 217, 0, 217, 320, 23);
+                    if (settings.twl.forwarder) {
+                        sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Games (Flashcard)");
+                    } else {
+                        sftd_draw_textf(font, 2, 2, RGBA8(255, 255, 255, 255), 12, "Games (SD Card)");
+                    }
+
+                    const size_t file_count = (settings.twl.forwarder ? fcfiles.size() : files.size());
+
+                    char romsel_counter1[16];
+                    char romsel_counter2[16];
+                    snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", cursorPosition + 1);
+                    // if(matching_files.size() == 0){
+                    snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", file_count);
+                    // }else{
+                    //  snprintf(romsel_counter2, sizeof(romsel_counter2), "%zu", matching_files.size());
+                    // }
+
+                    if (settings.ui.counter) {
+                        if (file_count < 100) {
+                            sftd_draw_text(font, 276, 2, RGBA8(255, 255, 255, 255), 12, romsel_counter1);
+                            sftd_draw_text(font, 295, 2, RGBA8(255, 255, 255, 255), 12, "/");
+                            sftd_draw_text(font, 300, 2, RGBA8(255, 255, 255, 255), 12, romsel_counter2);
+                        } else {
+                            sftd_draw_text(font, 276, 2, RGBA8(255, 255, 255, 255), 12, romsel_counter1);
+                            sftd_draw_text(font, 303, 2, RGBA8(255, 255, 255, 255), 12, "/");
+                            sftd_draw_text(font, 308, 2, RGBA8(255, 255, 255, 255), 12, romsel_counter2);
+                        }
+                    }
+                }
+            } else if (settings.ui.theme == 1) {
+                if (menu_ctrlset == CTRL_SET_MENU) {
+                    sf2d_draw_texture(iconstex, 320 / 2 - iconstex->width / 2, 240 / 2 - iconstex->height / 2);
+                    if (r4menu_cursorPosition == 0) {
+                        sf2d_draw_rectangle(12, 77, 92, 91, SET_ALPHA(color_data->color, 255));
+                        sf2d_draw_texture_part(iconstex, 14, 79, 14, 79, 88, 87);
+                        static const char selectiontext[] = "Games";
+                        const int text_width = sftd_get_text_width(font, 14, selectiontext);
+                        sftd_draw_textf(font, (320 - text_width) / 2, 220, RGBA8(255, 255, 255, 255), 14, selectiontext);
+                    } else  if (r4menu_cursorPosition == 1) {
+                        sf2d_draw_rectangle(115, 77, 92, 91, SET_ALPHA(color_data->color, 255));
+                        sf2d_draw_texture_part(iconstex, 117, 79, 117, 79, 88, 87);
+                        static const char selectiontext[] = "Launch Slot-1 card";
+                        const int text_width = sftd_get_text_width(font, 14, selectiontext);
+                        sftd_draw_textf(font, (320 - text_width) / 2, 220, RGBA8(255, 255, 255, 255), 14, selectiontext);
+                    } else  if (r4menu_cursorPosition == 2) {
+                        sf2d_draw_rectangle(217, 77, 92, 91, SET_ALPHA(color_data->color, 255));
+                        sf2d_draw_texture_part(iconstex, 219, 79, 219, 79, 88, 87);
+                        static const char selectiontext[] = "Start GBARunner2";
+                        const int text_width = sftd_get_text_width(font, 14, selectiontext);
+                        sftd_draw_textf(font, (320 - text_width) / 2, 220, RGBA8(255, 255, 255, 255), 14, selectiontext);
+                    }
+                    DrawDate(2, 220, RGBA8(255, 255, 255, 255), 14);
+                    sftd_draw_text(font, 276, 220, RGBA8(255, 255, 255, 255), 14, RetTime(true).c_str());
+                } else {
+                    sf2d_draw_texture(bottomtex, 320 / 2 - bottomtex->width / 2, 240 / 2 - bottomtex->height / 2);
+                    if (!bannertextloaded) {
+                        char path[256];
+                        bnriconnum = cursorPosition;
+                        if (settings.twl.forwarder) {
+                            const char* tempfile = fcfiles.at(bnriconnum).c_str();
+                            snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/flashcard/%s.bin", tempfile);
+                        } else {
+                            const char* tempfile = files.at(bnriconnum).c_str();
+                            snprintf(path, sizeof(path), "sdmc:/_nds/twloader/bnricons/%s.bin", tempfile);
+                        }
+                        if (access(path, F_OK) != -1) {
+                            LoadBNRIcon_R4Theme(path);
+                        } else {
+                            LoadBNRIcon_R4Theme(NULL);
+                        }
+                    }
+                    sf2d_draw_rectangle(80, 31, 192, 42, RGBA8(255, 255, 255, 255));
+                    sf2d_draw_texture(dboxtex_iconbox, 47, 31);
+                    sf2d_draw_texture_part(bnricontex[0], 52, 36, bnriconframenum * 32, 0, 32, 32);
+
+                    if (!bannertextloaded) {
+                        char path[256];
+                        if (settings.twl.forwarder) {
+                            // if(matching_files.size() == 0){
+                            if (fcfiles.size() != 0) {
+                                romsel_filename = fcfiles.at(cursorPosition).c_str();
+                                romsel_filename_w = utf8_to_wstring(romsel_filename);
+                            } else {
+                                romsel_filename = " ";
+                                romsel_filename_w = utf8_to_wstring(romsel_filename);
+                            }
+                            /* }else{
+                                if (matching_files.size() != 0) {
+                                    romsel_filename = matching_files.at(storedcursorPosition).c_str();
+                                    romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                } else {
+                                    romsel_filename = " ";
+                                    romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                }
+                            } */
+                            snprintf(path, sizeof(path), "%s/%s.bin", fcbnriconfolder, romsel_filename);
+                        } else {
+                            // if(matching_files.size() == 0){
+                            if (files.size() != 0) {
+                                romsel_filename = files.at(cursorPosition).c_str();
+                                romsel_filename_w = utf8_to_wstring(romsel_filename);
+                            } else {
+                                romsel_filename = " ";
+                                romsel_filename_w = utf8_to_wstring(romsel_filename);
+                            }
+                            snprintf(path, sizeof(path), "%s/%s.bin", bnriconfolder, romsel_filename);
+                            /* }else {
+                                if (matching_files.size() != 0) {
+                                    romsel_filename = matching_files.at(storedcursorPosition).c_str();
+                                    romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                } else {
+                                    romsel_filename = " ";
+                                    romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                }
+                                snprintf(path, sizeof(path), "%s/%s.bin", bnriconfolder, romsel_filename); */
+                        }
+
+                        if (access(path, F_OK) == -1) {
+                            // Banner file is not available.
+                            strcpy(path, "romfs:/notextbanner");
+                        }
+                        FILE* f_bnr = fopen(path, "rb");
+                        if (f_bnr) {
+                            romsel_gameline = grabText(f_bnr, language);
+                            fclose(f_bnr);
+                        } else {
+                            // Unable to open the banner file.
+                            romsel_gameline.clear();
+                            romsel_gameline.push_back(latin1_to_wstring("ERROR:"));
+                            romsel_gameline.push_back(latin1_to_wstring("Unable to open the cached banner."));
+                        }
+                        bannertextloaded = true;
+                    }
+                    if (cursorPosition >= 0) {
+                        int y = 32, dy = 12;
+                        // Print the banner text, center-aligned.
+                        const size_t banner_lines = std::min(3U, romsel_gameline.size());
+                        for (size_t i = 0; i < banner_lines; i++, y += dy) {
+                            const int text_width = sftd_get_wtext_width(font_b, 12, romsel_gameline[i].c_str());
+                            sftd_draw_wtext(font_b, 84 + (192 - text_width) / 2, y, RGBA8(0, 0, 0, 255), 12, romsel_gameline[i].c_str());
+                        }
+                    }
+                }
+            } else {
+                if (settings.ui.custombot == 1) {
+                    sf2d_draw_texture(bottomtex, 320 / 2 - bottomtex->width / 2, 240 / 2 - bottomtex->height / 2);
+                } else {
+                    sf2d_draw_texture_blend(bottomtex, 320 / 2 - bottomtex->width / 2, 240 / 2 - bottomtex->height / 2, menucolor);
+                }
+
+                if (fadealpha == 0) {
+                    sf2d_draw_texture(bubbletex, 0, 0);
+                    // if (dspfirmfound) { sfx_menuselect->play(); }
+                    bool drawBannerText = true;
+                    if (cursorPosition == -2) {
+                        const wchar_t* curn2text = TR(STR_SETTINGS_TEXT);
+                        const int text_width = sftd_get_wtext_width(font_b, 18, curn2text);
+                        sftd_draw_wtextf(font_b, (320 - text_width) / 2, 38, RGBA8(0, 0, 0, 255), 18, curn2text);
+                        drawBannerText = false;
+                    } else if (cursorPosition == -1) {
+                        if (settings.twl.forwarder) {
+                            static const char add_games_text[] = "Add Games";
+                            const int text_width = sftd_get_text_width(font_b, 18, add_games_text);
+                            sftd_draw_text(font_b, (320 - text_width) / 2, 38, RGBA8(0, 0, 0, 255), 18, add_games_text);
+                            drawBannerText = false;
+                        } else {
+                            // Get the text from the Slot 1 cartridge.
+                            if (!bannertextloaded) {
+                                romsel_gameline = gamecardGetText();
+                                const char* productCode = gamecardGetProductCode();
+                                if (!romsel_gameline.empty() && productCode) {
+                                    // Display the product code and revision.
+                                    // FIXME: Figure out a way to get the revision for CTR cards.
+                                    char buf[48];
+                                    if (gamecardGetType() != CARD_TYPE_CTR) {
+                                        snprintf(buf, sizeof(buf), "Slot-1: %s, Rev.%02u", productCode, gamecardGetRevision());
+                                    } else {
+                                        snprintf(buf, sizeof(buf), "Slot-1: %s", productCode);
+                                    }
+                                    romsel_filename_w = latin1_to_wstring(buf);
+                                } else {
+                                    romsel_filename_w.clear();
+                                }
+                            }
+
+                            if (romsel_gameline.empty()) {
+                                const wchar_t* msg;
+                                if (gamecardIsInserted()) {
+                                    // Game card is inserted, but unrecognized.
+                                    // It may be a blocked flashcard.
+                                    msg = TR(STR_UNKOWN);
+                                } else {
+                                    // No game card is inserted.
+                                    msg = TR(STR_NO_CARTRIDGE);
+                                }
+                                const int text_width = sftd_get_wtext_width(font_b, 18, msg);
+                                sftd_draw_wtext(font_b, (320 - text_width) / 2, 38, RGBA8(0, 0, 0, 255), 18, msg);
+                                drawBannerText = false;
+                            }
+                        }
+                    } else {
+                        if (!bannertextloaded) {
+                            char path[256];
+                            if (settings.twl.forwarder) {
+                                if (matching_files.size() == 0) {
+                                    if (fcfiles.size() != 0) {
+                                        romsel_filename = fcfiles.at(storedcursorPosition).c_str();
+                                        romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                    } else {
+                                        romsel_filename = " ";
+                                        romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                    }
+                                } else {
+                                    if (matching_files.size() != 0) {
+                                        romsel_filename = matching_files.at(storedcursorPosition).c_str();
+                                        romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                    } else {
+                                        romsel_filename = " ";
+                                        romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                    }
+                                }
+                                snprintf(path, sizeof(path), "%s/%s.bin", fcbnriconfolder, romsel_filename);
+                            } else {
+                                if (matching_files.size() == 0) {
+                                    if (files.size() != 0) {
+                                        romsel_filename = files.at(storedcursorPosition).c_str();
+                                        romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                    } else {
+                                        romsel_filename = " ";
+                                        romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                    }
+                                    snprintf(path, sizeof(path), "%s/%s.bin", bnriconfolder, romsel_filename);
+                                } else {
+                                    if (matching_files.size() != 0) {
+                                        romsel_filename = matching_files.at(storedcursorPosition).c_str();
+                                        romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                    } else {
+                                        romsel_filename = " ";
+                                        romsel_filename_w = utf8_to_wstring(romsel_filename);
+                                    }
+                                    snprintf(path, sizeof(path), "%s/%s.bin", bnriconfolder, romsel_filename);
+                                }
+                            }
+
+                            if (access(path, F_OK) == -1) {
+                                // Banner file is not available.
+                                strcpy(path, "romfs:/notextbanner");
+                            }
+                            bnriconnum = cursorPosition;
+                            FILE* f_bnr = fopen(path, "rb");
+                            if (f_bnr) {
+                                romsel_gameline = grabText(f_bnr, language);
+                                fclose(f_bnr);
+                            } else {
+                                // Unable to open the banner file.
+                                romsel_gameline.clear();
+                                romsel_gameline.push_back(latin1_to_wstring("ERROR:"));
+                                romsel_gameline.push_back(latin1_to_wstring("Unable to open the cached banner."));
+                            }
+                            bannertextloaded = true;
+                        }
+                    }
+
+                    if (drawBannerText) {
+                        int y, dy;
+                        //top dialog = 100px tall
+                        if (settings.ui.filename) {
+                            sftd_draw_wtext(font, 10, 8, RGBA8(127, 127, 127, 255), 12, romsel_filename_w.c_str());
+                            y = (100 - (19 * romsel_gameline.size())) / 2 + 4;
+                            //y = 24; dy = 19;
+                            dy = 19;
+                        } else {
+                            y = (100 - (22 * romsel_gameline.size())) / 2;
+                            //y = 16; dy = 22;
+                            dy = 22;
+                        }
+
+                        // Print the banner text, center-aligned.
+                        const size_t banner_lines = std::min(3U, romsel_gameline.size());
+                        for (size_t i = 0; i < banner_lines; i++, y += dy) {
+                            const int text_width = sftd_get_wtext_width(font_b, 16, romsel_gameline[i].c_str());
+                            sftd_draw_wtext(font_b, (320 - text_width) / 2, y, RGBA8(0, 0, 0, 255), 16, romsel_gameline[i].c_str());
+                        }
+
+                        if (cursorPosition >= 0 && settings.ui.counter) {
+                            char romsel_counter1[16];
+                            snprintf(romsel_counter1, sizeof(romsel_counter1), "%d", storedcursorPosition + 1);
+                            const char* p_romsel_counter;
+                            if (settings.twl.forwarder) {
+                                p_romsel_counter = romsel_counter2fc;
+                            } else {
+                                p_romsel_counter = romsel_counter2sd;
+                            }
+                            if (file_count < 100) {
+                                sftd_draw_textf(font, 8, 96, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
+                                sftd_draw_textf(font, 27, 96, RGBA8(0, 0, 0, 255), 12, "/");
+                                sftd_draw_textf(font, 32, 96, RGBA8(0, 0, 0, 255), 12, p_romsel_counter);
+                            } else {
+                                sftd_draw_textf(font, 8, 96, RGBA8(0, 0, 0, 255), 12, romsel_counter1);
+                                sftd_draw_textf(font, 35, 96, RGBA8(0, 0, 0, 255), 12, "/");
+                                sftd_draw_textf(font, 40, 96, RGBA8(0, 0, 0, 255), 12, p_romsel_counter);
+                            }
+                        }
+                    }
+                } else {
+                    sf2d_draw_texture(bottomlogotex, 320 / 2 - bottomlogotex->width / 2, 40);
+                }
+
+                if (!is3DSX) {
+                    const wchar_t* home_text = TR(STR_RETURN_TO_HOME_MENU);
+                    const int home_width = sftd_get_wtext_width(font, 13, home_text) + 16;
+                    const int home_x = (320 - home_width) / 2;
+                    sf2d_draw_texture(homeicontex, home_x, 220); // Draw HOME icon
+                    sftd_draw_wtext(font, home_x + 16, 221, RGBA8(0, 0, 0, 255), 13, home_text);
+                }
+
+                if (pagenum == 0) {
+                    if (settings.ui.iconsize) {
+                        sf2d_draw_texture_scale(bracetex, -74 + titleboxXmovepos * 1.25, 108, 1.25, 1.25);
+                        sf2d_draw_texture_scale(settingsicontex, -40 + setsboxXpos + titleboxXmovepos * 1.25, 111, 1.25, 1.25);
+                    } else {
+                        sf2d_draw_texture(bracetex, -32 + titleboxXmovepos, 116);
+                        sf2d_draw_texture(settingsicontex, setsboxXpos + titleboxXmovepos, 119);
+                    }
+
+                    if (!settings.twl.forwarder) {
+                        // Poll for Slot-1 changes.
+                        bool forcePoll = false;
+                        bool doSlot1Update = false;
+                        if (gamecardIsInserted() && gamecardGetType() == CARD_TYPE_UNKNOWN) {
+                            // Card is inserted, but we don't know its type.
+                            // Force an update.
+                            forcePoll = true;
+                        }
+                        bool s1chg = gamecardPoll(forcePoll);
+                        if (s1chg) {
+                            // Update Slot-1 if:
+                            // - forcePoll is false
+                            // - forcePoll is true, and card is no longer unknown.
+                            doSlot1Update = (!forcePoll || gamecardGetType() != CARD_TYPE_UNKNOWN);
+                        }
+                        if (doSlot1Update) {
+                            // Slot-1 card has changed.
+                            if (cursorPosition == -1) {
+                                // Reload the banner text.
+                                bannertextloaded = false;
+                            }
+                        }
+
+                        if (settings.ui.iconsize) {
+                            sf2d_draw_texture_scale(carttex(), -24 + cartXpos + titleboxXmovepos * 1.25, 111, 1.25, 1.25);
+                        } else {
+                            sf2d_draw_texture(carttex(), cartXpos + titleboxXmovepos, 120);
+                        }
+                        sf2d_texture* cardicontex = gamecardGetIcon();
+                        if (!cardicontex) {
+                            cardicontex = iconnulltex;
+                        }
+                        if (settings.ui.iconsize) {
+                            sf2d_draw_texture_part_scale(cardicontex, -4 + cartXpos + titleboxXmovepos * 1.25, 127, bnriconframenum * 32, 0, 32, 32, 1.25, 1.25);
+                        } else {
+                            sf2d_draw_texture_part(cardicontex, 16 + cartXpos + titleboxXmovepos, 133, bnriconframenum * 32, 0, 32, 32);
+                        }
+                    } else {
+                        // Get flash cart games.
+                        if (settings.ui.iconsize) {
+                            sf2d_draw_texture_scale(getfcgameboxtex, -24 + cartXpos + titleboxXmovepos * 1.25, 111, 1.25, 1.25);
+                        } else {
+                            sf2d_draw_texture(getfcgameboxtex, cartXpos + titleboxXmovepos, 119);
+                        }
+                    }
+                } else {
+                    sf2d_draw_texture(bracetex, 32 + cartXpos + titleboxXmovepos, 116);
+                }
+
+                if (settings.ui.iconsize) {
+                    titleboxXpos = 120;
+                    ndsiconXpos = 140;
+                } else {
+                    titleboxXpos = 128;
+                    ndsiconXpos = 144;
+                }
+                //filenameYpos = 0;
+                for (filenum = pagenum * 20; filenum < pagemax; filenum++) {
+                    if (settings.ui.iconsize) {
+                        sf2d_draw_texture_scale(boxfulltex, titleboxXpos + titleboxXmovepos * 1.25, 112, 1.25, 1.25);
+                        titleboxXpos += 80;
+
+                        bnriconnum = filenum;
+                        ChangeBNRIconNo();
+                        sf2d_draw_texture_part_scale(bnricontexnum, ndsiconXpos + titleboxXmovepos * 1.25, 127, bnriconframenum * 32, 0, 32, 32, 1.25, 1.25);
+                        ndsiconXpos += 80;
+                    } else {
+                        sf2d_draw_texture(boxfulltex, titleboxXpos + titleboxXmovepos, 120);
+                        titleboxXpos += 64;
+
+                        bnriconnum = filenum;
+                        ChangeBNRIconNo();
+                        sf2d_draw_texture_part(bnricontexnum, ndsiconXpos + titleboxXmovepos, 133, bnriconframenum * 32, 0, 32, 32);
+                        ndsiconXpos += 64;
+                    }
+                }
+
+                if (settings.ui.iconsize) {
+                    sf2d_draw_texture_scale(bracetex, 15 + ndsiconXpos + titleboxXmovepos * 1.25, 108, -1.25, 1.25);
+                } else {
+                    sf2d_draw_texture_scale(bracetex, 15 + ndsiconXpos + titleboxXmovepos, 116, -1, 1);
+                }
+                if (!applaunchprep) {
+                    if (titleboxXmovetimer == 0) {
+                        startbordermovepos = 0;
+                        startborderscalesize = 1.0;
+                    }
+                    if (!settings.twl.forwarder && cursorPosition == -1 && !gamecardIsInserted()) {
+                        // Slot-1 selected, but no cartridge is present.
+                        // Don't print "START" and the cursor border.
+                    } else {
+                        if (!is3DSX || cursorPosition == -2) {
+                            // Print "START" and the cursor border.
+                            if (settings.ui.iconsize) {
+                                sf2d_draw_texture_scale(startbordertex, 120 + startbordermovepos, 108 + startbordermovepos, startborderscalesize + 0.25, startborderscalesize + 0.25);
+                                const wchar_t* start_text = TR(STR_START);
+                                const int start_width = sftd_get_wtext_width(font_b, 16, start_text);
+                                sftd_draw_wtext(font_b, (320 - start_width) / 2, 183, RGBA8(255, 255, 255, 255), 16, start_text);
+                            } else {
+                                sf2d_draw_texture_scale(startbordertex, 128 + startbordermovepos, 116 + startbordermovepos, startborderscalesize, startborderscalesize);
+                                const wchar_t* start_text = TR(STR_START);
+                                const int start_width = sftd_get_wtext_width(font_b, 12, start_text);
+                                sftd_draw_wtext(font_b, (320 - start_width) / 2, 177, RGBA8(255, 255, 255, 255), 12, start_text);
+                            }
+                        }
+                    }
+                } else {
+                    if (settings.ui.custombot) {
+                        sf2d_draw_texture_part(bottomtex, 128, 116, 128, 116, 64, 80);
+                    } else {
+                        sf2d_draw_texture_part_blend(bottomtex, 128, 116, 128, 116, 64, 80, SET_ALPHA(menucolor, 255));    // Cover selected game/app
+                    }
+                    if (cursorPosition == -2) {
+                        sf2d_draw_texture(settingsicontex, 128, titleboxYmovepos - 1); // Draw settings box that moves up
+                    } else if (cursorPosition == -1) {
+                        if (settings.twl.forwarder) {
+                            sf2d_draw_texture(getfcgameboxtex, 128, titleboxYmovepos - 1);
+                        } else {
+                            // Draw selected Slot-1 game that moves up
+                            sf2d_draw_texture(carttex(), 128, titleboxYmovepos);
+                            sf2d_texture* cardicontex = gamecardGetIcon();
+                            if (!cardicontex) {
+                                cardicontex = iconnulltex;
+                            }
+                            sf2d_draw_texture(cardicontex, 144, ndsiconYmovepos);
+                        }
+                    } else {
+                        sf2d_draw_texture(boxfulltex, 128, titleboxYmovepos); // Draw selected game/app that moves up
+                        if (!applaunchicon) {
+                            bnriconnum = cursorPosition;
+                            ChangeBNRIconNo();
+                            bnricontexlaunch = bnricontexnum;
+                            applaunchicon = true;
+                        }
+                        sf2d_draw_texture_part(bnricontexlaunch, 144, ndsiconYmovepos, bnriconframenum * 32, 0, 32, 32);
+                    }
+                    sf2d_draw_texture_rotate(dotcircletex, 160, 152, rad);  // Dots moving in circles
+                }
+                if (menudbox_Ypos != -240) {
+                    // Draw the menu dialog box.
+                    drawMenuDialogBox();
+                }
+            }
+        } else if (screenmode == SCREEN_MODE_SETTINGS) {
+            if (colortexloaded_bot) {
+                sf2d_free_texture(dotcircletex);
+                dotcircletex = NULL;
+                sf2d_free_texture(startbordertex);
+                startbordertex = NULL;
+                sf2d_free_texture(bottomtex);
+                bottomtex = NULL;
+                colortexloaded_bot = false;
+            }
+            settingsDrawBottomScreen();
+        }
+        if (settings.ui.theme == 0) {
+            sf2d_draw_rectangle(0, 0, 320, 240, RGBA8(0, 0, 0, fadealpha));    // Fade in/out effect
+        }
+
+        sf2d_end_frame();
+        // }
+
+        sf2d_swapbuffers();
+
+
+        /* if (titleboxXmovetimer == 0) {
+            updatebotscreen = false;
+        } */
+        if (screenmode == SCREEN_MODE_ROM_SELECT) {
+            /* if (filenum == 0) {  // If no ROMs are found
+                romselect_layout = 1;
+                updatebotscreen = true;
+            } */
+            if (settings.ui.theme == 2) {
+                if (menu_ctrlset == CTRL_SET_MENU) {
+                    if (hDown & KEY_A) {
+                        switch (woodmenu_cursorPosition) {
+                            case 0:
+                            default:
+                                menu_ctrlset = CTRL_SET_GAMESEL;
+                                if (settings.twl.forwarder) {
+                                    settings.twl.forwarder = false;
+                                    cursorPosition = 0;
+                                    pagenum = 0;
+                                    boxarttexloaded = false; // Reload boxarts
+                                    bnricontexloaded = false; // Reload banner icons
+                                    bannertextloaded = false;
+                                }
+                                break;
+                            case 1:
+                                menu_ctrlset = CTRL_SET_GAMESEL;
+                                if (!settings.twl.forwarder) {
+                                    settings.twl.forwarder = true;
+                                    cursorPosition = 0;
+                                    pagenum = 0;
+                                    boxarttexloaded = false; // Reload boxarts
+                                    bnricontexloaded = false; // Reload banner icons
+                                    bannertextloaded = false;
+                                }
+                                break;
+                            case 2:
+                                if (!is3DSX) {
+                                    settings.twl.launchslot1 = true;
+                                    settings.twl.forwarder = false;
+                                    if (logEnabled) {
+                                        LogFM("Main", "Switching to NTR/TWL-mode");
+                                    }
+                                    applaunchon = true;
+                                }
+                                break;
+                            case 3:
+                                if (!is3DSX) {
+                                    gbarunnervalue = 1;
+                                    settings.ui.romfolder = "_nds";
+                                    rom = "GBARunner2.nds";
+                                    if (settings.twl.forwarder) {
+                                        settings.twl.launchslot1 = true;
+                                    } else {
+                                        settings.twl.launchslot1 = false;
+                                    }
+                                    if (logEnabled) {
+                                        LogFM("Main", "Switching to NTR/TWL-mode");
+                                    }
+                                    applaunchon = true;
+                                }
+                                break;
+                            case 4:
+                                sf2d_set_3D(1);
+                                screenmode = SCREEN_MODE_SETTINGS;
+                                settingsResetSubScreenMode();
+                                break;
+                        }
+                        wood_ndsiconscaletimer = 0;
+                    } else if (hDown & KEY_DOWN) {
+                        woodmenu_cursorPosition++;
+                        if (woodmenu_cursorPosition > 4) {
+                            woodmenu_cursorPosition = 4;
+                        }
+                        wood_ndsiconscaletimer = 0;
+                    } else if (hDown & KEY_UP) {
+                        woodmenu_cursorPosition--;
+                        if (woodmenu_cursorPosition < 0) {
+                            woodmenu_cursorPosition = 0;
+                        }
+                        wood_ndsiconscaletimer = 0;
+                    }
+                } else {
+                    if (cursorPosition < 0) {
+                        filenameYmovepos = 0;
+                        titleboxXmovepos -= 64;
+                        boxartXmovepos -= 18 * 8;
+                        cursorPosition = 0;
+                        // updatebotscreen = true;
+                    }
+                    if (hDown & KEY_A) {
+                        if (!is3DSX) {
+                            if (settings.twl.forwarder) {
+                                settings.twl.launchslot1 = true;
+                                // if(matching_files.size() == 0){
+                                rom = fcfiles.at(cursorPosition).c_str();
+                                // }else {
+                                //  rom = matching_files.at(cursorPosition).c_str();
+                                // }
+                            } else {
+                                settings.twl.launchslot1 = false;
+                                // if(matching_files.size() == 0){
+                                rom = files.at(cursorPosition).c_str();
+                                // }else {
+                                //  rom = matching_files.at(cursorPosition).c_str();
+                                // }
+                                sav = ReplaceAll(rom, ".nds", ".sav");
+                            }
+                            if (logEnabled) {
+                                LogFM("Main", "Switching to NTR/TWL-mode");
+                            }
+                            applaunchon = true;
+                        }
+                        wood_ndsiconscaletimer = 0;
+                    } else if (hDown & KEY_L) {
+                        if ((size_t)pagenum != 0 && file_count <= (size_t)0 - pagenum * 20) {
+                            pagenum--;
+                            bannertextloaded = false;
+                            cursorPosition = 0 + pagenum * 20;
+                            bnricontexloaded = false;
+                            boxarttexloaded = false;
+                        }
+                    } else if (hDown & KEY_R) {
+                        if (file_count > (size_t)pagemax) {
+                            pagenum++;
+                            bannertextloaded = false;
+                            cursorPosition = 0 + pagenum * 20;
+                            bnricontexloaded = false;
+                            boxarttexloaded = false;
+                        }
+                    } else if (hDown & KEY_DOWN) {
+                        cursorPosition++;
+                        if (cursorPosition >= pagemax) {
+                            cursorPosition = 0 + pagenum * 20;
+                        }
+                        wood_downpressed = true;
+                        wood_ndsiconscaletimer = 0;
+                        bannertextloaded = false;
+                    } else if ((hDown & KEY_UP) && (filenum > 1)) {
+                        cursorPosition--;
+                        if (cursorPosition < 0 + pagenum * 20) {
+                            cursorPosition = pagemax - 1;
+                        }
+                        wood_uppressed = true;
+                        wood_ndsiconscaletimer = 0;
+                        bannertextloaded = false;
+                    } else if (hDown & KEY_B) {
+                        menu_ctrlset = CTRL_SET_MENU;
+                        wood_ndsiconscaletimer = 0;
+                    }
+                    if (filenum > 4) {
+                        if (cursorPosition > 2 + pagenum * 20) {
+                            filenameYmovepos = -cursorPosition + 2 + pagenum * 20;
+                        } else {
+                            filenameYmovepos = 0;
+                        }
+                    }
+                }
+            } else if (settings.ui.theme == 1) {
+                if (menu_ctrlset == CTRL_SET_MENU) {
+                    if (hDown & KEY_A) {
+                        switch (r4menu_cursorPosition) {
+                            case 0:
+                            default:
+                                menu_ctrlset = CTRL_SET_GAMESEL;
+                                updatetopscreen = true;
+                                break;
+                            case 1:
+                                if (!is3DSX) {
+                                    settings.twl.launchslot1 = true;
+                                    settings.twl.forwarder = false;
+                                    if (logEnabled) {
+                                        LogFM("Main", "Switching to NTR/TWL-mode");
+                                    }
+                                    applaunchon = true;
+                                }
+                                break;
+                            case 2:
+                                if (!is3DSX) {
+                                    gbarunnervalue = 1;
+                                    settings.ui.romfolder = "_nds";
+                                    rom = "GBARunner2.nds";
+                                    if (settings.twl.forwarder) {
+                                        settings.twl.launchslot1 = true;
+                                    } else {
+                                        settings.twl.launchslot1 = false;
+                                    }
+                                    if (logEnabled) {
+                                        LogFM("Main", "Switching to NTR/TWL-mode");
+                                    }
+                                    applaunchon = true;
+                                }
+                                break;
+                        }
+                    } else if (hDown & KEY_RIGHT) {
+                        r4menu_cursorPosition++;
+                        if (r4menu_cursorPosition > 2) {
+                            r4menu_cursorPosition = 2;
+                        }
+                    } else if (hDown & KEY_LEFT) {
+                        r4menu_cursorPosition--;
+                        if (r4menu_cursorPosition < 0) {
+                            r4menu_cursorPosition = 0;
+                        }
+                    } else if (hDown & KEY_SELECT) {
+                        sf2d_set_3D(1);
+                        screenmode = SCREEN_MODE_SETTINGS;
+                        settingsResetSubScreenMode();
+                        updatetopscreen = true;
+                    }
+                } else {
+                    if (cursorPosition < 0) {
+                        filenameYmovepos = 0;
+                        titleboxXmovepos -= 64;
+                        boxartXmovepos -= 18 * 8;
+                        cursorPosition = 0;
+                        updatetopscreen = true;
+                    }
+                    if (hDown & KEY_L) {
+                        settings.twl.forwarder = !settings.twl.forwarder;
+                        cursorPosition = 0;
+                        pagenum = 0;
+                        boxarttexloaded = false; // Reload boxarts
+                        bnricontexloaded = false; // Reload banner icons
+                        bannertextloaded = false;
+                        updatetopscreen = true;
+                    }
+                    if (hDown & KEY_A) {
+                        if (!is3DSX) {
+                            if (settings.twl.forwarder) {
+                                settings.twl.launchslot1 = true;
+                                // if(matching_files.size() == 0){
+                                rom = fcfiles.at(cursorPosition).c_str();
+                                // }else {
+                                //  rom = matching_files.at(cursorPosition).c_str();
+                                // }
+                            } else {
+                                settings.twl.launchslot1 = false;
+                                // if(matching_files.size() == 0){
+                                rom = files.at(cursorPosition).c_str();
+                                // }else {
+                                //  rom = matching_files.at(cursorPosition).c_str();
+                                // }
+                                sav = ReplaceAll(rom, ".nds", ".sav");
+                            }
+                            if (logEnabled) {
+                                LogFM("Main", "Switching to NTR/TWL-mode");
+                            }
+                            applaunchon = true;
+                        }
+                    } else if (hDown & KEY_DOWN) {
+                        cursorPosition++;
+                        if (cursorPosition == filenum) {
+                            filenameYmovepos = 0;
+                            cursorPosition = 0;
+                        }
+                        bannertextloaded = false;
+                        updatetopscreen = true;
+                    } else if ((hDown & KEY_UP) && (filenum > 1)) {
+                        if (cursorPosition == 0) {
+                            cursorPosition = filenum;
+                        }
+                        cursorPosition--;
+                        bannertextloaded = false;
+                        updatetopscreen = true;
+                    } else if ((hDown & KEY_LEFT) && (filenum > 10)) {
+                        cursorPosition -= 10;
+                        if (cursorPosition < 0) {
+                            cursorPosition = 0;
+                        }
+                        bannertextloaded = false;
+                        updatetopscreen = true;
+                    } else if ((hDown & KEY_RIGHT) && (filenum > 10)) {
+                        cursorPosition += 10;
+                        if (cursorPosition >= filenum) {
+                            cursorPosition = filenum - 1;
+                        }
+                        bannertextloaded = false;
+                        updatetopscreen = true;
+                    } else if (hDown & KEY_B) {
+                        menu_ctrlset = CTRL_SET_MENU;
+                        updatetopscreen = true;
+                    }
+                    if (filenum > 15) {
+                        /* if (cursorPosition > filenum-8) {}
+                        else */ if (cursorPosition > 7) {
+                            filenameYmovepos = -cursorPosition + 7;
+                        } else {
+                            filenameYmovepos = 0;
+                        }
+                    }
+                }
+            } else {
+                startbordermovepos = 0;
+                startborderscalesize = 1.0;
+                if (!noromsfound && file_count == 0) {
+                    // No ROMs were found.
+                    cursorPosition = -1;
+                    storedcursorPosition = cursorPosition;
+                    titleboxXmovepos = +64;
+                    boxartXmovepos = 0;
+                    // updatebotscreen = true;
+                    noromsfound = true;
+                }
+                if (titleboxXmovetimer == 0 && menu_ctrlset == CTRL_SET_GAMESEL) {
+                    if (hDown & KEY_R) {
+                        menuaction_nextpage = true;
+                    } else if (hDown & KEY_L) {
+                        menuaction_prevpage = true;
+                    }
+                    if (hDown & KEY_Y) {
+                        if (dspfirmfound) {
+                            sfx_switch->stop(); // Prevent freezing
+                            sfx_switch->play();
+                        }
+                        settings.ui.iconsize = !settings.ui.iconsize;
+                    }
+                    hidTouchRead(&touch);
+                    if (hDown & KEY_TOUCH) {
+                        if (touch.px >= 128 && touch.px <= 192 && touch.py >= 112 && touch.py <= 192) {
+                            menuaction_launch = true;
+                        } else if (touch.px < 128 && touch.py >= 118 && touch.py <= 180  && menudbox_Ypos == -240) {
+                            //titleboxXmovepos -= 64;
+                            if (!titleboxXmoveright) {
+                                titleboxXmoveleft = true;
+                            }
+                            // updatebotscreen = true;
+                        } else if (touch.px > 192 && touch.py >= 118 && touch.py <= 180  && menudbox_Ypos == -240) {
+                            //titleboxXmovepos -= 64;
+                            if (!titleboxXmoveleft) {
+                                if (cursorPosition == -1) {
+                                    if (filenum == 0) {
+                                        if (!playwrongsounddone) {
+                                            if (dspfirmfound) {
+                                                sfx_wrong->stop();
+                                                sfx_wrong->play();
+                                            }
+                                            playwrongsounddone = true;
+                                        }
+                                    } else {
+                                        titleboxXmoveright = true;
+                                    }
+                                } else {
+                                    titleboxXmoveright = true;
+                                }
+                            }
+                            // updatebotscreen = true;
+                        }
+                    } else if (hDown & KEY_A) {
+                        menuaction_launch = true;
+                    } else if (hHeld & KEY_RIGHT && menudbox_Ypos == -240) {
+                        //titleboxXmovepos -= 64;
+                        if (!titleboxXmoveleft) {
+                            if (cursorPosition == -1) {
+                                if (filenum == 0) {
+                                    if (!playwrongsounddone) {
+                                        if (dspfirmfound) {
+                                            sfx_wrong->stop();
+                                            sfx_wrong->play();
+                                        }
+                                        playwrongsounddone = true;
+                                    }
+                                } else {
+                                    titleboxXmoveright = true;
+                                }
+                            } else {
+                                titleboxXmoveright = true;
+                            }
+                        }
+                        // updatebotscreen = true;
+                    } else if (hHeld & KEY_LEFT && menudbox_Ypos == -240) {
+                        //titleboxXmovepos += 64;
+                        if (!titleboxXmoveright) {
+                            titleboxXmoveleft = true;
+                        }
+                        // updatebotscreen = true;
+                    } else if (hDown & KEY_START) {
+                        // Switch to the "Start" menu.
+                        menudboxmode = DBOX_MODE_OPTIONS;
+                        if (!showdialogbox_menu) {
+                            if (menudbox_Ypos == -240) {
+                                showdialogbox_menu = true;
+                                menu_ctrlset = CTRL_SET_DBOX;
+                                // Reset the cursor positions.
+                                startmenu_cursorPosition = 0;
+                                gamesettings_cursorPosition = 0;
+                            }
+                        }
+                    } else if (hDown & KEY_SELECT) {
+                        // Switch to per-game settings.
+                        menudboxmode = DBOX_MODE_SETTINGS;
+                        if (!showdialogbox_menu) {
+                            if (cursorPosition >= 0 && menudbox_Ypos == -240) {
+                                if (settings.twl.forwarder) {
+                                    if (matching_files.size() == 0) {
+                                        rom = fcfiles.at(cursorPosition).c_str();
+                                    } else {
+                                        rom = matching_files.at(cursorPosition).c_str();
+                                    }
+                                } else {
+                                    if (matching_files.size() == 0) {
+                                        rom = files.at(cursorPosition).c_str();
+                                    } else {
+                                        rom = matching_files.at(cursorPosition).c_str();
+                                    }
+                                }
+                                LoadPerGameSettings();
+                                showdialogbox_menu = true;
+                                menu_ctrlset = CTRL_SET_DBOX;
+                                // Reset the cursor positions.
+                                startmenu_cursorPosition = 0;
+                                gamesettings_cursorPosition = 0;
+                            }
+                        }
+                    }
+
+                    if (menuaction_nextpage) {
+                        // Don't run the action again 'til R is pressed again
+                        menuaction_nextpage = false;
+                        if (file_count > (size_t)pagemax) {
+                            pagenum++;
+                            bannertextloaded = false;
+                            cursorPosition = 0 + pagenum * 20;
+                            storedcursorPosition = cursorPosition;
+                            titleboxXmovepos = 0;
+                            boxartXmovepos = 0;
+                            // noromsfound = false;
+                            bnricontexloaded = false;
+                            boxarttexloaded = false;
+                            if (dspfirmfound) {
+                                sfx_switch->stop(); // Prevent freezing
+                                sfx_switch->play();
+                            }
+                            // updatebotscreen = true;
+                        }
+                    } else if (menuaction_prevpage) {
+                        // Don't run the action again 'til L is pressed again
+                        menuaction_prevpage = false;
+                        if ((size_t)pagenum != 0 && file_count <= (size_t)0 - pagenum * 20) {
+                            pagenum--;
+                            bannertextloaded = false;
+                            cursorPosition = 0 + pagenum * 20;
+                            storedcursorPosition = cursorPosition;
+                            titleboxXmovepos = 0;
+                            boxartXmovepos = 0;
+                            // noromsfound = false;
+                            bnricontexloaded = false;
+                            boxarttexloaded = false;
+                            if (dspfirmfound) {
+                                sfx_switch->stop(); // Prevent freezing
+                                sfx_switch->play();
+                            }
+                            // updatebotscreen = true;
+                        }
+                    } else if (menuaction_launch) {
+                        menuaction_launch = false;  // Don't run the action again 'til A is pressed again
+                        if (!is3DSX || cursorPosition == -2) {
+                            bool playlaunchsound = true;
+                            if (titleboxXmovetimer == 0) {
+                                if (cursorPosition == -2) {
+                                    titleboxXmovetimer = 1;
+                                    screenmodeswitch = true;
+                                    applaunchprep = true;
+                                } else if (cursorPosition == -1) {
+                                    if (!settings.twl.forwarder && !gamecardIsInserted()) {
+                                        // Slot-1 is selected, but no
+                                        // cartridge is present.
+                                        if (!playwrongsounddone) {
+                                            if (dspfirmfound) {
+                                                sfx_wrong->stop();
+                                                sfx_wrong->play();
+                                            }
+                                            playwrongsounddone = true;
+                                        }
+                                        playlaunchsound = false;
+                                    } else {
+                                        titleboxXmovetimer = 1;
+                                        settings.twl.launchslot1 = true;
+                                        if (settings.twl.forwarder) {
+                                            keepsdvalue = true;
+                                            rom = "_nds/twloader.nds";
+                                        }
+                                        applaunchprep = true;
+                                    }
+                                } else {
+                                    titleboxXmovetimer = 1;
+                                    if (settings.twl.forwarder) {
+                                        settings.twl.launchslot1 = true;
+                                        if (matching_files.size() == 0) {
+                                            rom = fcfiles.at(cursorPosition).c_str();
+                                        } else {
+                                            rom = matching_files.at(cursorPosition).c_str();
+                                        }
+                                    } else {
+                                        settings.twl.launchslot1 = false;
+                                        if (matching_files.size() == 0) {
+                                            rom = files.at(cursorPosition).c_str();
+                                        } else {
+                                            rom = matching_files.at(cursorPosition).c_str();
+                                        }
+                                        sav = ReplaceAll(rom, ".nds", ".sav");
+                                    }
+                                    applaunchprep = true;
+                                }
+                            }
+                            if (playlaunchsound && dspfirmfound) {
+                                bgm_menu->stop();
+                                sfx_launch->play();
+                            }
+                        } else {
+                            if (!playwrongsounddone) {
+                                if (dspfirmfound) {
+                                    sfx_wrong->stop();
+                                    sfx_wrong->play();
+                                }
+                                playwrongsounddone = true;
+                            }
+                        }
+                    }
+
+                } else if (menu_ctrlset == CTRL_SET_DBOX) {
+                    hidTouchRead(&touch);
+
+                    if (menudboxmode == DBOX_MODE_OPTIONS) {
+                        if (hDown & KEY_SELECT) {
+                            if (cursorPosition >= 0) {
+                                // Switch to game-specific settings.
+                                menudboxmode = DBOX_MODE_SETTINGS;
+                            }
+                        } else if (hDown & KEY_RIGHT) {
+                            if (startmenu_cursorPosition % 2 != 1 &&
+                                    startmenu_cursorPosition != 5) {
+                                // Move right.
+                                startmenu_cursorPosition++;
+                            }
+                        } else if (hDown & KEY_LEFT) {
+                            if (startmenu_cursorPosition % 2 != 0) {
+                                // Move left.
+                                startmenu_cursorPosition--;
+                            }
+                        } else if (hDown & KEY_DOWN) {
+                            if (startmenu_cursorPosition < 4) {
+                                startmenu_cursorPosition += 2;
+                            }
+
+                        } else if (hDown & KEY_UP) {
+                            if (startmenu_cursorPosition > 1) {
+                                startmenu_cursorPosition -= 2;
+                            }
+                        } else if (hDown & KEY_TOUCH) {
+                            if (touch.px >= 23 && touch.px <= 155 && touch.py >= 31 && touch.py <= 65) { // Game location button
+                                startmenu_cursorPosition = 0;
+                                menudboxaction_switchloc = true;
+                            } else if (touch.px >= 161 && touch.px <= 293 && touch.py >= 31 && touch.py <= 65) { // Box art button
+                                startmenu_cursorPosition = 1;
+                                settings.romselect.toplayout = !settings.romselect.toplayout;
+                                if (dspfirmfound) {
+                                    sfx_switch->stop(); // Prevent freezing
+                                    sfx_switch->play();
+                                }
+                            } else if (touch.px >= 23 && touch.px <= 155 && touch.py >= 71 && touch.py <= 105) { // Start GBARunner2 button
+                                startmenu_cursorPosition = 2;
+                                if (!is3DSX) {
+                                    gbarunnervalue = 1;
+                                    settings.ui.romfolder = "_nds";
+                                    rom = "GBARunner2.nds";
+                                    if (settings.twl.forwarder) {
+                                        settings.twl.launchslot1 = true;
+                                    } else {
+                                        settings.twl.launchslot1 = false;
+                                    }
+                                    fadeout = true;
+                                    if (dspfirmfound) {
+                                        bgm_menu->stop();
+                                        sfx_launch->play();
+                                    }
+                                } else {
+                                    if (!playwrongsounddone) {
+                                        if (dspfirmfound) {
+                                            sfx_wrong->stop();
+                                            sfx_wrong->play();
+                                        }
+                                        playwrongsounddone = true;
+                                    }
+                                }
+                            } else if (touch.px >= 161 && touch.px <= 293 && touch.py >= 71 && touch.py <= 105) { // Top border button
+                                startmenu_cursorPosition = 3;
+                                settings.ui.topborder = !settings.ui.topborder;
+                            } else if (touch.px >= 23 && touch.px <= 155 && touch.py >= 111 && touch.py <= 145) { // Unset donor ROM button
+                                startmenu_cursorPosition = 4;
+                                bootstrapini.SetString(bootstrapini_ndsbootstrap, "ARM7_DONOR_PATH", "");
+                                bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
+                                showdialogbox_menu = false;
+                                menudbox_movespeed = 1;
+                                menu_ctrlset = CTRL_SET_GAMESEL;
+                            } else if (touch.px >= 161 && touch.px <= 293 && touch.py >= 111 && touch.py <= 145) { // Search button
+                                startmenu_cursorPosition = 5; // Only this is making sometimes to not show the light texture
+                                if (matching_files.size() != 0) {
+                                    matching_files.clear();
+                                    snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
+                                    snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size());
+                                }
+
+                                std::string gameName = keyboardInput(TR(STR_START_SEARCH_HINT));
+                                if (logEnabled) {
+                                    LogFMA("Main.search", "Text written", gameName.c_str());
+                                }
+
+                                if (!settings.twl.forwarder) {
+                                    // SD CARD
+                                    for (auto iter = files.cbegin(); iter != files.cend(); ++iter) {
+                                        if (iter->size() < gameName.size()) {
+                                            // Filename we're checking is shorter than the search term,
+                                            // so it can't match.
+                                            continue;
+                                        }
+                                        // Use C string comparison for case-insensitive checks.
+                                        if (strcasestr(iter->c_str(), gameName.c_str()) != NULL) {
+                                            // String matches.
+                                            matching_files.push_back(*iter);
+                                        }
+                                    }
+                                } else {
+                                    // FLASHCARD
+                                    for (auto iter = fcfiles.cbegin(); iter != fcfiles.cend(); ++iter) {
+                                        if (iter->size() < gameName.size()) {
+                                            // Filename we're checking is shorter than the search term,
+                                            // so it can't match.
+                                            continue;
+                                        }
+                                        // Use C string comparison for case-insensitive checks.
+                                        if (strcasestr(iter->c_str(), gameName.c_str()) != NULL) {
+                                            // String matches.
+                                            matching_files.push_back(*iter);
+                                        }
+                                    }
+                                }
+
+                                if (matching_files.size() != 0) {
+                                    /** Prepare some stuff to show correctly the filtered roms */
+                                    pagenum = 0; // Go to page 0
+                                    cursorPosition = 0; // Move the cursor to 0
+                                    storedcursorPosition = cursorPosition; // Move the cursor to 0
+                                    titleboxXmovepos = 0; // Move the cursor to 0
+                                    boxartXmovepos = 0; // Move the cursor to 0
+                                    snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", matching_files.size()); // Reload counter
+                                    boxarttexloaded = false; // Reload boxarts
+                                    bnricontexloaded = false; // Reload banner icons
+                                }
+                                sf2d_draw_texture(dboxtex_button, 161, menudbox_Ypos + 111); // Light the button to print it always
+                                showdialogbox_menu = false;
+                                menudbox_movespeed = 1;
+                                menu_ctrlset = CTRL_SET_GAMESEL;
+                            } else if (touch.px >= 233 && touch.px <= 299 && touch.py >= (menudbox_Ypos + 191) && touch.py <= (menudbox_Ypos + 217)) { // Back button
+                                showdialogbox_menu = false;
+                                menudbox_movespeed = 1;
+                                menu_ctrlset = CTRL_SET_GAMESEL;
+                            }
+                        } else if (hDown & KEY_A) {
+                            switch (startmenu_cursorPosition) {
+                                case 0:
+                                default:
+                                    menudboxaction_switchloc = true;
+                                    break;
+                                case 1:
+                                    settings.romselect.toplayout = !settings.romselect.toplayout;
+                                    if (dspfirmfound) {
+                                        sfx_switch->stop(); // Prevent freezing
+                                        sfx_switch->play();
+                                    }
+                                    break;
+                                case 2:
+                                    if (!is3DSX) {
+                                        gbarunnervalue = 1;
+                                        settings.ui.romfolder = "_nds";
+                                        rom = "GBARunner2.nds";
+                                        if (settings.twl.forwarder) {
+                                            settings.twl.launchslot1 = true;
+                                        } else {
+                                            settings.twl.launchslot1 = false;
+                                        }
+                                        fadeout = true;
+                                        if (dspfirmfound) {
+                                            bgm_menu->stop();
+                                            sfx_launch->play();
+                                        }
+                                    } else {
+                                        if (!playwrongsounddone) {
+                                            if (dspfirmfound) {
+                                                sfx_wrong->stop();
+                                                sfx_wrong->play();
+                                            }
+                                            playwrongsounddone = true;
+                                        }
+                                    }
+                                    break;
+                                case 3:
+                                    settings.ui.topborder = !settings.ui.topborder;
+                                    break;
+                                case 4:
+                                    // Unset donor ROM path
+                                    bootstrapini.SetString(bootstrapini_ndsbootstrap, "ARM7_DONOR_PATH", "");
+                                    bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
+                                    showdialogbox_menu = false;
+                                    menudbox_movespeed = 1;
+                                    menu_ctrlset = CTRL_SET_GAMESEL;
+                                    break;
+                                case 5: {
+                                    // Search
+                                    if (matching_files.size() != 0) {
+                                        matching_files.clear();
+                                        snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
+                                    }
+
+                                    std::string gameName = keyboardInput(TR(STR_START_SEARCH_HINT));
+                                    if (logEnabled) {
+                                        LogFMA("Main.search", "Text written", gameName.c_str());
+                                    }
+
+                                    for (auto iter = files.cbegin(); iter != files.cend(); ++iter) {
+                                        if (iter->size() < gameName.size()) {
+                                            // Filename we're checking is shorter than the search term,
+                                            // so it can't match.
+                                            continue;
+                                        }
+
+                                        // Check if the game name contains the search term.
+                                        // (Case-insensitive search.)
+                                        if (strcasestr(iter->c_str(), gameName.c_str()) != NULL) {
+                                            // String matches.
+                                            matching_files.push_back(*iter);
+                                        }
+                                    }
+
+                                    if (matching_files.size() != 0) {
+                                        /** Prepare some stuff to show correctly the filtered roms */
+                                        pagenum = 0; // Go to page 0
+                                        cursorPosition = 0; // Move the cursor to 0
+                                        storedcursorPosition = cursorPosition; // Move the cursor to 0
+                                        titleboxXmovepos = 0; // Move the cursor to 0
+                                        boxartXmovepos = 0; // Move the cursor to 0
+                                        snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", matching_files.size()); // Reload counter
+                                        boxarttexloaded = false; // Reload boxarts
+                                        bnricontexloaded = false; // Reload banner icons
+                                    }
+                                    showdialogbox_menu = false;
+                                    menudbox_movespeed = 1;
+                                    menu_ctrlset = CTRL_SET_GAMESEL;
+                                    break;
+                                }
+                            }
+                        } else if (hDown & (KEY_B | KEY_START)) {
+                            showdialogbox_menu = false;
+                            menudbox_movespeed = 1;
+                            menu_ctrlset = CTRL_SET_GAMESEL;
+                        }
+                    } else if (menudboxmode == DBOX_MODE_SETTINGS) {
+                        hidTouchRead(&touch);
+
+                        if (hDown & KEY_START) {
+                            // Switch to the "Start" menu.
+                            if (settings.twl.forwarder) {
+                                if (matching_files.size() == 0) {
+                                    rom = fcfiles.at(cursorPosition).c_str();
+                                } else {
+                                    rom = matching_files.at(cursorPosition).c_str();
+                                }
+                            } else {
+                                if (matching_files.size() == 0) {
+                                    rom = files.at(cursorPosition).c_str();
+                                } else {
+                                    rom = matching_files.at(cursorPosition).c_str();
+                                }
+
+                            }
+                            SavePerGameSettings();
+                            menudboxmode = DBOX_MODE_OPTIONS;
+                        } else if (hDown & KEY_RIGHT) {
+                            if (gamesettings_cursorPosition == 0) {
+                                gamesettings_cursorPosition = 1;
+                            } else if (gamesettings_cursorPosition == 2) {
+                                gamesettings_cursorPosition = 3;
+                            }
+                        } else if (hDown & KEY_LEFT) {
+                            if (gamesettings_cursorPosition == 1) {
+                                gamesettings_cursorPosition = 0;
+                            } else if (gamesettings_cursorPosition == 3) {
+                                gamesettings_cursorPosition = 2;
+                            }
+                        } else if (hDown & KEY_DOWN) {
+                            if (gamesettings_cursorPosition == 0) {
+                                gamesettings_cursorPosition = 2;
+                            } else if (gamesettings_cursorPosition == 1) {
+                                gamesettings_cursorPosition = 3;
+                            } else if (gamesettings_cursorPosition == 2) {
+                                gamesettings_cursorPosition = 4;
+                            }
+                        } else if (hDown & KEY_UP) {
+                            if (gamesettings_cursorPosition == 2) {
+                                gamesettings_cursorPosition = 0;
+                            } else if (gamesettings_cursorPosition == 3) {
+                                gamesettings_cursorPosition = 1;
+                            } else if (gamesettings_cursorPosition == 4) {
+                                gamesettings_cursorPosition = 2;
+                            }
+                        } else if (hDown & KEY_TOUCH) {
+                            if (touch.px >= 23 && touch.px <= 155 && touch.py >= 89 && touch.py <= 123) { // ARM9 CPU Speed
+                                gamesettings_cursorPosition = 0;
+                                settings.pergame.cpuspeed++;
+                                if (settings.pergame.cpuspeed == 2) {
+                                    settings.pergame.cpuspeed = -1;
+                                }
+                                if (dspfirmfound) {
+                                    sfx_select->stop(); // Prevent freezing
+                                    sfx_select->play();
+                                }
+                            } else if (touch.px >= 161 && touch.px <= 293 && touch.py >= 89 && touch.py <= 123) { // VRAM boost
+                                gamesettings_cursorPosition = 1;
+                                settings.pergame.extvram++;
+                                if (settings.pergame.extvram == 2) {
+                                    settings.pergame.extvram = -1;
+                                }
+                                if (dspfirmfound) {
+                                    sfx_select->stop(); // Prevent freezing
+                                    sfx_select->play();
+                                }
+                            } else if (touch.px >= 23 && touch.px <= 155 && touch.py >= 129 && touch.py <= 163) { // Lock ARM9 SCFG_EXT
+                                gamesettings_cursorPosition = 2;
+                                settings.pergame.lockarm9scfgext++;
+                                if (settings.pergame.lockarm9scfgext == 2) {
+                                    settings.pergame.lockarm9scfgext = -1;
+                                }
+                                if (dspfirmfound) {
+                                    sfx_select->stop(); // Prevent freezing
+                                    sfx_select->play();
+                                }
+                            } else if (touch.px >= 161 && touch.px <= 293 && touch.py >= 129 && touch.py <= 163) { // Set as donor ROM
+                                gamesettings_cursorPosition = 3;
+                                if (settings.twl.forwarder) {
+                                    if (matching_files.size() == 0) {
+                                        rom = fcfiles.at(cursorPosition).c_str();
+                                    } else {
+                                        rom = matching_files.at(cursorPosition).c_str();
+                                    }
+                                } else {
+                                    if (matching_files.size() == 0) {
+                                        rom = files.at(cursorPosition).c_str();
+                                    } else {
+                                        rom = matching_files.at(cursorPosition).c_str();
+                                    }
+                                    bootstrapini.SetString(bootstrapini_ndsbootstrap, "ARM7_DONOR_PATH", fat + settings.ui.romfolder + slashchar + rom);
+                                    bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
+                                }
+                                showdialogbox_menu = false;
+                                menudbox_movespeed = 1;
+                                menu_ctrlset = CTRL_SET_GAMESEL;
+                            } else if (touch.px >= 23 && touch.px <= 155 && touch.py >= 169 && touch.py <= 203) { // Set LED Color
+                                gamesettings_cursorPosition = 4;
+
+                                RGB[0] = keyboardInputInt("Red color: max is 255");
+                                RGB[1] = keyboardInputInt("Green color: max is 255");
+                                RGB[2] = keyboardInputInt("Blue color: max is 255");
+
+                                settings.pergame.red = RGB[0];
+                                settings.pergame.green = RGB[1];
+                                settings.pergame.blue = RGB[2];
+
+                            } else if (touch.px >= 233 && touch.px <= 299 && touch.py >= (menudbox_Ypos + 191) && touch.py <= (menudbox_Ypos + 217)) { // Back button
+                                if (settings.twl.forwarder) {
+                                    if (matching_files.size() == 0) {
+                                        rom = fcfiles.at(cursorPosition).c_str();
+                                    } else {
+                                        rom = matching_files.at(cursorPosition).c_str();
+                                    }
+                                } else {
+                                    if (matching_files.size() == 0) {
+                                        rom = files.at(cursorPosition).c_str();
+                                    } else {
+                                        rom = matching_files.at(cursorPosition).c_str();
+                                    }
+                                }
+                                SavePerGameSettings();
+                                showdialogbox_menu = false;
+                                menudbox_movespeed = 1;
+                                menu_ctrlset = CTRL_SET_GAMESEL;
+                            }
+                        } else if (hDown & KEY_A) {
+                            switch (gamesettings_cursorPosition) {
+                                case 0:
+                                default:
+                                    settings.pergame.cpuspeed++;
+                                    if (settings.pergame.cpuspeed == 2) {
+                                        settings.pergame.cpuspeed = -1;
+                                    }
+                                    if (dspfirmfound) {
+                                        sfx_select->stop(); // Prevent freezing
+                                        sfx_select->play();
+                                    }
+                                    break;
+                                case 1:
+                                    settings.pergame.extvram++;
+                                    if (settings.pergame.extvram == 2) {
+                                        settings.pergame.extvram = -1;
+                                    }
+                                    if (dspfirmfound) {
+                                        sfx_select->stop(); // Prevent freezing
+                                        sfx_select->play();
+                                    }
+                                    break;
+                                case 2:
+                                    settings.pergame.lockarm9scfgext++;
+                                    if (settings.pergame.lockarm9scfgext == 2) {
+                                        settings.pergame.lockarm9scfgext = -1;
+                                    }
+                                    if (dspfirmfound) {
+                                        sfx_select->stop(); // Prevent freezing
+                                        sfx_select->play();
+                                    }
+                                    break;
+                                case 3:
+                                    if (settings.twl.forwarder) {
+                                        if (matching_files.size() == 0) {
+                                            rom = fcfiles.at(cursorPosition).c_str();
+                                        } else {
+                                            rom = matching_files.at(cursorPosition).c_str();
+                                        }
+                                    } else {
+                                        if (matching_files.size() == 0) {
+                                            rom = files.at(cursorPosition).c_str();
+                                        } else {
+                                            rom = matching_files.at(cursorPosition).c_str();
+                                        }
+                                        bootstrapini.SetString(bootstrapini_ndsbootstrap, "ARM7_DONOR_PATH", fat + settings.ui.romfolder + slashchar + rom);
+                                        bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
+                                    }
+                                    showdialogbox_menu = false;
+                                    menudbox_movespeed = 1;
+                                    menu_ctrlset = CTRL_SET_GAMESEL;
+                                    break;
+                                case 4:
+                                    RGB[0] = keyboardInputInt("Red color: max is 255");
+                                    RGB[1] = keyboardInputInt("Green color: max is 255");
+                                    RGB[2] = keyboardInputInt("Blue color: max is 255");
+
+                                    settings.pergame.red = RGB[0];
+                                    settings.pergame.green = RGB[1];
+                                    settings.pergame.blue = RGB[2];
+                                    break;
+                            }
+                        } else if (hDown & (KEY_B | KEY_SELECT)) {
+                            if (settings.twl.forwarder) {
+                                if (matching_files.size() == 0) {
+                                    rom = fcfiles.at(cursorPosition).c_str();
+                                } else {
+                                    rom = matching_files.at(cursorPosition).c_str();
+                                }
+                            } else {
+                                if (matching_files.size() == 0) {
+                                    rom = files.at(cursorPosition).c_str();
+                                } else {
+                                    rom = matching_files.at(cursorPosition).c_str();
+                                }
+                            }
+                            SavePerGameSettings();
+                            showdialogbox_menu = false;
+                            menudbox_movespeed = 1;
+                            menu_ctrlset = CTRL_SET_GAMESEL;
+                        }
+                    }
+
+                    if (menudboxaction_switchloc) {
+                        menudboxaction_switchloc = false;
+                        if (dspfirmfound) {
+                            sfx_switch->stop(); // Prevent freezing
+                            sfx_switch->play();
+                        }
+                        matching_files.clear();
+                        pagenum = 0;
+                        bannertextloaded = false;
+                        cursorPosition = 0;
+                        storedcursorPosition = cursorPosition;
+                        titleboxXmovepos = 0;
+                        boxartXmovepos = 0;
+                        noromsfound = false;
+                        settings.twl.forwarder = !settings.twl.forwarder;
+                        bnricontexloaded = false;
+                        boxarttexloaded = false;
+                        if (dspfirmfound) {
+                            sfx_switch->stop(); // Prevent freezing
+                            sfx_switch->play();
+                        }
+                        // updatebotscreen = true;
+
+                        if (!settings.twl.forwarder) {
+                            // Poll for Slot-1 changes.
+                            gamecardPoll(true);
+
+                            // Load the Slot-1 boxart.
+                            // NOTE: This is needed here; otherwise, the
+                            // boxart won't be visible for a few frames
+                            // when switching from flashcard to SD.
+                            loadSlot1BoxArt();
+                        }
+                    }
+
+                }
+            }
+        } else if (screenmode == SCREEN_MODE_SETTINGS) {
+            settingsMoveCursor(hDown);
+        }
+
+        if (applaunchon) {
+            if (settings.twl.forwarder && gbarunnervalue == 0) {
+                CIniFile setfcrompathini(sdmc + settings.ui.fcromfolder + slashchar + rom);
+                std::string rominini = setfcrompathini.GetString(fcrompathini_flashcardrom, fcrompathini_rompath, "");
+                // TODO: Enum values for flash card type.
+                if (keepsdvalue) {
+                    switch (settings.twl.flashcard) {
+                        case 0:
+                        case 1:
+                        case 3:
+                        default: {
+                            CIniFile fcrompathini("sdmc:/_nds/YSMenu.ini");
+                            fcrompathini.SetString("YSMENU", "AUTO_BOOT", slashchar + rom);
+                            fcrompathini.SaveIniFile("sdmc:/_nds/YSMenu.ini");
+                            break;
+                        }
+
+                        case 2:
+                        case 4:
+                        case 5: {
+                            CIniFile fcrompathini("sdmc:/_nds/lastsave.ini");
+                            fcrompathini.SetString("Save Info", "lastLoaded", woodfat + rom);
+                            fcrompathini.SaveIniFile("sdmc:/_nds/lastsave.ini");
+                            break;
+                        }
+
+                        case 6: {
+                            CIniFile fcrompathini("sdmc:/_nds/dstwoautoboot.ini");
+                            fcrompathini.SetString("Dir Info", "fullName", dstwofat + rom);
+                            fcrompathini.SaveIniFile("sdmc:/_nds/dstwoautoboot.ini");
+                            break;
+                        }
+                    }
+                } else {
+                    CIniFile setfcrompathini(sdmc + settings.ui.fcromfolder + rom);
+                    switch (settings.twl.flashcard) {
+                        case 0:
+                        case 1:
+                        case 3:
+                        default: {
+                            CIniFile fcrompathini("sdmc:/_nds/YSMenu.ini");
+                            fcrompathini.SetString("YSMENU", "AUTO_BOOT", slashchar + rominini);
+                            fcrompathini.SetString("YSMENU", "DEFAULT_DMA", "true");
+                            fcrompathini.SetString("YSMENU", "DEFAULT_RESET", "false");
+                            fcrompathini.SaveIniFile("sdmc:/_nds/YSMenu.ini");
+                            break;
+                        }
+
+                        case 2:
+                        case 4:
+                        case 5: {
+                            CIniFile fcrompathini("sdmc:/_nds/lastsave.ini");
+                            fcrompathini.SetString("Save Info", "lastLoaded", woodfat + rominini);
+                            fcrompathini.SaveIniFile("sdmc:/_nds/lastsave.ini");
+                            break;
+                        }
+
+                        case 6: {
+                            CIniFile fcrompathini("sdmc:/_nds/dstwoautoboot.ini");
+                            fcrompathini.SetString("Dir Info", "fullName", dstwofat + rominini);
+                            fcrompathini.SaveIniFile("sdmc:/_nds/dstwoautoboot.ini");
+                            break;
+                        }
+                    }
+                }
+            } else if (settings.twl.forwarder && gbarunnervalue == 1) {
+                if (settings.twl.forwarder) {
+                    switch (settings.twl.flashcard) {
+                        case 0:
+                        case 1:
+                        case 3:
+                        default: {
+                            CIniFile fcrompathini("sdmc:/_nds/YSMenu.ini");
+                            fcrompathini.SetString("YSMENU", "AUTO_BOOT", slashchar + rom);
+                            fcrompathini.SetString("YSMENU", "DEFAULT_DMA", "true");
+                            fcrompathini.SetString("YSMENU", "DEFAULT_RESET", "false");
+                            fcrompathini.SaveIniFile("sdmc:/_nds/YSMenu.ini");
+                            break;
+                        }
+
+                        case 2:
+                        case 4:
+                        case 5: {
+                            CIniFile fcrompathini("sdmc:/_nds/lastsave.ini");
+                            fcrompathini.SetString("Save Info", "lastLoaded", woodfat + rom);
+                            fcrompathini.SaveIniFile("sdmc:/_nds/lastsave.ini");
+                            break;
+                        }
+
+                        case 6: {
+                            CIniFile fcrompathini("sdmc:/_nds/dstwoautoboot.ini");
+                            fcrompathini.SetString("Dir Info", "fullName", dstwofat + rom);
+                            fcrompathini.SaveIniFile("sdmc:/_nds/dstwoautoboot.ini");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Save settings.
+            saveOnExit = false;
+            SaveSettings();
+            SetPerGameSettings();
+            SaveBootstrapConfig();
+
+            // Prepare for the app launch.
+            u64 tid = TWLNAND_TID;
+            FS_MediaType mediaType = MEDIATYPE_NAND;
+            bool switchToTwl = true;
+
+            if (!settings.twl.forwarder && settings.twl.launchslot1) {
+                // CTR cards should be launched directly.
+                // TODO: TWL cards should also be launched directly,
+                // but APT_PrepareToDoApplicationJump() ends up
+                // rebooting to the home screen for NTR/TWL...
+                if (gamecardGetType() == CARD_TYPE_CTR) {
+                    u64 ctr_tid = gamecardGetTitleID();
+                    if (ctr_tid != 0) {
+                        tid = ctr_tid;
+                        mediaType = MEDIATYPE_GAME_CARD;
+                        switchToTwl = false;
+                    }
+                }
+            }
+
+            if (switchToTwl) {
+                // Switching to TWL.
+                // Activate the rainbow LED and shut off the screen.
+                // TODO: Allow rainbow LED even in CTR? (It'll stay
+                // cycling as long as no event causes it to change.)
+                if (cursorPosition >= 0 && gbarunnervalue == 0) {
+                    if (settings.twl.forwarder) {
+                        if (matching_files.size() == 0) {
+                            rom = fcfiles.at(cursorPosition).c_str();
+                        } else {
+                            rom = matching_files.at(cursorPosition).c_str();
+                        }
+                    } else {
+                        if (matching_files.size() == 0) {
+                            rom = files.at(cursorPosition).c_str();
+                        } else {
+                            rom = matching_files.at(cursorPosition).c_str();
+                        }
+                    }
+                    LoadPerGameSettings();
+                }
+                if ((RGB[0] < 0) && (RGB[1] < 0) && (RGB[2] < 0)) {
+                    // If RGB in pergame is less than 0, use standard rainbowled patern
+                    if (settings.twl.rainbowled) {
+                        RainbowLED();
+                    }
+                } else {
+                    // Use pergame led
+                    PergameLed();
+                }
+                screenoff();
+            }
+
+            // Buffers for APT_DoApplicationJump().
+            u8 param[0x300];
+            u8 hmac[0x20];
+            // Clear both buffers
+            memset(param, 0, sizeof(param));
+            memset(hmac, 0, sizeof(hmac));
+
+            APT_PrepareToDoApplicationJump(0, tid, mediaType);
+            // Tell APT to trigger the app launch and set the status of this app to exit
+            APT_DoApplicationJump(param, sizeof(param), hmac);
+            break;
+        }
+        //} // run
+    }   // aptMainLoop
+
+    // Unregister the "returned from HOME Menu" handler.
+    aptUnhook(&rfhm_cookie);
+    if (logEnabled) {
+        LogFM("Main", "returned from HOME Menu handler unregistered");
+    }
+
+    if (saveOnExit) {
+        // Save settings.
+        SaveSettings();
+        SetPerGameSettings();
+        SaveBootstrapConfig();
+    }
+    if (logEnabled) {
+        LogFM("Main.saveOnExit", "Settings are saved");
+    }
+
+    // Unload settings screen textures.
+    settingsUnloadTextures();
+    if (logEnabled) {
+        LogFM("Main.settingsUnloadTextures", "Settings textures unloaded");
+    }
+
+    if (colortexloaded) {
+        sf2d_free_texture(topbgtex);
+    }
+    if (logEnabled) {
+        LogFM("Main", "topbgtex freed");
+    }
+    sf2d_free_texture(toptex);
+    for (int i = 0; i < 6; i++) {
+        sf2d_free_texture(voltex[i]);
+    }
+
+    sf2d_free_texture(shoulderLtex);
+    sf2d_free_texture(shoulderRtex);
+    if (logEnabled) {
+        LogFM("Main", "Shoulder textures freed");
+    }
+
+    if (settings.ui.theme == 0) {
+        sf2d_free_texture(batterychrgtex);
+        for (int i = 0; i < 6; i++) {
+            sf2d_free_texture(batterytex[i]);
+        }
+        if (logEnabled) {
+            LogFM("Main", "DSi Menu battery textures freed");
+        }
+    }
+    if (settings.ui.theme == 1) {
+        sf2d_free_texture(iconstex);
+    }
+    if (colortexloaded) {
+        sf2d_free_texture(bottomtex);
+    }
+    sf2d_free_texture(sdicontex);
+    sf2d_free_texture(flashcardicontex);
+    sf2d_free_texture(gbaicontex);
+    sf2d_free_texture(smallsettingsicontex);
+    sf2d_free_texture(iconnulltex);
+    sf2d_free_texture(homeicontex);
+    sf2d_free_texture(bottomlogotex);
+    sf2d_free_texture(bubbletex);
+    sf2d_free_texture(settingsicontex);
+    sf2d_free_texture(getfcgameboxtex);
+    sf2d_free_texture(cartnulltex);
+    sf2d_free_texture(cartntrtex);
+    sf2d_free_texture(carttwltex);
+    if (settings.ui.theme == 0) {
+        gamecardClearCache();
+    }
+    sf2d_free_texture(boxfulltex);
+    if (colortexloaded && settings.ui.theme == 0) {
+        sf2d_free_texture(dotcircletex);
+        sf2d_free_texture(startbordertex);
+    }
+
+    // Free the arrays.
+    if (bnricontexloaded) {
+        for (int i = 0; i < 20; i++) {
+            sf2d_free_texture(bnricontex[i]);
+            free(boxartpath[i]);
+        }
+    }
+    if (boxarttexloaded) {
+        sf2d_free_texture(slot1boxarttex);
+        for (int i = 0; i < 6; i++) {
+            sf2d_free_texture(boxarttex[i]);
+        }
+    }
+
+    // Remaining common textures.
+    sf2d_free_texture(dboxtex_iconbox);
+    sf2d_free_texture(dboxtex_button);
+    sf2d_free_texture(dboxtex_buttonback);
+    sf2d_free_texture(dialogboxtex);
+    sf2d_free_texture(settingslogotex);
+
+    // Clear the translations cache.
+    langClear();
+
+    // Shut down audio.
+    delete bgm_menu;
+    //delete bgm_settings;
+    delete sfx_launch;
+    delete sfx_select;
+    delete sfx_stop;
+    delete sfx_switch;
+    delete sfx_wrong;
+    delete sfx_back;
+    if (dspfirmfound) {
+        ndspExit();
+    }
+
+    sftd_free_font(font);
+    sftd_free_font(font_b);
+    if (logEnabled) {
+        LogFM("Main", "Fonts freed");
+    }
+    sftd_fini();
+    sf2d_fini();
+
+    acExit();
+    hidExit();
+    srvExit();
+    romfsExit();
+    sdmcExit();
+    ptmuxExit();
+    ptmuExit();
+    amExit();
+    cfguExit();
+    aptExit();
+    if (logEnabled) {
+        LogFM("Main", "All services are closed and returned to HOME Menu");
+    }
+    return 0;
 }

--- a/gui/source/main.h
+++ b/gui/source/main.h
@@ -11,31 +11,31 @@
 #include <string>
 #include <vector>
 
-extern bool is3DSX;	// Is the program running as 3DSX?
-extern bool run;	// Set to false to exit to the Home Menu.
+extern bool is3DSX; // Is the program running as 3DSX?
+extern bool run;    // Set to false to exit to the Home Menu.
 
 // Fonts
-extern sftd_font *font;
-extern sftd_font *font_b;
+extern sftd_font* font;
+extern sftd_font* font_b;
 
 // Dialog box
-extern sf2d_texture *dialogboxtex; // Dialog box
-extern void DialogBoxAppear(const char *text, int mode);
-extern void DialogBoxDisappear(const char *text, int mode);
+extern sf2d_texture* dialogboxtex; // Dialog box
+extern void DialogBoxAppear(const char* text, int mode);
+extern void DialogBoxDisappear(const char* text, int mode);
 extern bool showdialogbox;
 
 // Shoulder button images.
-extern sf2d_texture *shoulderLtex;
-extern sf2d_texture *shoulderRtex;
+extern sf2d_texture* shoulderLtex;
+extern sf2d_texture* shoulderRtex;
 extern const char* Lshouldertext;
 extern const char* Rshouldertext;
 extern int LshoulderYpos;
 extern int RshoulderYpos;
 
 // Status bar functions.
-extern sf2d_texture *batteryIcon;	// Current battery level icon.
-void draw_volume_slider(sf2d_texture *texarray[]);
-void update_battery_level(sf2d_texture *texchrg, sf2d_texture *texarray[]);
+extern sf2d_texture* batteryIcon;   // Current battery level icon.
+void draw_volume_slider(sf2d_texture* texarray[]);
+void update_battery_level(sf2d_texture* texchrg, sf2d_texture* texarray[]);
 
 // Screen effects.
 extern int fadealpha;
@@ -44,19 +44,19 @@ extern bool fadeout;
 extern int titleboxXmovetimer; // Set to 1 for fade-in effect to run
 
 // Settings
-extern sf2d_texture *settingslogotex;	// TWLoader logo.
+extern sf2d_texture* settingslogotex;   // TWLoader logo.
 extern std::string settings_releasebootstrapver;
 extern std::string settings_unofficialbootstrapver;
 extern char settings_vertext[13];
 extern char settings_latestvertext[13];
 
-extern const u64 TWLNAND_TID;	// TWLNAND title ID.
+extern const u64 TWLNAND_TID;   // TWLNAND title ID.
 extern bool checkTWLNANDSide(void);
 
 // Current screen mode.
 enum ScreenMode {
-	SCREEN_MODE_ROM_SELECT = 0,	// ROM Select
-	SCREEN_MODE_SETTINGS = 1,	// Settings
+    SCREEN_MODE_ROM_SELECT = 0, // ROM Select
+    SCREEN_MODE_SETTINGS = 1,   // Settings
 };
 extern ScreenMode screenmode;
 
@@ -69,10 +69,10 @@ extern bool logEnabled;
 
 // Sound effects
 extern bool dspfirmfound;
-extern sound *sfx_select;
-extern sound *sfx_switch;
-extern sound *sfx_wrong;
-extern sound *sfx_back;
+extern sound* sfx_select;
+extern sound* sfx_switch;
+extern sound* sfx_wrong;
+extern sound* sfx_back;
 
 // Game start configuration.
 extern bool keepsdvalue;

--- a/gui/source/ndsheaderbanner.cpp
+++ b/gui/source/ndsheaderbanner.cpp
@@ -18,12 +18,13 @@ using std::wstring;
  * @param px16 BGR555 color value.
  * @return RGB5A1 color.
  */
-static inline u16 BGR555_to_RGB5A1(u16 px16) {
-	// BGR555: xBBBBBGG GGGRRRRR
-	// RGB5A1: RRRRRGGG GGBBBBBA
-	return   (px16 << 11) |	1 |		// Red (and alpha)
-		((px16 <<  1) & 0x07C0) |	// Green
-		((px16 >>  9) & 0x003E);	// Blue
+static inline u16 BGR555_to_RGB5A1(u16 px16)
+{
+    // BGR555: xBBBBBGG GGGRRRRR
+    // RGB5A1: RRRRRGGG GGBBBBBA
+    return (px16 << 11) | 1 |       // Red (and alpha)
+           ((px16 <<  1) & 0x07C0) |   // Green
+           ((px16 >>  9) & 0x003E);    // Blue
 }
 
 /**
@@ -32,10 +33,11 @@ static inline u16 BGR555_to_RGB5A1(u16 px16) {
  * @param buf Output buffer for title ID. (Must be at least 4 characters.
  * @return 0 on success; non-zero on error.
  */
-int grabTID(FILE* ndsFile, char *buf) {
-	fseek(ndsFile, offsetof(sNDSHeadertitlecodeonly, gameCode), SEEK_SET);
-	size_t read = fread(buf, 1, 4, ndsFile);
-	return !(read == 4);
+int grabTID(FILE* ndsFile, char* buf)
+{
+    fseek(ndsFile, offsetof(sNDSHeadertitlecodeonly, gameCode), SEEK_SET);
+    size_t read = fread(buf, 1, 4, ndsFile);
+    return !(read == 4);
 }
 
 /**
@@ -44,60 +46,61 @@ int grabTID(FILE* ndsFile, char *buf) {
  * @param bnrtitlenum Title number. (aka language)
  * @return Vector containing each line as a wide string. (empty on error)
  */
-vector<wstring> grabText(const sNDSBanner* ndsBanner, int bnrtitlenum) {
-	// Check for unsupported languages.
-	switch (bnrtitlenum-1) {
-		case N3DS_LANG_DUTCH:
-		case N3DS_LANG_PORTUGUESE:
-		case N3DS_LANG_RUSSIAN:
-			// Use Spanish.
-			bnrtitlenum = NDS_LANG_SPANISH;
-			break;
-		case N3DS_LANG_CHINESE_TRADITIONAL:
-			// Use simplified Chinese.
-			bnrtitlenum = NDS_LANG_CHINESE;
-			break;
-		default:
-			if (bnrtitlenum > N3DS_LANG_CHINESE_TRADITIONAL) {
-				// Invalid language number.
-				// Default to English.
-				bnrtitlenum = NDS_LANG_ENGLISH;
-			}
-			break;
-	}
+vector<wstring> grabText(const sNDSBanner* ndsBanner, int bnrtitlenum)
+{
+    // Check for unsupported languages.
+    switch (bnrtitlenum - 1) {
+        case N3DS_LANG_DUTCH:
+        case N3DS_LANG_PORTUGUESE:
+        case N3DS_LANG_RUSSIAN:
+            // Use Spanish.
+            bnrtitlenum = NDS_LANG_SPANISH;
+            break;
+        case N3DS_LANG_CHINESE_TRADITIONAL:
+            // Use simplified Chinese.
+            bnrtitlenum = NDS_LANG_CHINESE;
+            break;
+        default:
+            if (bnrtitlenum > N3DS_LANG_CHINESE_TRADITIONAL) {
+                // Invalid language number.
+                // Default to English.
+                bnrtitlenum = NDS_LANG_ENGLISH;
+            }
+            break;
+    }
 
-	// Check the banner version.
-	switch (ndsBanner->version) {
-		case NDS_BANNER_VER_ORIGINAL:
-			if (bnrtitlenum > NDS_LANG_SPANISH) {
-				// Unsupported language. (Chinese or Korean)
-				// Default to Japanese.
-				bnrtitlenum = NDS_LANG_JAPANESE;
-			}
-			break;
+    // Check the banner version.
+    switch (ndsBanner->version) {
+        case NDS_BANNER_VER_ORIGINAL:
+            if (bnrtitlenum > NDS_LANG_SPANISH) {
+                // Unsupported language. (Chinese or Korean)
+                // Default to Japanese.
+                bnrtitlenum = NDS_LANG_JAPANESE;
+            }
+            break;
 
-		case NDS_BANNER_VER_ZH:
-			if (bnrtitlenum > NDS_LANG_CHINESE) {
-				// Unsupported language. (Korean)
-				// Default to Japanese.
-				bnrtitlenum = NDS_LANG_JAPANESE;
-			}
-			break;
+        case NDS_BANNER_VER_ZH:
+            if (bnrtitlenum > NDS_LANG_CHINESE) {
+                // Unsupported language. (Korean)
+                // Default to Japanese.
+                bnrtitlenum = NDS_LANG_JAPANESE;
+            }
+            break;
 
-		case NDS_BANNER_VER_ZH_KO:
-		case NDS_BANNER_VER_DSi:
-			break;
+        case NDS_BANNER_VER_ZH_KO:
+        case NDS_BANNER_VER_DSi:
+            break;
 
-		case 0:
-		default:
-			// Unsupported banner version.
-			vector<wstring> vec_wstr;
-			vec_wstr.push_back(L"No Info");
-			return vec_wstr;
-	}
+        case 0:
+        default:
+            // Unsupported banner version.
+            vector<wstring> vec_wstr;
+            vec_wstr.push_back(L"No Info");
+            return vec_wstr;
+    }
 
-	// Convert the UTF-16 description (with newlines) to a vector of wstrings.
-	return utf16_nl_to_vwstring(ndsBanner->titles[bnrtitlenum], 128);
+    // Convert the UTF-16 description (with newlines) to a vector of wstrings.
+    return utf16_nl_to_vwstring(ndsBanner->titles[bnrtitlenum], 128);
 }
 
 /**
@@ -106,24 +109,25 @@ vector<wstring> grabText(const sNDSBanner* ndsBanner, int bnrtitlenum) {
  * @param bnrtitlenum Title number. (aka language)
  * @return Vector containing each line as a wide string. (empty on error)
  */
-vector<wstring> grabText(FILE* binFile, int bnrtitlenum) {
-	// Load the banner.
-	// NOTE: ndsBanner is cleared first in case the banner
-	// file is smaller than NDS_BANNER_SIZE_DSi.
-	sNDSBanner ndsBanner;
-	memset(&ndsBanner, 0, sizeof(ndsBanner));
-	fseek(binFile, 0, SEEK_SET);
-	size_t read = fread(&ndsBanner, 1, sizeof(ndsBanner), binFile);
-	if (read < NDS_BANNER_VER_ORIGINAL) {
-		// Banner file is invalid.
-		// Unsupported banner version.
-		vector<wstring> vec_wstr;
-		vec_wstr.push_back(L"No Info");
-		return vec_wstr;
-	}
+vector<wstring> grabText(FILE* binFile, int bnrtitlenum)
+{
+    // Load the banner.
+    // NOTE: ndsBanner is cleared first in case the banner
+    // file is smaller than NDS_BANNER_SIZE_DSi.
+    sNDSBanner ndsBanner;
+    memset(&ndsBanner, 0, sizeof(ndsBanner));
+    fseek(binFile, 0, SEEK_SET);
+    size_t read = fread(&ndsBanner, 1, sizeof(ndsBanner), binFile);
+    if (read < NDS_BANNER_VER_ORIGINAL) {
+        // Banner file is invalid.
+        // Unsupported banner version.
+        vector<wstring> vec_wstr;
+        vec_wstr.push_back(L"No Info");
+        return vec_wstr;
+    }
 
-	// Get the banner text.
-	return grabText(&ndsBanner, bnrtitlenum);
+    // Get the banner text.
+    return grabText(&ndsBanner, bnrtitlenum);
 }
 
 /**
@@ -133,95 +137,110 @@ vector<wstring> grabText(FILE* binFile, int bnrtitlenum) {
  * @param setfont Font to use for messages.
  * @return 0 on success; non-zero on error.
  */
-int cacheBanner(FILE* ndsFile, const char* filename, sftd_font* setfont, sf2d_texture* dbox, const char* title, const char* counter1, const char* counter2) {
-	char bannerpath[256];
-	snprintf(bannerpath, sizeof(bannerpath), "sdmc:/_nds/twloader/bnricons/%s.bin", filename);
+int cacheBanner(FILE* ndsFile, const char* filename, sftd_font* setfont, sf2d_texture* dbox, const char* title, const char* counter1, const char* counter2)
+{
+    char bannerpath[256];
+    snprintf(bannerpath, sizeof(bannerpath), "sdmc:/_nds/twloader/bnricons/%s.bin", filename);
 
-	if (!access(bannerpath, F_OK)) {
-		// Banner is already cached.
-		// TODO: If it's 0 bytes, re-cache it?
-		// sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Banner data already exists.");
-		// sf2d_end_frame();
-		// sf2d_swapbuffers();
-		return 0;
-	}
-	sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-	sf2d_draw_texture(dbox, 0, 0);
-	sftd_draw_text(setfont, 12, 16, RGBA8(0, 0, 0, 255), 12, title);
-	sftd_draw_text(setfont, 12, 48, RGBA8(0, 0, 0, 255), 12, counter1);
-	sftd_draw_text(setfont, 39, 48, RGBA8(0, 0, 0, 255), 12, "/");
-	sftd_draw_text(setfont, 44, 48, RGBA8(0, 0, 0, 255), 12, counter2);
+    if (!access(bannerpath, F_OK)) {
+        // Banner is already cached.
+        // TODO: If it's 0 bytes, re-cache it?
+        // sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Banner data already exists.");
+        // sf2d_end_frame();
+        // sf2d_swapbuffers();
+        return 0;
+    }
+    sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+    sf2d_draw_texture(dbox, 0, 0);
+    sftd_draw_text(setfont, 12, 16, RGBA8(0, 0, 0, 255), 12, title);
+    sftd_draw_text(setfont, 12, 48, RGBA8(0, 0, 0, 255), 12, counter1);
+    sftd_draw_text(setfont, 39, 48, RGBA8(0, 0, 0, 255), 12, "/");
+    sftd_draw_text(setfont, 44, 48, RGBA8(0, 0, 0, 255), 12, counter2);
 
-	if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Reading .NDS file:", filename);
-	sNDSHeader NDSHeader;
-	fseek(ndsFile, 0, SEEK_SET);
-	fread(&NDSHeader, 1, sizeof(NDSHeader), ndsFile);
-	if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", ".NDS file read:", filename);
+    if (logEnabled) {
+        LogFMA("NDSBannerHeader.cacheBanner", "Reading .NDS file:", filename);
+    }
+    sNDSHeader NDSHeader;
+    fseek(ndsFile, 0, SEEK_SET);
+    fread(&NDSHeader, 1, sizeof(NDSHeader), ndsFile);
+    if (logEnabled) {
+        LogFMA("NDSBannerHeader.cacheBanner", ".NDS file read:", filename);
+    }
 
-	sNDSBanner ndsBanner;
-	memset(&ndsBanner, 0, sizeof(ndsBanner));
-	u32 bannersize = 0;
-	if (NDSHeader.bannerOffset != 0x00000000) {
-		// Read the banner from the NDS file.
-		fseek(ndsFile , NDSHeader.bannerOffset, SEEK_SET);
-		fread(&ndsBanner, 1, sizeof(ndsBanner), ndsFile);
+    sNDSBanner ndsBanner;
+    memset(&ndsBanner, 0, sizeof(ndsBanner));
+    u32 bannersize = 0;
+    if (NDSHeader.bannerOffset != 0x00000000) {
+        // Read the banner from the NDS file.
+        fseek(ndsFile, NDSHeader.bannerOffset, SEEK_SET);
+        fread(&ndsBanner, 1, sizeof(ndsBanner), ndsFile);
 
-		sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Now caching banner data (SD Card)...");
-		sf2d_end_frame();
-		sf2d_swapbuffers();
-		if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Caching banner data:", bannerpath);
+        sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Now caching banner data (SD Card)...");
+        sf2d_end_frame();
+        sf2d_swapbuffers();
+        if (logEnabled) {
+            LogFMA("NDSBannerHeader.cacheBanner", "Caching banner data:", bannerpath);
+        }
 
-		switch (ndsBanner.version) {
-			case NDS_BANNER_VER_DSi:
-				bannersize = NDS_BANNER_SIZE_DSi;
-				break;
-			case NDS_BANNER_VER_ZH_KO:
-				bannersize = NDS_BANNER_SIZE_ZH_KO;
-				break;
-			case NDS_BANNER_VER_ZH:
-				bannersize = NDS_BANNER_SIZE_ZH;
-				break;
-			case NDS_BANNER_VER_ORIGINAL:
-			default:
-				bannersize = NDS_BANNER_SIZE_ORIGINAL;
-				break;
-		}
-	} else {
-		// No banner. Use the generic version.
-		FILE* nobannerFile = fopen("romfs:/notextbanner", "rb");
-		sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Now caching banner data (SD Card)...");
-		sf2d_end_frame();
-		sf2d_swapbuffers();
-		if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Caching banner data (empty):", bannerpath);
-		// notextbanner is v0003 (ZH/KO)
-		bannersize = NDS_BANNER_SIZE_ZH_KO;
-		fread(&ndsBanner, 1, bannersize, nobannerFile);
-		fclose(nobannerFile);
-	}
+        switch (ndsBanner.version) {
+            case NDS_BANNER_VER_DSi:
+                bannersize = NDS_BANNER_SIZE_DSi;
+                break;
+            case NDS_BANNER_VER_ZH_KO:
+                bannersize = NDS_BANNER_SIZE_ZH_KO;
+                break;
+            case NDS_BANNER_VER_ZH:
+                bannersize = NDS_BANNER_SIZE_ZH;
+                break;
+            case NDS_BANNER_VER_ORIGINAL:
+            default:
+                bannersize = NDS_BANNER_SIZE_ORIGINAL;
+                break;
+        }
+    } else {
+        // No banner. Use the generic version.
+        FILE* nobannerFile = fopen("romfs:/notextbanner", "rb");
+        sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Now caching banner data (SD Card)...");
+        sf2d_end_frame();
+        sf2d_swapbuffers();
+        if (logEnabled) {
+            LogFMA("NDSBannerHeader.cacheBanner", "Caching banner data (empty):", bannerpath);
+        }
+        // notextbanner is v0003 (ZH/KO)
+        bannersize = NDS_BANNER_SIZE_ZH_KO;
+        fread(&ndsBanner, 1, bannersize, nobannerFile);
+        fclose(nobannerFile);
+    }
 
-	if (bannersize == 0) {
-		// Invalid banner.
-		if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Failed to open NDS source file:", filename);
-		sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Invalid banner loaded; not caching.");
-		sf2d_end_frame();
-		sf2d_swapbuffers();
-		return -1;
-	}
+    if (bannersize == 0) {
+        // Invalid banner.
+        if (logEnabled) {
+            LogFMA("NDSBannerHeader.cacheBanner", "Failed to open NDS source file:", filename);
+        }
+        sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Invalid banner loaded; not caching.");
+        sf2d_end_frame();
+        sf2d_swapbuffers();
+        return -1;
+    }
 
-	// Write the cached banner.
-	FILE* filetosave = fopen(bannerpath, "wb");
-	if (!filetosave) {
-		// Error opening the banner cache file.
-		if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Failed to write banner cache file:", bannerpath);
-		sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Error writing the banner cache file.");
-		sf2d_end_frame();
-		sf2d_swapbuffers();
-		return -2;
-	}
-	fwrite(&ndsBanner, 1, bannersize, filetosave);
-	fclose(filetosave);
-	if (logEnabled)	LogFMA("NDSBannerHeader.cacheBanner", "Banner data cached:", bannerpath);
-	return 0;
+    // Write the cached banner.
+    FILE* filetosave = fopen(bannerpath, "wb");
+    if (!filetosave) {
+        // Error opening the banner cache file.
+        if (logEnabled) {
+            LogFMA("NDSBannerHeader.cacheBanner", "Failed to write banner cache file:", bannerpath);
+        }
+        sftd_draw_textf(setfont, 12, 32, RGBA8(0, 0, 0, 255), 12, "Error writing the banner cache file.");
+        sf2d_end_frame();
+        sf2d_swapbuffers();
+        return -2;
+    }
+    fwrite(&ndsBanner, 1, bannersize, filetosave);
+    fclose(filetosave);
+    if (logEnabled) {
+        LogFMA("NDSBannerHeader.cacheBanner", "Banner data cached:", bannerpath);
+    }
+    return 0;
 }
 
 /**
@@ -229,65 +248,66 @@ int cacheBanner(FILE* ndsFile, const char* filename, sftd_font* setfont, sf2d_te
  * @param binFile NDS banner.
  * @return Icon texture. (NULL on error)
  */
-sf2d_texture* grabIcon(const sNDSBanner* ndsBanner) {
-	// Convert the palette from RGB555 to RGB5A1.
-	// (We need to ensure the MSB is set for all except
-	// color 0, which is transparent.)
-	u16 palette[16];
-	palette[0] = 0;	// Color 0 is always transparent.
-	for (int i = 16-1; i > 0; i--) {
-		// Convert from NDS BGR555 to RGB5A1.
-		// NOTE: The GPU expects byteswapped data.
-		palette[i] = BGR555_to_RGB5A1(ndsBanner->palette[i]);
-	}
+sf2d_texture* grabIcon(const sNDSBanner* ndsBanner)
+{
+    // Convert the palette from RGB555 to RGB5A1.
+    // (We need to ensure the MSB is set for all except
+    // color 0, which is transparent.)
+    u16 palette[16];
+    palette[0] = 0; // Color 0 is always transparent.
+    for (int i = 16 - 1; i > 0; i--) {
+        // Convert from NDS BGR555 to RGB5A1.
+        // NOTE: The GPU expects byteswapped data.
+        palette[i] = BGR555_to_RGB5A1(ndsBanner->palette[i]);
+    }
 
-	// Un-tile the icon.
-	// NOTE: Allocating 64x32, because the "sf2d_create_texture_mem_RGBA8"
-	// function hates small sizes like 32x32 (TWLoader freezes if that size is used).
-	static const int w = 64;
-	static const int h = 32;
-	u16 *textureData = (u16*)linearAlloc(w*h*sizeof(u16));
-	const u8 *offset = ndsBanner->icon;
-	for (int y = 0; y < 32; y += 8) {
-		for (int x = 0; x < 32; x += 8) {
-			for (int y2 = 0; y2 < 8; y2++) {
-				u16 *texptr = &textureData[x + ((y + y2) * 64)];
-				for (int x2 = 0; x2 < 8; x2 += 2) {
-					texptr[0] = palette[*offset & 0x0F];
-					texptr[1] = palette[*offset >> 4];
-					offset++;
-					texptr += 2;
-				}
-			}
-		}
-	}
+    // Un-tile the icon.
+    // NOTE: Allocating 64x32, because the "sf2d_create_texture_mem_RGBA8"
+    // function hates small sizes like 32x32 (TWLoader freezes if that size is used).
+    static const int w = 64;
+    static const int h = 32;
+    u16* textureData = (u16*)linearAlloc(w * h * sizeof(u16));
+    const u8* offset = ndsBanner->icon;
+    for (int y = 0; y < 32; y += 8) {
+        for (int x = 0; x < 32; x += 8) {
+            for (int y2 = 0; y2 < 8; y2++) {
+                u16* texptr = &textureData[x + ((y + y2) * 64)];
+                for (int x2 = 0; x2 < 8; x2 += 2) {
+                    texptr[0] = palette[*offset & 0x0F];
+                    texptr[1] = palette[*offset >> 4];
+                    offset++;
+                    texptr += 2;
+                }
+            }
+        }
+    }
 
-	// Create an RGB5A1 texture directly.
-	// NOTE: sf2d doesn't support this, so we'll do it manually.
-	// Based on sf2d_texture.c.
-	sf2d_texture *texture = sf2d_create_texture(w, h, TEXFMT_RGB5A1, SF2D_PLACE_RAM);
+    // Create an RGB5A1 texture directly.
+    // NOTE: sf2d doesn't support this, so we'll do it manually.
+    // Based on sf2d_texture.c.
+    sf2d_texture* texture = sf2d_create_texture(w, h, TEXFMT_RGB5A1, SF2D_PLACE_RAM);
 
-	// Tile the texture for the GPU.
-	const u32 flags = (GX_TRANSFER_FLIP_VERT(1) | GX_TRANSFER_OUT_TILED(1) | GX_TRANSFER_RAW_COPY(0) |
-		GX_TRANSFER_IN_FORMAT(GX_TRANSFER_FMT_RGB5A1) | GX_TRANSFER_OUT_FORMAT(GX_TRANSFER_FMT_RGB5A1) |
-		GX_TRANSFER_SCALING(GX_TRANSFER_SCALE_NO));
+    // Tile the texture for the GPU.
+    const u32 flags = (GX_TRANSFER_FLIP_VERT(1) | GX_TRANSFER_OUT_TILED(1) | GX_TRANSFER_RAW_COPY(0) |
+                       GX_TRANSFER_IN_FORMAT(GX_TRANSFER_FMT_RGB5A1) | GX_TRANSFER_OUT_FORMAT(GX_TRANSFER_FMT_RGB5A1) |
+                       GX_TRANSFER_SCALING(GX_TRANSFER_SCALE_NO));
 
-	GSPGPU_FlushDataCache(textureData, (w*h)*2);
-	GSPGPU_FlushDataCache(texture->tex.data, texture->tex.size);
+    GSPGPU_FlushDataCache(textureData, (w * h) * 2);
+    GSPGPU_FlushDataCache(texture->tex.data, texture->tex.size);
 
-	C3D_SafeDisplayTransfer(
-		(u32*)textureData,
-		GX_BUFFER_DIM(w, h),
-		(u32*)texture->tex.data,
-		GX_BUFFER_DIM(texture->tex.width, texture->tex.height),
-		flags
-	);
+    C3D_SafeDisplayTransfer(
+        (u32*)textureData,
+        GX_BUFFER_DIM(w, h),
+        (u32*)texture->tex.data,
+        GX_BUFFER_DIM(texture->tex.width, texture->tex.height),
+        flags
+    );
 
-	gspWaitForPPF();
-	texture->tiled = 1;
+    gspWaitForPPF();
+    texture->tiled = 1;
 
-	linearFree(textureData);
-	return texture;
+    linearFree(textureData);
+    return texture;
 }
 
 /**
@@ -295,15 +315,16 @@ sf2d_texture* grabIcon(const sNDSBanner* ndsBanner) {
  * @param binFile Banner file.
  * @return Icon texture. (NULL on error)
  */
-sf2d_texture* grabIcon(FILE* binFile) {
-	sNDSBanner ndsBanner;
-	fseek(binFile, 0, SEEK_SET);
-	size_t read = fread(&ndsBanner, 1, sizeof(ndsBanner), binFile);
-	if (read < NDS_BANNER_VER_ORIGINAL) {
-		// Banner file is invalid.
-		return NULL;
-	}
+sf2d_texture* grabIcon(FILE* binFile)
+{
+    sNDSBanner ndsBanner;
+    fseek(binFile, 0, SEEK_SET);
+    size_t read = fread(&ndsBanner, 1, sizeof(ndsBanner), binFile);
+    if (read < NDS_BANNER_VER_ORIGINAL) {
+        // Banner file is invalid.
+        return NULL;
+    }
 
-	// Get the icon.
-	return grabIcon(&ndsBanner);
+    // Get the icon.
+    return grabIcon(&ndsBanner);
 }

--- a/gui/source/ndsheaderbanner.h
+++ b/gui/source/ndsheaderbanner.h
@@ -1,28 +1,28 @@
 /*---------------------------------------------------------------------------------
 
-	memory.h -- Declaration of memory regions
+    memory.h -- Declaration of memory regions
 
 
-	Copyright (C) 2005 Michael Noland (joat) and Jason Rogers (dovoto)
+    Copyright (C) 2005 Michael Noland (joat) and Jason Rogers (dovoto)
 
-	This software is provided 'as-is', without any express or implied
-	warranty.  In no event will the authors be held liable for any
-	damages arising from the use of this software.
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any
+    damages arising from the use of this software.
 
-	Permission is granted to anyone to use this software for any
-	purpose, including commercial applications, and to alter it and
-	redistribute it freely, subject to the following restrictions:
+    Permission is granted to anyone to use this software for any
+    purpose, including commercial applications, and to alter it and
+    redistribute it freely, subject to the following restrictions:
 
-	1.	The origin of this software must not be misrepresented; you
-		must not claim that you wrote the original software. If you use
-		this software in a product, an acknowledgment in the product
-		documentation would be appreciated but is not required.
+    1.  The origin of this software must not be misrepresented; you
+        must not claim that you wrote the original software. If you use
+        this software in a product, an acknowledgment in the product
+        documentation would be appreciated but is not required.
 
-	2.	Altered source versions must be plainly marked as such, and
-		must not be misrepresented as being the original software.
+    2.  Altered source versions must be plainly marked as such, and
+        must not be misrepresented as being the original software.
 
-	3.	This notice may not be removed or altered from any source
-		distribution.
+    3.  This notice may not be removed or altered from any source
+        distribution.
 
 ---------------------------------------------------------------------------------*/
 /*! \file ndsheaderbanner.h
@@ -41,100 +41,100 @@
 #include <vector>
 
 /*!
-	\brief the GBA file header format.
-	See gbatek for more info.
+    \brief the GBA file header format.
+    See gbatek for more info.
 */
 typedef struct {
-	u32 entryPoint;		//!< 32 bits arm opcode to jump to executable code.
-	u8 logo[156];		//!< nintendo logo needed for booting the game.
-	char title[0xC];	//!< 12 characters for the game title.
-	char gamecode[0x4];	//!< 4 characters for the game code. first character is usally A or B, next 2 characters is a short title
-						//!< and last character is for destination/language.
-	u16 makercode;		//!< identifies the (commercial) developer.
-	u8 is96h;			//!< fixed value that is always 96h.
-	u8 unitcode;		//!< identifies the required hardware.
-	u8 devicecode;		//!< used by nintedo's hardware debuggers. normally 0.
-	u8 unused[7];
-	u8 version;			//!< the version of the game.
-	u8 complement;		//!< complement checksum of the gba header.
-	u16 checksum;		//!< a 16 bit checksum? (gbatek says its unused/reserved).
+    u32 entryPoint;     //!< 32 bits arm opcode to jump to executable code.
+    u8 logo[156];       //!< nintendo logo needed for booting the game.
+    char title[0xC];    //!< 12 characters for the game title.
+    char gamecode[0x4]; //!< 4 characters for the game code. first character is usally A or B, next 2 characters is a short title
+    //!< and last character is for destination/language.
+    u16 makercode;      //!< identifies the (commercial) developer.
+    u8 is96h;           //!< fixed value that is always 96h.
+    u8 unitcode;        //!< identifies the required hardware.
+    u8 devicecode;      //!< used by nintedo's hardware debuggers. normally 0.
+    u8 unused[7];
+    u8 version;         //!< the version of the game.
+    u8 complement;      //!< complement checksum of the gba header.
+    u16 checksum;       //!< a 16 bit checksum? (gbatek says its unused/reserved).
 } sGBAHeader;
 
 //#define GBA_HEADER (*(tGBAHeader *)0x08000000)
 
 /*!
-	\brief the NDS file header format
-	See gbatek for more info.
+    \brief the NDS file header format
+    See gbatek for more info.
 */
 typedef struct {
-	char gameTitle[12];			//!< 12 characters for the game title.
-	char gameCode[4];			//!< 4 characters for the game code.
-	char makercode[2];			//!< identifies the (commercial) developer.
-	u8 unitCode;				//!< identifies the required hardware.
-	u8 deviceType;				//!< type of device in the game card
-	u8 deviceSize;				//!< capacity of the device (1 << n Mbit)
-	u8 reserved1[9];
-	u8 romversion;				//!< version of the ROM.
-	u8 flags;					//!< bit 2: auto-boot flag.
+    char gameTitle[12];         //!< 12 characters for the game title.
+    char gameCode[4];           //!< 4 characters for the game code.
+    char makercode[2];          //!< identifies the (commercial) developer.
+    u8 unitCode;                //!< identifies the required hardware.
+    u8 deviceType;              //!< type of device in the game card
+    u8 deviceSize;              //!< capacity of the device (1 << n Mbit)
+    u8 reserved1[9];
+    u8 romversion;              //!< version of the ROM.
+    u8 flags;                   //!< bit 2: auto-boot flag.
 
-	u32 arm9romOffset;			//!< offset of the arm9 binary in the nds file.
-	u32 arm9executeAddress;		//!< adress that should be executed after the binary has been copied.
-	u32 arm9destination;		//!< destination address to where the arm9 binary should be copied.
-	u32 arm9binarySize;			//!< size of the arm9 binary.
+    u32 arm9romOffset;          //!< offset of the arm9 binary in the nds file.
+    u32 arm9executeAddress;     //!< adress that should be executed after the binary has been copied.
+    u32 arm9destination;        //!< destination address to where the arm9 binary should be copied.
+    u32 arm9binarySize;         //!< size of the arm9 binary.
 
-	u32 arm7romOffset;			//!< offset of the arm7 binary in the nds file.
-	u32 arm7executeAddress;		//!< adress that should be executed after the binary has been copied.
-	u32 arm7destination;		//!< destination address to where the arm7 binary should be copied.
-	u32 arm7binarySize;			//!< size of the arm7 binary.
+    u32 arm7romOffset;          //!< offset of the arm7 binary in the nds file.
+    u32 arm7executeAddress;     //!< adress that should be executed after the binary has been copied.
+    u32 arm7destination;        //!< destination address to where the arm7 binary should be copied.
+    u32 arm7binarySize;         //!< size of the arm7 binary.
 
-	u32 filenameOffset;			//!< File Name Table (FNT) offset.
-	u32 filenameSize;			//!< File Name Table (FNT) size.
-	u32 fatOffset;				//!< File Allocation Table (FAT) offset.
-	u32 fatSize;				//!< File Allocation Table (FAT) size.
+    u32 filenameOffset;         //!< File Name Table (FNT) offset.
+    u32 filenameSize;           //!< File Name Table (FNT) size.
+    u32 fatOffset;              //!< File Allocation Table (FAT) offset.
+    u32 fatSize;                //!< File Allocation Table (FAT) size.
 
-	u32 arm9overlaySource;		//!< File arm9 overlay offset.
-	u32 arm9overlaySize;		//!< File arm9 overlay size.
-	u32 arm7overlaySource;		//!< File arm7 overlay offset.
-	u32 arm7overlaySize;		//!< File arm7 overlay size.
+    u32 arm9overlaySource;      //!< File arm9 overlay offset.
+    u32 arm9overlaySize;        //!< File arm9 overlay size.
+    u32 arm7overlaySource;      //!< File arm7 overlay offset.
+    u32 arm7overlaySize;        //!< File arm7 overlay size.
 
-	u32 cardControl13;			//!< Port 40001A4h setting for normal commands (used in modes 1 and 3)
-	u32 cardControlBF;			//!< Port 40001A4h setting for KEY1 commands (used in mode 2)
-	u32 bannerOffset;			//!< offset to the banner with icon and titles etc.
+    u32 cardControl13;          //!< Port 40001A4h setting for normal commands (used in modes 1 and 3)
+    u32 cardControlBF;          //!< Port 40001A4h setting for KEY1 commands (used in mode 2)
+    u32 bannerOffset;           //!< offset to the banner with icon and titles etc.
 
-	u16 secureCRC16;			//!< Secure Area Checksum, CRC-16.
+    u16 secureCRC16;            //!< Secure Area Checksum, CRC-16.
 
-	u16 readTimeout;			//!< Secure Area Loading Timeout.
+    u16 readTimeout;            //!< Secure Area Loading Timeout.
 
-	u32 unknownRAM1;			//!< ARM9 Auto Load List RAM Address (?)
-	u32 unknownRAM2;			//!< ARM7 Auto Load List RAM Address (?)
+    u32 unknownRAM1;            //!< ARM9 Auto Load List RAM Address (?)
+    u32 unknownRAM2;            //!< ARM7 Auto Load List RAM Address (?)
 
-	u32 bfPrime1;				//!< Secure Area Disable part 1.
-	u32 bfPrime2;				//!< Secure Area Disable part 2.
-	u32 romSize;				//!< total size of the ROM.
+    u32 bfPrime1;               //!< Secure Area Disable part 1.
+    u32 bfPrime2;               //!< Secure Area Disable part 2.
+    u32 romSize;                //!< total size of the ROM.
 
-	u32 headerSize;				//!< ROM header size.
-	u32 zeros88[14];
-	u8 gbaLogo[156];			//!< Nintendo logo needed for booting the game.
-	u16 logoCRC16;				//!< Nintendo Logo Checksum, CRC-16.
-	u16 headerCRC16;			//!< header checksum, CRC-16.
+    u32 headerSize;             //!< ROM header size.
+    u32 zeros88[14];
+    u8 gbaLogo[156];            //!< Nintendo logo needed for booting the game.
+    u16 logoCRC16;              //!< Nintendo Logo Checksum, CRC-16.
+    u16 headerCRC16;            //!< header checksum, CRC-16.
 
-	u32 debugRomSource;			//!< debug ROM offset.
-	u32 debugRomSize;			//!< debug size.
-	u32 debugRomDestination;	//!< debug RAM destination.
-	u32 offset_0x16C;			//reserved?
+    u32 debugRomSource;         //!< debug ROM offset.
+    u32 debugRomSize;           //!< debug size.
+    u32 debugRomDestination;    //!< debug RAM destination.
+    u32 offset_0x16C;           //reserved?
 
-	u8 zero[0x90];
+    u8 zero[0x90];
 
-	// 0x200
-	// TODO: More DSi-specific fields.
-	u8 dsi1[0x30];
-	u32 dsi_tid;
-	u8 dsi2[0x180];
+    // 0x200
+    // TODO: More DSi-specific fields.
+    u8 dsi1[0x30];
+    u32 dsi_tid;
+    u8 dsi2[0x180];
 } sNDSHeader;
 
 typedef struct {
-	char gameTitle[12];			//!< 12 characters for the game title.
-	char gameCode[4];			//!< 4 characters for the game code.
+    char gameTitle[12];         //!< 12 characters for the game title.
+    char gameCode[4];           //!< 4 characters for the game code.
 } sNDSHeadertitlecodeonly;
 
 
@@ -145,40 +145,40 @@ static_assert(sizeof(sNDSHeader) == 0x3B4, "sizeof(sNDSHeader) is not 0x3B4 byte
 
 
 /*!
-	\brief the NDS banner format.
-	See gbatek for more information.
+    \brief the NDS banner format.
+    See gbatek for more information.
 */
 typedef struct {
-	u16 version;		//!< version of the banner.
-	u16 crc[4];		//!< CRC-16s of the banner.
-	u8 reserved[22];
-	u8 icon[512];		//!< 32*32 icon of the game with 4 bit per pixel.
-	u16 palette[16];	//!< the palette of the icon.
-	u16 titles[8][128];	//!< title of the game in 8 different languages.
+    u16 version;        //!< version of the banner.
+    u16 crc[4];     //!< CRC-16s of the banner.
+    u8 reserved[22];
+    u8 icon[512];       //!< 32*32 icon of the game with 4 bit per pixel.
+    u16 palette[16];    //!< the palette of the icon.
+    u16 titles[8][128]; //!< title of the game in 8 different languages.
 
-	// [0xA40] Reserved space, possibly for other titles.
-	u8 reserved2[0x800];
+    // [0xA40] Reserved space, possibly for other titles.
+    u8 reserved2[0x800];
 
-	// DSi-specific.
-	u8 dsi_icon[8][512];	//!< DSi animated icon frame data.
-	u16 dsi_palette[8][16];	//!< Palette for each DSi icon frame.
-	u16 dsi_seq[64];	//!< DSi animated icon sequence.
+    // DSi-specific.
+    u8 dsi_icon[8][512];    //!< DSi animated icon frame data.
+    u16 dsi_palette[8][16]; //!< Palette for each DSi icon frame.
+    u16 dsi_seq[64];    //!< DSi animated icon sequence.
 } sNDSBanner;
 
 // sNDSBanner version.
 typedef enum {
-	NDS_BANNER_VER_ORIGINAL	= 0x0001,
-	NDS_BANNER_VER_ZH	= 0x0002,
-	NDS_BANNER_VER_ZH_KO	= 0x0003,
-	NDS_BANNER_VER_DSi	= 0x0103,
+    NDS_BANNER_VER_ORIGINAL = 0x0001,
+    NDS_BANNER_VER_ZH   = 0x0002,
+    NDS_BANNER_VER_ZH_KO    = 0x0003,
+    NDS_BANNER_VER_DSi  = 0x0103,
 } sNDSBannerVersion;
 
 // sNDSBanner sizes.
 typedef enum {
-	NDS_BANNER_SIZE_ORIGINAL	= 0x0840,
-	NDS_BANNER_SIZE_ZH		= 0x0940,
-	NDS_BANNER_SIZE_ZH_KO		= 0x0A40,
-	NDS_BANNER_SIZE_DSi		= 0x23C0,
+    NDS_BANNER_SIZE_ORIGINAL    = 0x0840,
+    NDS_BANNER_SIZE_ZH      = 0x0940,
+    NDS_BANNER_SIZE_ZH_KO       = 0x0A40,
+    NDS_BANNER_SIZE_DSi     = 0x23C0,
 } sNDSBannerSize;
 
 // Make sure the banner size is correct.
@@ -186,22 +186,22 @@ static_assert(sizeof(sNDSBanner) == NDS_BANNER_SIZE_DSi, "sizeof(sNDSBanner) is 
 
 // Language indexes.
 typedef enum {
-	// DS and 3DS
-	NDS_LANG_JAPANESE	= 0,
-	NDS_LANG_ENGLISH	= 1,
-	NDS_LANG_FRENCH		= 2,
-	NDS_LANG_GERMAN		= 3,
-	NDS_LANG_ITALIAN	= 4,
-	NDS_LANG_SPANISH	= 5,
-	NDS_LANG_CHINESE	= 6,
-	NDS_LANG_KOREAN		= 7,
+    // DS and 3DS
+    NDS_LANG_JAPANESE   = 0,
+    NDS_LANG_ENGLISH    = 1,
+    NDS_LANG_FRENCH     = 2,
+    NDS_LANG_GERMAN     = 3,
+    NDS_LANG_ITALIAN    = 4,
+    NDS_LANG_SPANISH    = 5,
+    NDS_LANG_CHINESE    = 6,
+    NDS_LANG_KOREAN     = 7,
 
-	// 3DS only
-	N3DS_LANG_CHINESE_SIMPLIFIED	= 6,
-	N3DS_LANG_DUTCH			= 8,
-	N3DS_LANG_PORTUGUESE		= 9,
-	N3DS_LANG_RUSSIAN		= 10,
-	N3DS_LANG_CHINESE_TRADITIONAL	= 11,
+    // 3DS only
+    N3DS_LANG_CHINESE_SIMPLIFIED    = 6,
+    N3DS_LANG_DUTCH         = 8,
+    N3DS_LANG_PORTUGUESE        = 9,
+    N3DS_LANG_RUSSIAN       = 10,
+    N3DS_LANG_CHINESE_TRADITIONAL   = 11,
 } sNDSLanguage;
 
 /**
@@ -210,7 +210,7 @@ typedef enum {
  * @param buf Output buffer for title ID. (Must be at least 4 characters.
  * @return 0 on success; non-zero on error.
  */
-int grabTID(FILE* ndsFile, char *buf);
+int grabTID(FILE* ndsFile, char* buf);
 
 /**
  * Get text from an NDS banner.

--- a/gui/source/ptmu_x.h
+++ b/gui/source/ptmu_x.h
@@ -11,7 +11,7 @@ Result ptmuxInit(void);
 
 void ptmuxExit(void);
 
-Result PTMUX_GetAdapterState(u8 *out);
+Result PTMUX_GetAdapterState(u8* out);
 
 #ifdef __cplusplus
 }

--- a/gui/source/rmkdir.h
+++ b/gui/source/rmkdir.h
@@ -12,7 +12,7 @@ extern "C" {
  * @param omde Mode.
  * @return 0 on success; non-zero on error.
  */
-int rmkdir(const char *path, int mode);
+int rmkdir(const char* path, int mode);
 
 #ifdef __cplusplus
 }

--- a/gui/source/settings.cpp
+++ b/gui/source/settings.cpp
@@ -25,26 +25,26 @@ using std::wstring;
 
 /** Top screen **/
 static bool settings_tex_loaded = false;
-static sf2d_texture *whomeicontex = NULL;	// HOME icon.
-static sf2d_texture *setvoltex[6] = { };	// Volume levels.
-static sf2d_texture *setbatterychrgtex = NULL;	// Fully charged.
-static sf2d_texture *setbatterytex[6] = { };	// Battery levels.
+static sf2d_texture* whomeicontex = NULL;   // HOME icon.
+static sf2d_texture* setvoltex[6] = { };    // Volume levels.
+static sf2d_texture* setbatterychrgtex = NULL;  // Fully charged.
+static sf2d_texture* setbatterytex[6] = { };    // Battery levels.
 
-static sf2d_texture *dsboottex = NULL;		// DS boot screen
-static sf2d_texture *dsiboottex = NULL;	// DSi boot screen
-static sf2d_texture *dshstex = NULL;		// DS H&S screen
-static sf2d_texture *dsihstex = NULL;		// DSi H&S screen
-static sf2d_texture *disabledtex = NULL;	// Red circle with line
+static sf2d_texture* dsboottex = NULL;      // DS boot screen
+static sf2d_texture* dsiboottex = NULL; // DSi boot screen
+static sf2d_texture* dshstex = NULL;        // DS H&S screen
+static sf2d_texture* dsihstex = NULL;       // DSi H&S screen
+static sf2d_texture* disabledtex = NULL;    // Red circle with line
 
 /** Bottom screen **/
-sf2d_texture *settingstex = NULL;
+sf2d_texture* settingstex = NULL;
 
 enum SubScreenMode {
-	SUBSCREEN_MODE_FRONTEND = 0,	// Frontend settings
-	SUBSCREEN_MODE_NTR_TWL = 1,	// NTR/TWL-mode settings
-	SUBSCREEN_MODE_FLASH_CARD = 2,	// Flash card options
-	SUBSCREEN_MODE_SUB_THEME = 3,	// Sub-theme select
-	SUBSCREEN_MODE_CHANGE_ROM_PATH = 4, // Sub-menu with rom path location
+    SUBSCREEN_MODE_FRONTEND = 0,    // Frontend settings
+    SUBSCREEN_MODE_NTR_TWL = 1, // NTR/TWL-mode settings
+    SUBSCREEN_MODE_FLASH_CARD = 2,  // Flash card options
+    SUBSCREEN_MODE_SUB_THEME = 3,   // Sub-theme select
+    SUBSCREEN_MODE_CHANGE_ROM_PATH = 4, // Sub-menu with rom path location
 };
 static SubScreenMode subscreenmode = SUBSCREEN_MODE_FRONTEND;
 
@@ -54,7 +54,7 @@ static CIniFile settingsini("sdmc:/_nds/twloader/settings.ini");
 
 // Color settings.
 // Use SET_ALPHA() to replace the alpha value.
-const ColorData *color_data = NULL;
+const ColorData* color_data = NULL;
 u32 menucolor;
 
 // 3D offsets. (0 == Left, 1 == Right)
@@ -75,8 +75,8 @@ Settings_t settings;
  */
 void settingsResetSubScreenMode(void)
 {
-	subscreenmode = SUBSCREEN_MODE_FRONTEND;
-	memset(cursor_pos, 0, sizeof(cursor_pos));
+    subscreenmode = SUBSCREEN_MODE_FRONTEND;
+    memset(cursor_pos, 0, sizeof(cursor_pos));
 }
 
 /**
@@ -84,64 +84,65 @@ void settingsResetSubScreenMode(void)
  */
 void settingsLoadTextures(void)
 {
-	if (settings_tex_loaded)
-		return;
+    if (settings_tex_loaded) {
+        return;
+    }
 
-	/** Top screen **/
-	setvoltex[0] = sfil_load_PNG_file("romfs:/graphics/settings/volume0.png", SF2D_PLACE_RAM); // Show no volume (settings)
-	setvoltex[1] = sfil_load_PNG_file("romfs:/graphics/settings/volume1.png", SF2D_PLACE_RAM); // Volume low above 0 (settings)
-	setvoltex[2] = sfil_load_PNG_file("romfs:/graphics/settings/volume2.png", SF2D_PLACE_RAM); // Volume medium (settings)
-	setvoltex[3] = sfil_load_PNG_file("romfs:/graphics/settings/volume3.png", SF2D_PLACE_RAM); // Hight volume (settings)	
-	setvoltex[4] = sfil_load_PNG_file("romfs:/graphics/settings/volume4.png", SF2D_PLACE_RAM); // 100% (settings)
-	setvoltex[5] = sfil_load_PNG_file("romfs:/graphics/settings/volume5.png", SF2D_PLACE_RAM); // No DSP firm found (settings)
+    /** Top screen **/
+    setvoltex[0] = sfil_load_PNG_file("romfs:/graphics/settings/volume0.png", SF2D_PLACE_RAM); // Show no volume (settings)
+    setvoltex[1] = sfil_load_PNG_file("romfs:/graphics/settings/volume1.png", SF2D_PLACE_RAM); // Volume low above 0 (settings)
+    setvoltex[2] = sfil_load_PNG_file("romfs:/graphics/settings/volume2.png", SF2D_PLACE_RAM); // Volume medium (settings)
+    setvoltex[3] = sfil_load_PNG_file("romfs:/graphics/settings/volume3.png", SF2D_PLACE_RAM); // Hight volume (settings)
+    setvoltex[4] = sfil_load_PNG_file("romfs:/graphics/settings/volume4.png", SF2D_PLACE_RAM); // 100% (settings)
+    setvoltex[5] = sfil_load_PNG_file("romfs:/graphics/settings/volume5.png", SF2D_PLACE_RAM); // No DSP firm found (settings)
 
-	setbatterychrgtex = sfil_load_PNG_file("romfs:/graphics/settings/battery_charging.png", SF2D_PLACE_RAM);
-	setbatterytex[0] = sfil_load_PNG_file("romfs:/graphics/settings/battery0.png", SF2D_PLACE_RAM);
-	setbatterytex[1] = sfil_load_PNG_file("romfs:/graphics/settings/battery1.png", SF2D_PLACE_RAM);
-	setbatterytex[2] = sfil_load_PNG_file("romfs:/graphics/settings/battery2.png", SF2D_PLACE_RAM);
-	setbatterytex[3] = sfil_load_PNG_file("romfs:/graphics/settings/battery3.png", SF2D_PLACE_RAM);
-	setbatterytex[4] = sfil_load_PNG_file("romfs:/graphics/settings/battery4.png", SF2D_PLACE_RAM);
-	setbatterytex[5] = sfil_load_PNG_file("romfs:/graphics/settings/battery5.png", SF2D_PLACE_RAM);
+    setbatterychrgtex = sfil_load_PNG_file("romfs:/graphics/settings/battery_charging.png", SF2D_PLACE_RAM);
+    setbatterytex[0] = sfil_load_PNG_file("romfs:/graphics/settings/battery0.png", SF2D_PLACE_RAM);
+    setbatterytex[1] = sfil_load_PNG_file("romfs:/graphics/settings/battery1.png", SF2D_PLACE_RAM);
+    setbatterytex[2] = sfil_load_PNG_file("romfs:/graphics/settings/battery2.png", SF2D_PLACE_RAM);
+    setbatterytex[3] = sfil_load_PNG_file("romfs:/graphics/settings/battery3.png", SF2D_PLACE_RAM);
+    setbatterytex[4] = sfil_load_PNG_file("romfs:/graphics/settings/battery4.png", SF2D_PLACE_RAM);
+    setbatterytex[5] = sfil_load_PNG_file("romfs:/graphics/settings/battery5.png", SF2D_PLACE_RAM);
 
-	dsboottex = sfil_load_PNG_file("romfs:/graphics/settings/dsboot.png", SF2D_PLACE_RAM); // DS boot screen in settings
-	dsiboottex = sfil_load_PNG_file("romfs:/graphics/settings/dsiboot.png", SF2D_PLACE_RAM); // DSi boot screen in settings
-	switch (sys_language) {
-		case 0:
-		case 6:
-		case 7:
-			dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_JA.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_JA.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			break;
-		case 1:
-		default:
-			dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_EN.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dsihs.png", SF2D_PLACE_RAM); // DSi H&S screen in settings
-			break;
-		case 2:
-			dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_FR.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_FR.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			break;
-		case 3:
-			dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_DE.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_DE.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			break;
-		case 4:
-			dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_IT.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_IT.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			break;
-		case 5:
-			dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_ES.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_ES.png", SF2D_PLACE_RAM); // DS H&S screen in settings
-			break;
-	}
-	disabledtex = sfil_load_PNG_file("romfs:/graphics/settings/disable.png", SF2D_PLACE_RAM); // Red circle with line
+    dsboottex = sfil_load_PNG_file("romfs:/graphics/settings/dsboot.png", SF2D_PLACE_RAM); // DS boot screen in settings
+    dsiboottex = sfil_load_PNG_file("romfs:/graphics/settings/dsiboot.png", SF2D_PLACE_RAM); // DSi boot screen in settings
+    switch (sys_language) {
+        case 0:
+        case 6:
+        case 7:
+            dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_JA.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_JA.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            break;
+        case 1:
+        default:
+            dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_EN.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dsihs.png", SF2D_PLACE_RAM); // DSi H&S screen in settings
+            break;
+        case 2:
+            dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_FR.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_FR.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            break;
+        case 3:
+            dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_DE.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_DE.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            break;
+        case 4:
+            dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_IT.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_IT.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            break;
+        case 5:
+            dshstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_ES.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            dsihstex = sfil_load_PNG_file("romfs:/graphics/settings/dshs_ES.png", SF2D_PLACE_RAM); // DS H&S screen in settings
+            break;
+    }
+    disabledtex = sfil_load_PNG_file("romfs:/graphics/settings/disable.png", SF2D_PLACE_RAM); // Red circle with line
 
-	/** Bottom screen **/
-	settingstex = sfil_load_PNG_file("romfs:/graphics/settings/screen.png", SF2D_PLACE_RAM); // Bottom of settings screen
-	whomeicontex = sfil_load_PNG_file("romfs:/graphics/settings/whomeicon.png", SF2D_PLACE_RAM); // HOME icon
+    /** Bottom screen **/
+    settingstex = sfil_load_PNG_file("romfs:/graphics/settings/screen.png", SF2D_PLACE_RAM); // Bottom of settings screen
+    whomeicontex = sfil_load_PNG_file("romfs:/graphics/settings/whomeicon.png", SF2D_PLACE_RAM); // HOME icon
 
-	// All textures loaded.
-	settings_tex_loaded = true;
+    // All textures loaded.
+    settings_tex_loaded = true;
 }
 
 /**
@@ -149,40 +150,41 @@ void settingsLoadTextures(void)
  */
 void settingsUnloadTextures(void)
 {
-	if (!settings_tex_loaded)
-		return;
+    if (!settings_tex_loaded) {
+        return;
+    }
 
-	/** Top screen **/
-	for (int i = 0; i < 6; i++) {
-		sf2d_free_texture(setvoltex[i]);
-		setvoltex[i] = NULL;
-	}
-	sf2d_free_texture(setbatterychrgtex);
+    /** Top screen **/
+    for (int i = 0; i < 6; i++) {
+        sf2d_free_texture(setvoltex[i]);
+        setvoltex[i] = NULL;
+    }
+    sf2d_free_texture(setbatterychrgtex);
 
-	for (int i = 0; i < 6; i++) {
-		sf2d_free_texture(setbatterytex[i]);
-		setbatterytex[i] = NULL;
-	}
+    for (int i = 0; i < 6; i++) {
+        sf2d_free_texture(setbatterytex[i]);
+        setbatterytex[i] = NULL;
+    }
 
-	sf2d_free_texture(dsboottex);
-	dsboottex = NULL;
-	sf2d_free_texture(dsiboottex);
-	dsiboottex = NULL;
-	sf2d_free_texture(dshstex);
-	dshstex = NULL;
-	sf2d_free_texture(dsihstex);
-	dsihstex = NULL;
-	sf2d_free_texture(disabledtex);
-	disabledtex = NULL;
+    sf2d_free_texture(dsboottex);
+    dsboottex = NULL;
+    sf2d_free_texture(dsiboottex);
+    dsiboottex = NULL;
+    sf2d_free_texture(dshstex);
+    dshstex = NULL;
+    sf2d_free_texture(dsihstex);
+    dsihstex = NULL;
+    sf2d_free_texture(disabledtex);
+    disabledtex = NULL;
 
-	/** Bottom screen **/
-	sf2d_free_texture(settingstex);
-	settingstex = NULL;
-	sf2d_free_texture(whomeicontex);
-	whomeicontex = NULL;
+    /** Bottom screen **/
+    sf2d_free_texture(settingstex);
+    settingstex = NULL;
+    sf2d_free_texture(whomeicontex);
+    whomeicontex = NULL;
 
-	// All textures unloaded.
-	settings_tex_loaded = false;
+    // All textures unloaded.
+    settings_tex_loaded = false;
 }
 
 /**
@@ -190,71 +192,73 @@ void settingsUnloadTextures(void)
  */
 void settingsDrawTopScreen(void)
 {
-	/* if (!musicbool) {
-		if (dspfirmfound) { bgm_settings->play(); }
-		musicbool = true;
-	} */
-	if (!settings_tex_loaded) {
-		settingsLoadTextures();
-	}
-	update_battery_level(setbatterychrgtex, setbatterytex);
+    /* if (!musicbool) {
+        if (dspfirmfound) { bgm_settings->play(); }
+        musicbool = true;
+    } */
+    if (!settings_tex_loaded) {
+        settingsLoadTextures();
+    }
+    update_battery_level(setbatterychrgtex, setbatterytex);
 
-	// Draw twice; once per 3D framebuffer.
-	for (int topfb = GFX_LEFT; topfb <= GFX_RIGHT; topfb++) {
-		sf2d_start_frame(GFX_TOP, (gfx3dSide_t)topfb);
-		sf2d_draw_texture_scale(settingstex, 0, 0, 1.32, 1);
-		if (subscreenmode == SUBSCREEN_MODE_NTR_TWL) {
-			if (settings.twl.bootscreen == 2) {
-				sf2d_draw_texture(dsiboottex, offset3D[topfb].boxart+136, 20); // Draw boot screen
-			} else if (settings.twl.bootscreen == 1) {
-				sf2d_draw_texture(dsboottex, offset3D[topfb].boxart+136, 20); // Draw boot screen
-			} else {
-				sf2d_draw_rectangle(offset3D[topfb].boxart+136, 20, 128, 96, RGBA8(255, 255, 255, 255));
-			}
-			if (settings.twl.healthsafety == 1) {
-				if (settings.twl.bootscreen == 2) {
-					sf2d_draw_texture(dsihstex, offset3D[topfb].boxart+136, 124); // Draw H&S screen
-				} else if (settings.twl.bootscreen == 1) {
-					sf2d_draw_texture(dshstex, offset3D[topfb].boxart+136, 124); // Draw H&S screen
-				} else {
-					sf2d_draw_rectangle(offset3D[topfb].boxart+136, 124, 128, 96, RGBA8(255, 255, 255, 255));
-				}
-			} else {
-				// Draw a white screen in place of the H&S screen.
-				sf2d_draw_rectangle(offset3D[topfb].boxart+136, 124, 128, 96, RGBA8(255, 255, 255, 255));
-			}
-			if (settings.twl.bootscreen == 0) {
-				sf2d_draw_texture(disabledtex, offset3D[topfb].disabled+136, 20); // Draw disabled texture
-				sf2d_draw_texture(disabledtex, offset3D[topfb].disabled+136, 124); // Draw disabled texture
-			}
-		} else {
-			sf2d_draw_texture(settingslogotex, offset3D[topfb].boxart+400/2 - settingslogotex->width/2, 240/2 - settingslogotex->height/2);
-			if (subscreenmode == SUBSCREEN_MODE_FRONTEND) {
-				sftd_draw_wtext(font, offset3D[topfb].disabled+72, 166, RGBA8(0, 0, 255, 255), 14, TR(STR_SETTINGS_XBUTTON_RELEASE));
-				sftd_draw_wtext(font, offset3D[topfb].disabled+72, 180, RGBA8(0, 255, 0, 255), 14, TR(STR_SETTINGS_YBUTTON_UNOFFICIAL));
-				if(!is3DSX) sftd_draw_wtext(font, offset3D[topfb].disabled+72, 194, RGBA8(255, 255, 255, 255), 14, TR(STR_SETTINGS_SETTINGS_START_UPDATE_TWLOADER));
-			}
-		}
+    // Draw twice; once per 3D framebuffer.
+    for (int topfb = GFX_LEFT; topfb <= GFX_RIGHT; topfb++) {
+        sf2d_start_frame(GFX_TOP, (gfx3dSide_t)topfb);
+        sf2d_draw_texture_scale(settingstex, 0, 0, 1.32, 1);
+        if (subscreenmode == SUBSCREEN_MODE_NTR_TWL) {
+            if (settings.twl.bootscreen == 2) {
+                sf2d_draw_texture(dsiboottex, offset3D[topfb].boxart + 136, 20); // Draw boot screen
+            } else if (settings.twl.bootscreen == 1) {
+                sf2d_draw_texture(dsboottex, offset3D[topfb].boxart + 136, 20); // Draw boot screen
+            } else {
+                sf2d_draw_rectangle(offset3D[topfb].boxart + 136, 20, 128, 96, RGBA8(255, 255, 255, 255));
+            }
+            if (settings.twl.healthsafety == 1) {
+                if (settings.twl.bootscreen == 2) {
+                    sf2d_draw_texture(dsihstex, offset3D[topfb].boxart + 136, 124); // Draw H&S screen
+                } else if (settings.twl.bootscreen == 1) {
+                    sf2d_draw_texture(dshstex, offset3D[topfb].boxart + 136, 124); // Draw H&S screen
+                } else {
+                    sf2d_draw_rectangle(offset3D[topfb].boxart + 136, 124, 128, 96, RGBA8(255, 255, 255, 255));
+                }
+            } else {
+                // Draw a white screen in place of the H&S screen.
+                sf2d_draw_rectangle(offset3D[topfb].boxart + 136, 124, 128, 96, RGBA8(255, 255, 255, 255));
+            }
+            if (settings.twl.bootscreen == 0) {
+                sf2d_draw_texture(disabledtex, offset3D[topfb].disabled + 136, 20); // Draw disabled texture
+                sf2d_draw_texture(disabledtex, offset3D[topfb].disabled + 136, 124); // Draw disabled texture
+            }
+        } else {
+            sf2d_draw_texture(settingslogotex, offset3D[topfb].boxart + 400 / 2 - settingslogotex->width / 2, 240 / 2 - settingslogotex->height / 2);
+            if (subscreenmode == SUBSCREEN_MODE_FRONTEND) {
+                sftd_draw_wtext(font, offset3D[topfb].disabled + 72, 166, RGBA8(0, 0, 255, 255), 14, TR(STR_SETTINGS_XBUTTON_RELEASE));
+                sftd_draw_wtext(font, offset3D[topfb].disabled + 72, 180, RGBA8(0, 255, 0, 255), 14, TR(STR_SETTINGS_YBUTTON_UNOFFICIAL));
+                if (!is3DSX) {
+                    sftd_draw_wtext(font, offset3D[topfb].disabled + 72, 194, RGBA8(255, 255, 255, 255), 14, TR(STR_SETTINGS_SETTINGS_START_UPDATE_TWLOADER));
+                }
+            }
+        }
 
-		sftd_draw_text(font, 328, 3, RGBA8(255, 255, 255, 255), 12, RetTime(false).c_str());
-		
-		std::string version = settings_vertext;		
-		if (version.substr(version.find_first_not_of(' '), (version.find_last_not_of(' ') - version.find_first_not_of(' ') + 1)).size() > 8) {
-			sftd_draw_text(font, 334, 222, RGBA8(255, 255, 255, 255), 14, settings_vertext);
-		}else{
-			sftd_draw_text(font, 347, 222, RGBA8(255, 255, 255, 255), 14, settings_vertext);
-		}
-		settings.twl.bootstrapfile ? sftd_draw_text(font, 5, 222, RGBA8(0, 0, 255, 255), 14, settings_releasebootstrapver.c_str()) : sftd_draw_text(font, 5, 222, RGBA8(0, 255, 0, 255), 14, settings_unofficialbootstrapver.c_str());
+        sftd_draw_text(font, 328, 3, RGBA8(255, 255, 255, 255), 12, RetTime(false).c_str());
 
-		draw_volume_slider(setvoltex);
-		sf2d_draw_texture(batteryIcon, 371, 2);
-		if (!settings.ui.name.empty()) {
-			sftd_draw_textf(font, 34, 3, SET_ALPHA(color_data->color, 255), 12, settings.ui.name.c_str());
-		}
-		DrawDate(282, 3, RGBA8(255, 255, 255, 255), 12);
-		sf2d_draw_rectangle(0, 0, 400, 240, RGBA8(0, 0, 0, fadealpha)); // Fade in/out effect
-		sf2d_end_frame();
-	}
+        std::string version = settings_vertext;
+        if (version.substr(version.find_first_not_of(' '), (version.find_last_not_of(' ') - version.find_first_not_of(' ') + 1)).size() > 8) {
+            sftd_draw_text(font, 334, 222, RGBA8(255, 255, 255, 255), 14, settings_vertext);
+        } else {
+            sftd_draw_text(font, 347, 222, RGBA8(255, 255, 255, 255), 14, settings_vertext);
+        }
+        settings.twl.bootstrapfile ? sftd_draw_text(font, 5, 222, RGBA8(0, 0, 255, 255), 14, settings_releasebootstrapver.c_str()) : sftd_draw_text(font, 5, 222, RGBA8(0, 255, 0, 255), 14, settings_unofficialbootstrapver.c_str());
+
+        draw_volume_slider(setvoltex);
+        sf2d_draw_texture(batteryIcon, 371, 2);
+        if (!settings.ui.name.empty()) {
+            sftd_draw_textf(font, 34, 3, SET_ALPHA(color_data->color, 255), 12, settings.ui.name.c_str());
+        }
+        DrawDate(282, 3, RGBA8(255, 255, 255, 255), 12);
+        sf2d_draw_rectangle(0, 0, 400, 240, RGBA8(0, 0, 0, fadealpha)); // Fade in/out effect
+        sf2d_end_frame();
+    }
 }
 
 /**
@@ -262,556 +266,562 @@ void settingsDrawTopScreen(void)
  */
 void settingsDrawBottomScreen(void)
 {
-	if (!settings_tex_loaded) {
-		settingsLoadTextures();
-	}
+    if (!settings_tex_loaded) {
+        settingsLoadTextures();
+    }
 
-	sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-	sf2d_draw_texture(settingstex, 0, 0);
-	if(!is3DSX) {
-		const wchar_t *home_text = TR(STR_RETURN_TO_HOME_MENU);
-		const int home_width = sftd_get_wtext_width(font, 13, home_text) + 16;
-		const int home_x = (320-home_width)/2;
-		sf2d_draw_texture(whomeicontex, home_x, 220); // Draw HOME icon
-		sftd_draw_wtext(font, home_x+16, 221, RGBA8(255, 255, 255, 255), 13, home_text);
-	}
+    sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
+    sf2d_draw_texture(settingstex, 0, 0);
+    if (!is3DSX) {
+        const wchar_t* home_text = TR(STR_RETURN_TO_HOME_MENU);
+        const int home_width = sftd_get_wtext_width(font, 13, home_text) + 16;
+        const int home_x = (320 - home_width) / 2;
+        sf2d_draw_texture(whomeicontex, home_x, 220); // Draw HOME icon
+        sftd_draw_wtext(font, home_x + 16, 221, RGBA8(255, 255, 255, 255), 13, home_text);
+    }
 
-	// X positions.
-	static const int Xpos = 24;
-	static const int XposValue = 236;
-	// Title for the bottom screen.
-	const wchar_t *title = L"";
+    // X positions.
+    static const int Xpos = 24;
+    static const int XposValue = 236;
+    // Title for the bottom screen.
+    const wchar_t* title = L"";
 
-	if (subscreenmode == SUBSCREEN_MODE_FRONTEND) {
-		sf2d_draw_texture(shoulderLtex, 0, LshoulderYpos);
-		sf2d_draw_texture(shoulderRtex, 248, RshoulderYpos);
-		sftd_draw_text(font, 17, LshoulderYpos+5, RGBA8(0, 0, 0, 255), 11, Lshouldertext);
-		sftd_draw_text(font, 252, RshoulderYpos+5, RGBA8(0, 0, 0, 255), 11, Rshouldertext);
+    if (subscreenmode == SUBSCREEN_MODE_FRONTEND) {
+        sf2d_draw_texture(shoulderLtex, 0, LshoulderYpos);
+        sf2d_draw_texture(shoulderRtex, 248, RshoulderYpos);
+        sftd_draw_text(font, 17, LshoulderYpos + 5, RGBA8(0, 0, 0, 255), 11, Lshouldertext);
+        sftd_draw_text(font, 252, RshoulderYpos + 5, RGBA8(0, 0, 0, 255), 11, Rshouldertext);
 
-		// Language.
-		static const char *const language_text[] = {
-			"日本語",	// Japanese
-			"English",	// English
-			"Français",	// French
-			"Deutsch",	// German
-			"Italiano",	// Italian
-			"Español",	// Spanish
-			"ZHCN",		// Simplified Chinese (TODO)
-			"Korean",	// Korean [Font is missing characters]
-			"Nederlands",	// Dutch
-			"Português",	// Portuguese
-			"Russian",	// Russian (TODO) [Font's characters are too wide]
-			"ZHTW",		// Traditional Chinese (TODO)
-		};
-		// TODO: Cache the conversion?
-		wstring languagevaluetext;
-		if (settings.ui.language >= 0 && settings.ui.language < 12) {
-			languagevaluetext = utf8_to_wstring(language_text[settings.ui.language]);
-		} else {
-			// TODO: Translate?
-			languagevaluetext = latin1_to_wstring("System");
-		}
+        // Language.
+        static const char* const language_text[] = {
+            "日本語",    // Japanese
+            "English",  // English
+            "Français",    // French
+            "Deutsch",  // German
+            "Italiano", // Italian
+            "Español", // Spanish
+            "ZHCN",     // Simplified Chinese (TODO)
+            "Korean",   // Korean [Font is missing characters]
+            "Nederlands",   // Dutch
+            "Português",   // Portuguese
+            "Russian",  // Russian (TODO) [Font's characters are too wide]
+            "ZHTW",     // Traditional Chinese (TODO)
+        };
+        // TODO: Cache the conversion?
+        wstring languagevaluetext;
+        if (settings.ui.language >= 0 && settings.ui.language < 12) {
+            languagevaluetext = utf8_to_wstring(language_text[settings.ui.language]);
+        } else {
+            // TODO: Translate?
+            languagevaluetext = latin1_to_wstring("System");
+        }
 
-		// Theme text.
-		static const char *const theme_text[] = {
-			"DSi Menu", "R4", "akMenu/Wood"
-		};
-		if (settings.ui.theme < 0 || settings.ui.theme > 2)
-			settings.ui.theme = 0;
-		const char *const themevaluetext = theme_text[settings.ui.theme];
+        // Theme text.
+        static const char* const theme_text[] = {
+            "DSi Menu", "R4", "akMenu/Wood"
+        };
+        if (settings.ui.theme < 0 || settings.ui.theme > 2) {
+            settings.ui.theme = 0;
+        }
+        const char* const themevaluetext = theme_text[settings.ui.theme];
 
-		// Color text.
-		const wchar_t *color_text[] = {
-			TR(STR_SETTINGS_VALUES_GRAY),
-			TR(STR_SETTINGS_VALUES_BROWN),
-			TR(STR_SETTINGS_VALUES_RED),
-			TR(STR_SETTINGS_VALUES_PINK),
-			TR(STR_SETTINGS_VALUES_ORANGE),
-			TR(STR_SETTINGS_VALUES_YELLOW),
-			TR(STR_SETTINGS_VALUES_YELLOW_GREEN),
-			TR(STR_SETTINGS_VALUES_GREEN_1),
-			TR(STR_SETTINGS_VALUES_GREEN_2),
-			TR(STR_SETTINGS_VALUES_LIGHT_GREEN),
-			TR(STR_SETTINGS_VALUES_SKY_BLUE),
-			TR(STR_SETTINGS_VALUES_LIGHT_BLUE),
-			TR(STR_SETTINGS_VALUES_BLUE),
-			TR(STR_SETTINGS_VALUES_VIOLET),
-			TR(STR_SETTINGS_VALUES_PURPLE),
-			TR(STR_SETTINGS_VALUES_FUCHSIA),
-			TR(STR_SETTINGS_VALUES_RED_AND_BLUE),
-			TR(STR_SETTINGS_VALUES_GREEN_AND_YELLOW),
-			TR(STR_SETTINGS_VALUES_CHRISTMAS)
-		};
-		if (settings.ui.color < 0 || settings.ui.color > 18)
-			settings.ui.color = 0;
-		const wchar_t *colorvaluetext = color_text[settings.ui.color];
+        // Color text.
+        const wchar_t* color_text[] = {
+            TR(STR_SETTINGS_VALUES_GRAY),
+            TR(STR_SETTINGS_VALUES_BROWN),
+            TR(STR_SETTINGS_VALUES_RED),
+            TR(STR_SETTINGS_VALUES_PINK),
+            TR(STR_SETTINGS_VALUES_ORANGE),
+            TR(STR_SETTINGS_VALUES_YELLOW),
+            TR(STR_SETTINGS_VALUES_YELLOW_GREEN),
+            TR(STR_SETTINGS_VALUES_GREEN_1),
+            TR(STR_SETTINGS_VALUES_GREEN_2),
+            TR(STR_SETTINGS_VALUES_LIGHT_GREEN),
+            TR(STR_SETTINGS_VALUES_SKY_BLUE),
+            TR(STR_SETTINGS_VALUES_LIGHT_BLUE),
+            TR(STR_SETTINGS_VALUES_BLUE),
+            TR(STR_SETTINGS_VALUES_VIOLET),
+            TR(STR_SETTINGS_VALUES_PURPLE),
+            TR(STR_SETTINGS_VALUES_FUCHSIA),
+            TR(STR_SETTINGS_VALUES_RED_AND_BLUE),
+            TR(STR_SETTINGS_VALUES_GREEN_AND_YELLOW),
+            TR(STR_SETTINGS_VALUES_CHRISTMAS)
+        };
+        if (settings.ui.color < 0 || settings.ui.color > 18) {
+            settings.ui.color = 0;
+        }
+        const wchar_t* colorvaluetext = color_text[settings.ui.color];
 
-		// Menu color text.
-		const wchar_t *menu_color_text[] = {
-			TR(STR_SETTINGS_VALUES_WHITE),
-			TR(STR_SETTINGS_VALUES_BLACK),
-			TR(STR_SETTINGS_VALUES_BROWN),
-			TR(STR_SETTINGS_VALUES_RED),
-			TR(STR_SETTINGS_VALUES_PINK),
-			TR(STR_SETTINGS_VALUES_ORANGE),
-			TR(STR_SETTINGS_VALUES_YELLOW),
-			TR(STR_SETTINGS_VALUES_YELLOW_GREEN),
-			TR(STR_SETTINGS_VALUES_GREEN_1),
-			TR(STR_SETTINGS_VALUES_GREEN_2),
-			TR(STR_SETTINGS_VALUES_LIGHT_GREEN),
-			TR(STR_SETTINGS_VALUES_SKY_BLUE),
-			TR(STR_SETTINGS_VALUES_LIGHT_BLUE),
-			TR(STR_SETTINGS_VALUES_BLUE),
-			TR(STR_SETTINGS_VALUES_VIOLET),
-			TR(STR_SETTINGS_VALUES_PURPLE),
-			TR(STR_SETTINGS_VALUES_FUCHSIA)
-		};
-		if (settings.ui.menucolor < 0 || settings.ui.menucolor > 18)
-			settings.ui.menucolor = 0;
-		const wchar_t  *menucolorvaluetext = menu_color_text[settings.ui.menucolor];
+        // Menu color text.
+        const wchar_t* menu_color_text[] = {
+            TR(STR_SETTINGS_VALUES_WHITE),
+            TR(STR_SETTINGS_VALUES_BLACK),
+            TR(STR_SETTINGS_VALUES_BROWN),
+            TR(STR_SETTINGS_VALUES_RED),
+            TR(STR_SETTINGS_VALUES_PINK),
+            TR(STR_SETTINGS_VALUES_ORANGE),
+            TR(STR_SETTINGS_VALUES_YELLOW),
+            TR(STR_SETTINGS_VALUES_YELLOW_GREEN),
+            TR(STR_SETTINGS_VALUES_GREEN_1),
+            TR(STR_SETTINGS_VALUES_GREEN_2),
+            TR(STR_SETTINGS_VALUES_LIGHT_GREEN),
+            TR(STR_SETTINGS_VALUES_SKY_BLUE),
+            TR(STR_SETTINGS_VALUES_LIGHT_BLUE),
+            TR(STR_SETTINGS_VALUES_BLUE),
+            TR(STR_SETTINGS_VALUES_VIOLET),
+            TR(STR_SETTINGS_VALUES_PURPLE),
+            TR(STR_SETTINGS_VALUES_FUCHSIA)
+        };
+        if (settings.ui.menucolor < 0 || settings.ui.menucolor > 18) {
+            settings.ui.menucolor = 0;
+        }
+        const wchar_t*  menucolorvaluetext = menu_color_text[settings.ui.menucolor];
 
-		const char *const filenamevaluetext = (settings.ui.filename ? "On" : "Off");
-		const char *const countervaluetext = (settings.ui.counter ? "On" : "Off");
-		const char *const custombotvaluetext = (settings.ui.custombot ? "On" : "Off");
+        const char* const filenamevaluetext = (settings.ui.filename ? "On" : "Off");
+        const char* const countervaluetext = (settings.ui.counter ? "On" : "Off");
+        const char* const custombotvaluetext = (settings.ui.custombot ? "On" : "Off");
 
-		const char *autoupdatevaluetext;
-		switch (settings.ui.autoupdate) {
-			case 0:
-			default:
-				autoupdatevaluetext = "Off";
-				break;
-			case 1:
-				autoupdatevaluetext = "Release";
-				break;
-			case 2:
-				autoupdatevaluetext = "Unofficial";
-				break;
-		}
-		const char *autodlvaluetext = (settings.ui.autodl ? "On" : "Off");
+        const char* autoupdatevaluetext;
+        switch (settings.ui.autoupdate) {
+            case 0:
+            default:
+                autoupdatevaluetext = "Off";
+                break;
+            case 1:
+                autoupdatevaluetext = "Release";
+                break;
+            case 2:
+                autoupdatevaluetext = "Unofficial";
+                break;
+        }
+        const char* autodlvaluetext = (settings.ui.autodl ? "On" : "Off");
 
-		title = TR(STR_SETTINGS_GUI);
-		int Ypos = 40;
-		if (cursor_pos[0] == 0) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_LANGUAGE));
-			sftd_draw_wtext(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, languagevaluetext.c_str());
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_LANGUAGE_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_LANGUAGE_2));
-			Ypos += 12;
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_LANGUAGE));
-			sftd_draw_wtext(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, languagevaluetext.c_str());
-			Ypos += 12;
-		}
-		if (cursor_pos[0] == 1) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_THEME));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, themevaluetext);
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_THEME_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_THEME_2));
-			Ypos += 12;
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_THEME));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, themevaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[0] == 2) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_COLOR));
-			sftd_draw_wtext(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, colorvaluetext);
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_COLOR_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_COLOR_2));
-			Ypos += 12;
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_COLOR));
-			sftd_draw_wtext(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, colorvaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[0] == 3) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_MENUCOLOR));
-			sftd_draw_wtext(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, menucolorvaluetext);
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_MENUCOLOR_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_MENUCOLOR_2));
-			Ypos += 12;
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_MENUCOLOR));
-			sftd_draw_wtext(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, menucolorvaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[0] == 4) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_FILENAME));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, filenamevaluetext);
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_FILENAME_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_FILENAME_2));
-			Ypos += 12;
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_FILENAME));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, filenamevaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[0] == 5) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_COUNTER));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, countervaluetext);
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_COUNTER_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_COUNTER_2));
-			Ypos += 12;
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_COUNTER));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, countervaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[0] == 6) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_CUSTOM_BOTTOM));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, custombotvaluetext);
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_CUSTOM_BOTTOM_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_CUSTOM_BOTTOM_2));
-			Ypos += 12;
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_CUSTOM_BOTTOM));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, custombotvaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[0] == 7) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_AUTOUPDATE_BOOTSTRAP));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, autoupdatevaluetext);
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_AUTOUPDATE_BOOTSTRAP_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_AUTOUPDATE_BOOTSTRAP_2));
-			Ypos += 12;
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_AUTOUPDATE_BOOTSTRAP));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, autoupdatevaluetext);
-			Ypos += 12;
-		}
-		if(!is3DSX) {
-			if (cursor_pos[0] == 8) {
-				sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_AUTOUPDATE_TWLOADER));
-				sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, autodlvaluetext);
-				sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_AUTOUPDATE_TWLOADER_1));
-				sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_AUTOUPDATE_TWLOADER_2));
-				Ypos += 12;
-			} else {
-				sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_AUTOUPDATE_TWLOADER));
-				sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, autodlvaluetext);
-				Ypos += 12;
-			}
-		}
-		if (cursor_pos[0] == 9) {
-			// Selected			
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, L"Rom path");
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, L"Press A to change rom location folder.");
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, L"");
-			sftd_draw_textf(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, "SD:/%s", settings.ui.romfolder.c_str());
-			Ypos += 12;
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, L"Rom path");
-			sftd_draw_textf(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, "SD:/%s", settings.ui.romfolder.c_str());
-			Ypos += 12;
-		}
-	} else if (subscreenmode == SUBSCREEN_MODE_NTR_TWL) {
-		sf2d_draw_texture(shoulderLtex, 0, LshoulderYpos);
-		sf2d_draw_texture(shoulderRtex, 248, RshoulderYpos);
-		sftd_draw_text(font, 17, LshoulderYpos+5, RGBA8(0, 0, 0, 255), 11, Lshouldertext);
-		sftd_draw_text(font, 252, RshoulderYpos+5, RGBA8(0, 0, 0, 255), 11, Rshouldertext);
+        title = TR(STR_SETTINGS_GUI);
+        int Ypos = 40;
+        if (cursor_pos[0] == 0) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_LANGUAGE));
+            sftd_draw_wtext(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, languagevaluetext.c_str());
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_LANGUAGE_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_LANGUAGE_2));
+            Ypos += 12;
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_LANGUAGE));
+            sftd_draw_wtext(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, languagevaluetext.c_str());
+            Ypos += 12;
+        }
+        if (cursor_pos[0] == 1) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_THEME));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, themevaluetext);
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_THEME_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_THEME_2));
+            Ypos += 12;
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_THEME));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, themevaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[0] == 2) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_COLOR));
+            sftd_draw_wtext(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, colorvaluetext);
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_COLOR_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_COLOR_2));
+            Ypos += 12;
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_COLOR));
+            sftd_draw_wtext(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, colorvaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[0] == 3) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_MENUCOLOR));
+            sftd_draw_wtext(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, menucolorvaluetext);
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_MENUCOLOR_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_MENUCOLOR_2));
+            Ypos += 12;
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_MENUCOLOR));
+            sftd_draw_wtext(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, menucolorvaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[0] == 4) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_FILENAME));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, filenamevaluetext);
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_FILENAME_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_FILENAME_2));
+            Ypos += 12;
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_FILENAME));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, filenamevaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[0] == 5) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_COUNTER));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, countervaluetext);
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_COUNTER_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_COUNTER_2));
+            Ypos += 12;
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_COUNTER));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, countervaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[0] == 6) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_CUSTOM_BOTTOM));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, custombotvaluetext);
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_CUSTOM_BOTTOM_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_CUSTOM_BOTTOM_2));
+            Ypos += 12;
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_CUSTOM_BOTTOM));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, custombotvaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[0] == 7) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_AUTOUPDATE_BOOTSTRAP));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, autoupdatevaluetext);
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_AUTOUPDATE_BOOTSTRAP_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_AUTOUPDATE_BOOTSTRAP_2));
+            Ypos += 12;
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_AUTOUPDATE_BOOTSTRAP));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, autoupdatevaluetext);
+            Ypos += 12;
+        }
+        if (!is3DSX) {
+            if (cursor_pos[0] == 8) {
+                sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_AUTOUPDATE_TWLOADER));
+                sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, autodlvaluetext);
+                sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_AUTOUPDATE_TWLOADER_1));
+                sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_AUTOUPDATE_TWLOADER_2));
+                Ypos += 12;
+            } else {
+                sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_AUTOUPDATE_TWLOADER));
+                sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, autodlvaluetext);
+                Ypos += 12;
+            }
+        }
+        if (cursor_pos[0] == 9) {
+            // Selected
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, L"Rom path");
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, L"Press A to change rom location folder.");
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, L"");
+            sftd_draw_textf(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, "SD:/%s", settings.ui.romfolder.c_str());
+            Ypos += 12;
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, L"Rom path");
+            sftd_draw_textf(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, "SD:/%s", settings.ui.romfolder.c_str());
+            Ypos += 12;
+        }
+    } else if (subscreenmode == SUBSCREEN_MODE_NTR_TWL) {
+        sf2d_draw_texture(shoulderLtex, 0, LshoulderYpos);
+        sf2d_draw_texture(shoulderRtex, 248, RshoulderYpos);
+        sftd_draw_text(font, 17, LshoulderYpos + 5, RGBA8(0, 0, 0, 255), 11, Lshouldertext);
+        sftd_draw_text(font, 252, RshoulderYpos + 5, RGBA8(0, 0, 0, 255), 11, Rshouldertext);
 
-		const char *rainbowledvaluetext = (settings.twl.rainbowled ? "On" : "Off");
-		const char *cpuspeedvaluetext = (settings.twl.cpuspeed ? "133mhz (TWL)" : "67mhz (NTR)");
-		const char *extvramvaluetext = (settings.twl.extvram ? "On" : "Off");
-		// Boot screen text.
-		static const char *const bootscreen_text[] = {
-			"None", "Nintendo DS", "Nintendo DSi"
-		};
-		if (settings.twl.bootscreen < 0 || settings.twl.bootscreen > 2)
-			settings.twl.bootscreen = 0;
-		const char *const bootscreenvaluetext = bootscreen_text[settings.twl.bootscreen];
-		const char *healthsafetyvaluetext = (settings.twl.healthsafety ? "On" : "Off");
-		const char *resetslot1valuetext = (settings.twl.resetslot1 ? "On" : "Off");
-		const char *bootstrapfilevaluetext = (settings.twl.bootstrapfile ? "Release" : "Unofficial");
+        const char* rainbowledvaluetext = (settings.twl.rainbowled ? "On" : "Off");
+        const char* cpuspeedvaluetext = (settings.twl.cpuspeed ? "133mhz (TWL)" : "67mhz (NTR)");
+        const char* extvramvaluetext = (settings.twl.extvram ? "On" : "Off");
+        // Boot screen text.
+        static const char* const bootscreen_text[] = {
+            "None", "Nintendo DS", "Nintendo DSi"
+        };
+        if (settings.twl.bootscreen < 0 || settings.twl.bootscreen > 2) {
+            settings.twl.bootscreen = 0;
+        }
+        const char* const bootscreenvaluetext = bootscreen_text[settings.twl.bootscreen];
+        const char* healthsafetyvaluetext = (settings.twl.healthsafety ? "On" : "Off");
+        const char* resetslot1valuetext = (settings.twl.resetslot1 ? "On" : "Off");
+        const char* bootstrapfilevaluetext = (settings.twl.bootstrapfile ? "Release" : "Unofficial");
 
-		const char *consolevaluetext;
-		switch (settings.twl.console) {
-			case 0:
-			default:
-				consolevaluetext = "Off";
-				break;
-			case 1:
-				consolevaluetext = "On";
-				break;
-			case 2:
-				consolevaluetext = "On (Debug)";
-				break;
-		}
+        const char* consolevaluetext;
+        switch (settings.twl.console) {
+            case 0:
+            default:
+                consolevaluetext = "Off";
+                break;
+            case 1:
+                consolevaluetext = "On";
+                break;
+            case 2:
+                consolevaluetext = "On (Debug)";
+                break;
+        }
 
-		const char *lockarm9scfgextvaluetext = (settings.twl.lockarm9scfgext ? "On" : "Off");
+        const char* lockarm9scfgextvaluetext = (settings.twl.lockarm9scfgext ? "On" : "Off");
 
-		title = TR(STR_SETTINGS_NTR_TWL);
-		int Ypos = 40;
-		if (cursor_pos[1] == 0) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_FLASHCARD_SELECT));
-			Ypos += 12;
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_FLASHCARD_SELECT_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_FLASHCARD_SELECT_2));
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_FLASHCARD_SELECT));
-			Ypos += 12;
-		}
-		if (cursor_pos[1] == 1) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_RAINBOW_LED));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, rainbowledvaluetext);
-			Ypos += 12;
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_RAINBOW_LED_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_RAINBOW_LED_2));
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_RAINBOW_LED));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, rainbowledvaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[1] == 2) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(SRT_SETTINGS_ARM9_CPU_SPEED));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, cpuspeedvaluetext);
-			Ypos += 12;
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(SRT_SETTINGS_DESCRIPTION_ARM9_CPU_SPEED_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(SRT_SETTINGS_DESCRIPTION_ARM9_CPU_SPEED_2));
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(SRT_SETTINGS_ARM9_CPU_SPEED));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, cpuspeedvaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[1] == 3) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_VRAM_BOOST));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, extvramvaluetext);
-			Ypos += 12;
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_VRAM_BOOST_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_VRAM_BOOST_2));
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_VRAM_BOOST));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, extvramvaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[1] == 4) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_DS_DSi_BOOT_SCREEN));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, bootscreenvaluetext);
-			Ypos += 12;
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_DS_DSi_BOOT_SCREEN_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_DS_DSi_BOOT_SCREEN_2));
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_DS_DSi_BOOT_SCREEN));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, bootscreenvaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[1] == 5) {
-			sftd_draw_wtext(font, Xpos+16, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_DS_DSi_SAFETY_MESSAGE));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, healthsafetyvaluetext);
-			Ypos += 12;
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_DS_DSi_SAFETY_MESSAGE_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_DS_DSi_SAFETY_MESSAGE_2));
-		} else {
-			sftd_draw_wtext(font, Xpos+16, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_DS_DSi_SAFETY_MESSAGE));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, healthsafetyvaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[1] == 6) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_RESET_SLOT_1));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, resetslot1valuetext);
-			Ypos += 12;
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_RESET_SLOT_1_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_RESET_SLOT_1_2));
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_RESET_SLOT_1));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, resetslot1valuetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[1] == 7) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_CONSOLE_OUTPUT));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, consolevaluetext);
-			Ypos += 12;
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_CONSOLE_OUTPUT_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_CONSOLE_OUTPUT_2));
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_CONSOLE_OUTPUT));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, consolevaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[1] == 8) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_LOCK_ARM9_SCFG_EXT));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, lockarm9scfgextvaluetext);
-			Ypos += 12;
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_LOCK_ARM9_SCFG_EXT_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_LOCK_ARM9_SCFG_EXT_2));
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_LOCK_ARM9_SCFG_EXT));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, lockarm9scfgextvaluetext);
-			Ypos += 12;
-		}
-		if (cursor_pos[1] == 9) {
-			sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_BOOTSTRAP));
-			sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, bootstrapfilevaluetext);
-			Ypos += 12;
-			sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_BOOTSTRAP_1));
-			sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_BOOTSTRAP_2));
-		} else {
-			sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_BOOTSTRAP));
-			sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, bootstrapfilevaluetext);
-			Ypos += 12;
-		}
-	} else if (subscreenmode == SUBSCREEN_MODE_FLASH_CARD) {
-		// Flash card options.
-		static const char *const flash_card_options[][6] = {
-			{"DSTT", "R4i Gold", "R4i-SDHC (Non-v1.4.x version) (www.r4i-sdhc.com)",
-				"R4 SDHC Dual-Core", "R4 SDHC Upgrade", "SuperCard DSONE"},
-			{"Original R4", "M3 Simply", " ", " ", " ", " "},
-			{"R4iDSN", "R4i Gold RTS", " ", " ", " ", " "},
-			{"Acekard 2(i)", "Galaxy Eagle", "M3DS Real", " ", " ", " "},
-			{"Acekard RPG", " ", " ", " ", " ", " "},
-			{"Ace 3DS+", "Gateway Blue Card", "R4iTT", " ", " ", " "},
-			{"SuperCard DSTWO", " ", " ", " ", " ", " "},
-		};
+        title = TR(STR_SETTINGS_NTR_TWL);
+        int Ypos = 40;
+        if (cursor_pos[1] == 0) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_FLASHCARD_SELECT));
+            Ypos += 12;
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_FLASHCARD_SELECT_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_FLASHCARD_SELECT_2));
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_FLASHCARD_SELECT));
+            Ypos += 12;
+        }
+        if (cursor_pos[1] == 1) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_RAINBOW_LED));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, rainbowledvaluetext);
+            Ypos += 12;
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_RAINBOW_LED_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_RAINBOW_LED_2));
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_RAINBOW_LED));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, rainbowledvaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[1] == 2) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(SRT_SETTINGS_ARM9_CPU_SPEED));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, cpuspeedvaluetext);
+            Ypos += 12;
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(SRT_SETTINGS_DESCRIPTION_ARM9_CPU_SPEED_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(SRT_SETTINGS_DESCRIPTION_ARM9_CPU_SPEED_2));
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(SRT_SETTINGS_ARM9_CPU_SPEED));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, cpuspeedvaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[1] == 3) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_VRAM_BOOST));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, extvramvaluetext);
+            Ypos += 12;
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_VRAM_BOOST_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_VRAM_BOOST_2));
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_VRAM_BOOST));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, extvramvaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[1] == 4) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_DS_DSi_BOOT_SCREEN));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, bootscreenvaluetext);
+            Ypos += 12;
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_DS_DSi_BOOT_SCREEN_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_DS_DSi_BOOT_SCREEN_2));
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_DS_DSi_BOOT_SCREEN));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, bootscreenvaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[1] == 5) {
+            sftd_draw_wtext(font, Xpos + 16, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_DS_DSi_SAFETY_MESSAGE));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, healthsafetyvaluetext);
+            Ypos += 12;
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_DS_DSi_SAFETY_MESSAGE_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_DS_DSi_SAFETY_MESSAGE_2));
+        } else {
+            sftd_draw_wtext(font, Xpos + 16, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_DS_DSi_SAFETY_MESSAGE));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, healthsafetyvaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[1] == 6) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_RESET_SLOT_1));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, resetslot1valuetext);
+            Ypos += 12;
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_RESET_SLOT_1_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_RESET_SLOT_1_2));
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_RESET_SLOT_1));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, resetslot1valuetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[1] == 7) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_CONSOLE_OUTPUT));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, consolevaluetext);
+            Ypos += 12;
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_CONSOLE_OUTPUT_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_CONSOLE_OUTPUT_2));
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_CONSOLE_OUTPUT));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, consolevaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[1] == 8) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_LOCK_ARM9_SCFG_EXT));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, lockarm9scfgextvaluetext);
+            Ypos += 12;
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_LOCK_ARM9_SCFG_EXT_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_LOCK_ARM9_SCFG_EXT_2));
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_LOCK_ARM9_SCFG_EXT));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, lockarm9scfgextvaluetext);
+            Ypos += 12;
+        }
+        if (cursor_pos[1] == 9) {
+            sftd_draw_wtext(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_BOOTSTRAP));
+            sftd_draw_text(font, XposValue, Ypos, SET_ALPHA(color_data->color, 255), 12, bootstrapfilevaluetext);
+            Ypos += 12;
+            sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_BOOTSTRAP_1));
+            sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_DESCRIPTION_BOOTSTRAP_2));
+        } else {
+            sftd_draw_wtext(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, TR(STR_SETTINGS_BOOTSTRAP));
+            sftd_draw_text(font, XposValue, Ypos, RGBA8(255, 255, 255, 255), 12, bootstrapfilevaluetext);
+            Ypos += 12;
+        }
+    } else if (subscreenmode == SUBSCREEN_MODE_FLASH_CARD) {
+        // Flash card options.
+        static const char* const flash_card_options[][6] = {
+            {
+                "DSTT", "R4i Gold", "R4i-SDHC (Non-v1.4.x version) (www.r4i-sdhc.com)",
+                "R4 SDHC Dual-Core", "R4 SDHC Upgrade", "SuperCard DSONE"
+            },
+            {"Original R4", "M3 Simply", " ", " ", " ", " "},
+            {"R4iDSN", "R4i Gold RTS", " ", " ", " ", " "},
+            {"Acekard 2(i)", "Galaxy Eagle", "M3DS Real", " ", " ", " "},
+            {"Acekard RPG", " ", " ", " ", " ", " "},
+            {"Ace 3DS+", "Gateway Blue Card", "R4iTT", " ", " ", " "},
+            {"SuperCard DSTWO", " ", " ", " ", " ", " "},
+        };
 
-		if (settings.twl.flashcard < 0 || settings.twl.flashcard > 6) {
-			settings.twl.flashcard = 0;
-		}
-		const char *const *fctext = flash_card_options[settings.twl.flashcard];
-		title = TR(STR_SETTINGS_FLASHCARD_SELECT);
-		int Ypos = 40;
-		for (int i = 0; i < 6; i++, Ypos += 12) {
-			sftd_draw_text(font, Xpos, Ypos,
-				SET_ALPHA(color_data->color, 255), 12, fctext[i]);
-		}
-		sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_LEFTRIGHT_PICK));
-		sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_AB_SAVE_RETURN));
-	} else if (subscreenmode == SUBSCREEN_MODE_SUB_THEME) {
-		if (settings.ui.theme == 0) {
-			title = TR(STR_SETTINGS_SUBTHEME_DSi);
-			sftd_draw_wtext(font, Xpos, 40, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_NO_SUB_THEMES));
-		} else if (settings.ui.theme == 1) {
-			title = TR(STR_SETTINGS_SUBTHEME_R4);
-			int Ypos = 40;
-			if (settings.ui.subtheme == 0) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme01");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme01");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 1) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme02");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme02");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 2) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme03");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme03");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 3) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme04");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme04");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 4) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme05");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme05");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 5) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme06");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme06");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 6) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme07");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme07");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 7) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme08");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme08");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 8) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme09");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme09");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 9) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme10");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme10");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 10) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme11");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme11");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 11) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme12");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme12");
-			}
-			Ypos += 12;
-		} else if (settings.ui.theme == 2) {
-			title = TR(STR_SETTINGS_SUBTHEME_WOOD);
-			int Ypos = 40;
-			if (settings.ui.subtheme == 0) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "GBATemp");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "GBATemp");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 1) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "Acekard black");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "Acekard black");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 2) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "akaio");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "akaio");
-			}
-			Ypos += 12;
-			if (settings.ui.subtheme == 3) {
-				sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "DSTWO");
-			} else {
-				sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "DSTWO");
-			}
-			Ypos += 12;
-		}
-		sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_AB_SAVE_RETURN));
-	}else if (subscreenmode == SUBSCREEN_MODE_CHANGE_ROM_PATH) {
-		title = L"Rom path location";
-	
-		if (cursor_pos[4] == 0){
-			// Selected SD
-			sftd_draw_text(font, 24, 40, SET_ALPHA(color_data->color, 255), 12, "SD ROM location:");			
-			sftd_draw_textf(font, 30, 52, SET_ALPHA(color_data->color, 255), 12, "SD:/%s", settings.ui.romfolder.c_str());
-			
-			// Unselect Flashcard
-			sftd_draw_text(font, 24, 66, RGBA8(255, 255, 255, 255), 12, "Flashcard INI location:");
-			sftd_draw_textf(font, 30, 78, RGBA8(255, 255, 255, 255), 12, "SD:/%s", settings.ui.fcromfolder.c_str());
-			
-		}else if (cursor_pos[4] == 1){
-			// Unselected SD
-			sftd_draw_text(font, 24, 40, RGBA8(255, 255, 255, 255), 12, "SD ROM location:");
-			sftd_draw_textf(font, 30, 52, RGBA8(255, 255, 255, 255), 12, "SD:/%s", settings.ui.romfolder.c_str());		
-			
-			// Selected Flashcard
-			sftd_draw_text(font, 24, 66, SET_ALPHA(color_data->color, 255), 12, "Flashcard INI location:");
-			sftd_draw_textf(font, 30, 78, SET_ALPHA(color_data->color, 255), 12, "SD:/%s", settings.ui.fcromfolder.c_str());
-			
-		}
-		
-		sftd_draw_text(font, 24, 160, RGBA8(255, 255, 255, 255), 12, "TWLoader will auto-restart if location is changed");
-		
-		sftd_draw_text(font, 8, 184, RGBA8(255, 255, 255, 255), 13, "A: Change path");
-		sftd_draw_text(font, 8, 198, RGBA8(255, 255, 255, 255), 13, "B: Return");	
-	}
-	sftd_draw_wtext(font, 2, 2, RGBA8(255, 255, 255, 255), 16, title);
+        if (settings.twl.flashcard < 0 || settings.twl.flashcard > 6) {
+            settings.twl.flashcard = 0;
+        }
+        const char* const* fctext = flash_card_options[settings.twl.flashcard];
+        title = TR(STR_SETTINGS_FLASHCARD_SELECT);
+        int Ypos = 40;
+        for (int i = 0; i < 6; i++, Ypos += 12) {
+            sftd_draw_text(font, Xpos, Ypos,
+                           SET_ALPHA(color_data->color, 255), 12, fctext[i]);
+        }
+        sftd_draw_wtext(font, 8, 184, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_LEFTRIGHT_PICK));
+        sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_AB_SAVE_RETURN));
+    } else if (subscreenmode == SUBSCREEN_MODE_SUB_THEME) {
+        if (settings.ui.theme == 0) {
+            title = TR(STR_SETTINGS_SUBTHEME_DSi);
+            sftd_draw_wtext(font, Xpos, 40, SET_ALPHA(color_data->color, 255), 12, TR(STR_SETTINGS_NO_SUB_THEMES));
+        } else if (settings.ui.theme == 1) {
+            title = TR(STR_SETTINGS_SUBTHEME_R4);
+            int Ypos = 40;
+            if (settings.ui.subtheme == 0) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme01");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme01");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 1) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme02");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme02");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 2) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme03");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme03");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 3) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme04");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme04");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 4) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme05");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme05");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 5) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme06");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme06");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 6) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme07");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme07");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 7) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme08");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme08");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 8) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme09");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme09");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 9) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme10");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme10");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 10) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme11");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme11");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 11) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "theme12");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "theme12");
+            }
+            Ypos += 12;
+        } else if (settings.ui.theme == 2) {
+            title = TR(STR_SETTINGS_SUBTHEME_WOOD);
+            int Ypos = 40;
+            if (settings.ui.subtheme == 0) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "GBATemp");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "GBATemp");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 1) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "Acekard black");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "Acekard black");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 2) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "akaio");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "akaio");
+            }
+            Ypos += 12;
+            if (settings.ui.subtheme == 3) {
+                sftd_draw_text(font, Xpos, Ypos, SET_ALPHA(color_data->color, 255), 12, "DSTWO");
+            } else {
+                sftd_draw_text(font, Xpos, Ypos, RGBA8(255, 255, 255, 255), 12, "DSTWO");
+            }
+            Ypos += 12;
+        }
+        sftd_draw_wtext(font, 8, 198, RGBA8(255, 255, 255, 255), 13, TR(STR_SETTINGS_AB_SAVE_RETURN));
+    } else if (subscreenmode == SUBSCREEN_MODE_CHANGE_ROM_PATH) {
+        title = L"Rom path location";
+
+        if (cursor_pos[4] == 0) {
+            // Selected SD
+            sftd_draw_text(font, 24, 40, SET_ALPHA(color_data->color, 255), 12, "SD ROM location:");
+            sftd_draw_textf(font, 30, 52, SET_ALPHA(color_data->color, 255), 12, "SD:/%s", settings.ui.romfolder.c_str());
+
+            // Unselect Flashcard
+            sftd_draw_text(font, 24, 66, RGBA8(255, 255, 255, 255), 12, "Flashcard INI location:");
+            sftd_draw_textf(font, 30, 78, RGBA8(255, 255, 255, 255), 12, "SD:/%s", settings.ui.fcromfolder.c_str());
+
+        } else if (cursor_pos[4] == 1) {
+            // Unselected SD
+            sftd_draw_text(font, 24, 40, RGBA8(255, 255, 255, 255), 12, "SD ROM location:");
+            sftd_draw_textf(font, 30, 52, RGBA8(255, 255, 255, 255), 12, "SD:/%s", settings.ui.romfolder.c_str());
+
+            // Selected Flashcard
+            sftd_draw_text(font, 24, 66, SET_ALPHA(color_data->color, 255), 12, "Flashcard INI location:");
+            sftd_draw_textf(font, 30, 78, SET_ALPHA(color_data->color, 255), 12, "SD:/%s", settings.ui.fcromfolder.c_str());
+
+        }
+
+        sftd_draw_text(font, 24, 160, RGBA8(255, 255, 255, 255), 12, "TWLoader will auto-restart if location is changed");
+
+        sftd_draw_text(font, 8, 184, RGBA8(255, 255, 255, 255), 13, "A: Change path");
+        sftd_draw_text(font, 8, 198, RGBA8(255, 255, 255, 255), 13, "B: Return");
+    }
+    sftd_draw_wtext(font, 2, 2, RGBA8(255, 255, 255, 255), 16, title);
 }
 
 /**
@@ -821,513 +831,532 @@ void settingsDrawBottomScreen(void)
  */
 bool settingsMoveCursor(u32 hDown)
 {
-	touchPosition touch;
-	hidTouchRead(&touch);
+    touchPosition touch;
+    hidTouchRead(&touch);
 
-	Lshouldertext = "GUI";
-	Rshouldertext = "NTR/TWL";
+    Lshouldertext = "GUI";
+    Rshouldertext = "NTR/TWL";
 
-	if (hDown == 0) {
-		// Nothing to do here.
-		return false;
-	}
+    if (hDown == 0) {
+        // Nothing to do here.
+        return false;
+    }
 
-	// Sound effect to play.
-	sound *sfx = NULL;
+    // Sound effect to play.
+    sound* sfx = NULL;
 
-	if (subscreenmode == SUBSCREEN_MODE_SUB_THEME) {
-		if (hDown & KEY_UP) {
-			settings.ui.subtheme--;
-			sfx = sfx_select;
-		} else if (hDown & KEY_DOWN) {
-			settings.ui.subtheme++;
-			sfx = sfx_select;
-		} else if (hDown & (KEY_A | KEY_B)) {
-			subscreenmode = SUBSCREEN_MODE_FRONTEND;
-			sfx = sfx_select;
-		}
-		if (settings.ui.theme == 0) {
-			settings.ui.subtheme = 0;
-		} else if (settings.ui.theme == 1) {
-			if (settings.ui.subtheme < 0)
-				settings.ui.subtheme = 11;
-			else if (settings.ui.subtheme > 11)
-				settings.ui.subtheme = 0;
-		} else if (settings.ui.theme == 2) {
-			if (settings.ui.subtheme < 0)
-				settings.ui.subtheme = 3;
-			else if (settings.ui.subtheme > 3)
-				settings.ui.subtheme = 0;
-		}
-	} else if (subscreenmode == SUBSCREEN_MODE_FLASH_CARD) {
-		if (hDown & KEY_LEFT && settings.twl.flashcard > 0) {
-			settings.twl.flashcard--; // Flashcard
-			sfx = sfx_select;
-		} else if (hDown & KEY_RIGHT && settings.twl.flashcard < 6) {
-			settings.twl.flashcard++; // Flashcard
-			sfx = sfx_select;
-		} else if (hDown & (KEY_A | KEY_B)) {
-			subscreenmode = SUBSCREEN_MODE_NTR_TWL;
-			sfx = sfx_select;
-		}
-	} else if (subscreenmode == SUBSCREEN_MODE_NTR_TWL) {
-		if (hDown & (KEY_A | KEY_LEFT | KEY_RIGHT)) {
-			switch (cursor_pos[SUBSCREEN_MODE_NTR_TWL]) {
-				case 0:
-				default:
-					// Top item: Only listen to 'A'.
-					if (hDown & KEY_A) {
-						subscreenmode = SUBSCREEN_MODE_FLASH_CARD;
-					} else {
-						// Ignore this key.
-						return false;
-					}
-					break;
-				case 1:	// Rainbow LED
-					settings.twl.rainbowled = !settings.twl.rainbowled;
-					break;
-				case 2:	// CPU speed
-					settings.twl.cpuspeed = !settings.twl.cpuspeed;
-					break;
-				case 3:	// VRAM boost
-					settings.twl.extvram = !settings.twl.extvram;
-					break;
-				case 4:	// Boot screen
-					if (hDown & (KEY_A | KEY_RIGHT)) {
-						settings.twl.bootscreen++;
-						if (settings.twl.bootscreen > 2) {
-							settings.twl.bootscreen = 0;
-						}
-					} else if (hDown & KEY_LEFT) {
-						settings.twl.bootscreen--;
-						if (settings.twl.bootscreen < 0) {
-							settings.twl.bootscreen = 2;
-						}
-					}
-					break;
-				case 5:	// H&S message
-					settings.twl.healthsafety = !settings.twl.healthsafety;
-					break;
-				case 6:	// Reset Slot-1
-					settings.twl.resetslot1 = !settings.twl.resetslot1;
-					break;
-				case 7:	// Console output
-					if (hDown & (KEY_A | KEY_RIGHT)) {
-						settings.twl.console++;
-						if (settings.twl.console > 2) {
-							settings.twl.console = 0;
-						}
-					} else if (hDown & KEY_LEFT) {
-						settings.twl.console--;
-						if (settings.twl.console < 0) {
-							settings.twl.console = 2;
-						}
-					}
-					break;
-				case 8:	// Lock ARM9 SCFG_EXT
-					settings.twl.lockarm9scfgext = !settings.twl.lockarm9scfgext;
-					break;
-				case 9: // Bootstrap version
-					settings.twl.bootstrapfile = ! settings.twl.bootstrapfile;
-					break;					
-			}
-			sfx = sfx_select;
-		} else if ((hDown & KEY_DOWN) && cursor_pos[1] < 9) {
-			cursor_pos[1]++;
-			sfx = sfx_select;
-		} else if ((hDown & KEY_UP) && cursor_pos[1] > 0) {
-			cursor_pos[1]--;
-			sfx = sfx_select;
-		} else if (hDown & KEY_L) {
-			subscreenmode = SUBSCREEN_MODE_FRONTEND;
-			sfx = sfx_switch;
-		} else if (hDown & KEY_B) {
-			titleboxXmovetimer = 1;
-			fadeout = true;
-			//bgm_settings->stop();
-			sfx = sfx_back;
-		}
-		if(hDown & KEY_TOUCH){
-			if (touch.px <= 72 && touch.py >= 220) {
-				subscreenmode = SUBSCREEN_MODE_FRONTEND;
-				sfx = sfx_switch;
-			}
-		}
-	} else if (subscreenmode == SUBSCREEN_MODE_FRONTEND) {
-		if (hDown & (KEY_A | KEY_LEFT | KEY_RIGHT)) {
-			switch (cursor_pos[SUBSCREEN_MODE_FRONTEND]) {
-				case 0:	// Language
-				default:
-					if (hDown & (KEY_A | KEY_RIGHT)) {
-						settings.ui.language++;
-						if (settings.ui.language > 11) {
-							settings.ui.language = -1;
-						}
-					} else if (hDown & KEY_LEFT) {
-						settings.ui.language--;
-						if (settings.ui.language < -1) {
-							settings.ui.language = 11;
-						}
-					}
-					langInit();
-					break;
-				case 1:	// Theme
-					if (hDown & (KEY_RIGHT)) {
-						settings.ui.subtheme = 0;
-						settings.ui.theme++;
-						if (settings.ui.theme > 2) {
-							settings.ui.theme = 0;
-						}
-					} else if (hDown & KEY_LEFT) {
-						settings.ui.subtheme = 0;
-						settings.ui.theme--;
-						if (settings.ui.theme < 0) {
-							settings.ui.theme = 2;
-						}
-					} else if (hDown & KEY_A)
-						subscreenmode = SUBSCREEN_MODE_SUB_THEME;
-					break;
-				case 2:	// Color
-					if (hDown & (KEY_A | KEY_RIGHT)) {
-						settings.ui.color++;
-						if (settings.ui.color > 18) {
-							settings.ui.color = 0;
-						}
-					} else if (hDown & KEY_LEFT) {
-						settings.ui.color--;
-						if (settings.ui.color < 0) {
-							settings.ui.color = 18;
-						}
-					}
-					LoadColor();
-					break;
-				case 3:	// Menu color
-					if (hDown & (KEY_A | KEY_RIGHT)) {
-						settings.ui.menucolor++;
-						if (settings.ui.menucolor > 16) {
-							settings.ui.menucolor = 0;
-						}
-					} else if (hDown & KEY_LEFT) {
-						settings.ui.menucolor--;
-						if (settings.ui.menucolor < 0) {
-							settings.ui.menucolor = 16;
-						}
-					}
-					LoadMenuColor();
-					break;
-				case 4:	// Show filename
-					settings.ui.filename = !settings.ui.filename;
-					break;
-				case 5:	// Game counter
-					settings.ui.counter = !settings.ui.counter;
-					break;
-				case 6:	// Custom bottom image
-					settings.ui.custombot = !settings.ui.custombot;
-					LoadBottomImage();
-					break;
-				case 7:	// Enable or disable autoupdate
-					if (hDown & (KEY_A | KEY_RIGHT)) {
-						settings.ui.autoupdate++;
-						if (settings.ui.autoupdate > 2) {
-							settings.ui.autoupdate = 0;
-						}
-					} else if (hDown & KEY_LEFT) {
-						settings.ui.autoupdate--;
-						if (settings.ui.autoupdate < 0) {
-							settings.ui.autoupdate = 2;
-						}
-					}
-					break;
-				case 8:	// Enable or disable autodownload
-					settings.ui.autodl = !settings.ui.autodl;
-					break;
-				case 9: // Rom path
-					if (hDown & KEY_A) {
-						subscreenmode = SUBSCREEN_MODE_CHANGE_ROM_PATH;
-					}
-					break;
-			}
-			sfx = sfx_select;
-		} else if ((hDown & KEY_DOWN) && cursor_pos[0] < 9) {
-			cursor_pos[0]++;
-			if(is3DSX) {
-				if(cursor_pos[0] == 9)
-					cursor_pos[0]--;
-			}
-			sfx = sfx_select;
-		} else if ((hDown & KEY_UP) && cursor_pos[0] > 0) {
-			cursor_pos[0]--;
-			sfx = sfx_select;
-		} else if (hDown & KEY_R) {
-			subscreenmode = SUBSCREEN_MODE_NTR_TWL;
-			sfx = sfx_switch;
-		} else if (hDown & KEY_X) {
-			if (checkWifiStatus()) {
-				// Play the sound now instead of waiting.
-				if (dspfirmfound && sfx_select) {
-					sfx_select->stop();	// Prevent freezing
-					sfx_select->play();
-				}
-				UpdateBootstrapRelease();
-			} else {
-				// Wi-Fi is not connected.
-				sfx = sfx_wrong;
-			}
-		} else if (hDown & KEY_Y) {
-			if (checkWifiStatus()) {
-				// Play the sound now instead of waiting.
-				if (dspfirmfound && sfx_select) {
-					sfx_select->stop();	// Prevent freezing
-					sfx_select->play();
-				}
-				UpdateBootstrapUnofficial();
-			} else {
-				// Wi-Fi is not connected.
-				sfx = sfx_wrong;
-			}
-		} else if (hDown & KEY_START && checkWifiStatus() && !is3DSX) {
-			if (checkUpdate() == 0) {
-				// Play the sound now instead of waiting.
-				if (dspfirmfound && sfx_select) {
-					sfx_select->stop();	// Prevent freezing
-					sfx_select->play();
-				}
-				DownloadTWLoaderCIAs();
-			}
-		} else if (hDown & KEY_B) {
-			titleboxXmovetimer = 1;
-			fadeout = true;
-			sfx = sfx_back;
-		}
-		if(hDown & KEY_TOUCH){
-			if (touch.px >= 248 && touch.py >= 220) {
-				subscreenmode = SUBSCREEN_MODE_NTR_TWL;
-				sfx = sfx_switch;
-			}
-		}
-	}else if (subscreenmode == SUBSCREEN_MODE_CHANGE_ROM_PATH) {
-		if (hDown & KEY_UP) {
-			cursor_pos[4]--;
-			if (cursor_pos[4] < 0)
-				cursor_pos[4] = 0;			
-			sfx = sfx_select;
-		} else if (hDown & KEY_DOWN) {
-			cursor_pos[4]++;
-			if (cursor_pos[4] > 1)
-				cursor_pos[4] = 1;
-			sfx = sfx_select;
-		} else if (hDown & KEY_B) {		
-			subscreenmode = SUBSCREEN_MODE_FRONTEND;
-			sfx = sfx_select;
-		} else if (hDown & KEY_A) {
-			std::string oldPath = (cursor_pos[4] == 0) ? settings.ui.romfolder : settings.ui.fcromfolder;
-			std::wstring widestr = (cursor_pos[4] == 0) ? 
-													std::wstring(settings.ui.romfolder.begin(), settings.ui.romfolder.end()) : 
-													std::wstring(settings.ui.fcromfolder.begin(), settings.ui.fcromfolder.end());
-			
-			const wchar_t* currentPath = widestr.c_str();
-			std::string newPath = keyboardInput(currentPath);
-			
-			(cursor_pos[4] == 0) ? settings.ui.romfolder = newPath : settings.ui.fcromfolder = newPath;			
+    if (subscreenmode == SUBSCREEN_MODE_SUB_THEME) {
+        if (hDown & KEY_UP) {
+            settings.ui.subtheme--;
+            sfx = sfx_select;
+        } else if (hDown & KEY_DOWN) {
+            settings.ui.subtheme++;
+            sfx = sfx_select;
+        } else if (hDown & (KEY_A | KEY_B)) {
+            subscreenmode = SUBSCREEN_MODE_FRONTEND;
+            sfx = sfx_select;
+        }
+        if (settings.ui.theme == 0) {
+            settings.ui.subtheme = 0;
+        } else if (settings.ui.theme == 1) {
+            if (settings.ui.subtheme < 0) {
+                settings.ui.subtheme = 11;
+            } else if (settings.ui.subtheme > 11) {
+                settings.ui.subtheme = 0;
+            }
+        } else if (settings.ui.theme == 2) {
+            if (settings.ui.subtheme < 0) {
+                settings.ui.subtheme = 3;
+            } else if (settings.ui.subtheme > 3) {
+                settings.ui.subtheme = 0;
+            }
+        }
+    } else if (subscreenmode == SUBSCREEN_MODE_FLASH_CARD) {
+        if (hDown & KEY_LEFT && settings.twl.flashcard > 0) {
+            settings.twl.flashcard--; // Flashcard
+            sfx = sfx_select;
+        } else if (hDown & KEY_RIGHT && settings.twl.flashcard < 6) {
+            settings.twl.flashcard++; // Flashcard
+            sfx = sfx_select;
+        } else if (hDown & (KEY_A | KEY_B)) {
+            subscreenmode = SUBSCREEN_MODE_NTR_TWL;
+            sfx = sfx_select;
+        }
+    } else if (subscreenmode == SUBSCREEN_MODE_NTR_TWL) {
+        if (hDown & (KEY_A | KEY_LEFT | KEY_RIGHT)) {
+            switch (cursor_pos[SUBSCREEN_MODE_NTR_TWL]) {
+                case 0:
+                default:
+                    // Top item: Only listen to 'A'.
+                    if (hDown & KEY_A) {
+                        subscreenmode = SUBSCREEN_MODE_FLASH_CARD;
+                    } else {
+                        // Ignore this key.
+                        return false;
+                    }
+                    break;
+                case 1: // Rainbow LED
+                    settings.twl.rainbowled = !settings.twl.rainbowled;
+                    break;
+                case 2: // CPU speed
+                    settings.twl.cpuspeed = !settings.twl.cpuspeed;
+                    break;
+                case 3: // VRAM boost
+                    settings.twl.extvram = !settings.twl.extvram;
+                    break;
+                case 4: // Boot screen
+                    if (hDown & (KEY_A | KEY_RIGHT)) {
+                        settings.twl.bootscreen++;
+                        if (settings.twl.bootscreen > 2) {
+                            settings.twl.bootscreen = 0;
+                        }
+                    } else if (hDown & KEY_LEFT) {
+                        settings.twl.bootscreen--;
+                        if (settings.twl.bootscreen < 0) {
+                            settings.twl.bootscreen = 2;
+                        }
+                    }
+                    break;
+                case 5: // H&S message
+                    settings.twl.healthsafety = !settings.twl.healthsafety;
+                    break;
+                case 6: // Reset Slot-1
+                    settings.twl.resetslot1 = !settings.twl.resetslot1;
+                    break;
+                case 7: // Console output
+                    if (hDown & (KEY_A | KEY_RIGHT)) {
+                        settings.twl.console++;
+                        if (settings.twl.console > 2) {
+                            settings.twl.console = 0;
+                        }
+                    } else if (hDown & KEY_LEFT) {
+                        settings.twl.console--;
+                        if (settings.twl.console < 0) {
+                            settings.twl.console = 2;
+                        }
+                    }
+                    break;
+                case 8: // Lock ARM9 SCFG_EXT
+                    settings.twl.lockarm9scfgext = !settings.twl.lockarm9scfgext;
+                    break;
+                case 9: // Bootstrap version
+                    settings.twl.bootstrapfile = ! settings.twl.bootstrapfile;
+                    break;
+            }
+            sfx = sfx_select;
+        } else if ((hDown & KEY_DOWN) && cursor_pos[1] < 9) {
+            cursor_pos[1]++;
+            sfx = sfx_select;
+        } else if ((hDown & KEY_UP) && cursor_pos[1] > 0) {
+            cursor_pos[1]--;
+            sfx = sfx_select;
+        } else if (hDown & KEY_L) {
+            subscreenmode = SUBSCREEN_MODE_FRONTEND;
+            sfx = sfx_switch;
+        } else if (hDown & KEY_B) {
+            titleboxXmovetimer = 1;
+            fadeout = true;
+            //bgm_settings->stop();
+            sfx = sfx_back;
+        }
+        if (hDown & KEY_TOUCH) {
+            if (touch.px <= 72 && touch.py >= 220) {
+                subscreenmode = SUBSCREEN_MODE_FRONTEND;
+                sfx = sfx_switch;
+            }
+        }
+    } else if (subscreenmode == SUBSCREEN_MODE_FRONTEND) {
+        if (hDown & (KEY_A | KEY_LEFT | KEY_RIGHT)) {
+            switch (cursor_pos[SUBSCREEN_MODE_FRONTEND]) {
+                case 0: // Language
+                default:
+                    if (hDown & (KEY_A | KEY_RIGHT)) {
+                        settings.ui.language++;
+                        if (settings.ui.language > 11) {
+                            settings.ui.language = -1;
+                        }
+                    } else if (hDown & KEY_LEFT) {
+                        settings.ui.language--;
+                        if (settings.ui.language < -1) {
+                            settings.ui.language = 11;
+                        }
+                    }
+                    langInit();
+                    break;
+                case 1: // Theme
+                    if (hDown & (KEY_RIGHT)) {
+                        settings.ui.subtheme = 0;
+                        settings.ui.theme++;
+                        if (settings.ui.theme > 2) {
+                            settings.ui.theme = 0;
+                        }
+                    } else if (hDown & KEY_LEFT) {
+                        settings.ui.subtheme = 0;
+                        settings.ui.theme--;
+                        if (settings.ui.theme < 0) {
+                            settings.ui.theme = 2;
+                        }
+                    } else if (hDown & KEY_A) {
+                        subscreenmode = SUBSCREEN_MODE_SUB_THEME;
+                    }
+                    break;
+                case 2: // Color
+                    if (hDown & (KEY_A | KEY_RIGHT)) {
+                        settings.ui.color++;
+                        if (settings.ui.color > 18) {
+                            settings.ui.color = 0;
+                        }
+                    } else if (hDown & KEY_LEFT) {
+                        settings.ui.color--;
+                        if (settings.ui.color < 0) {
+                            settings.ui.color = 18;
+                        }
+                    }
+                    LoadColor();
+                    break;
+                case 3: // Menu color
+                    if (hDown & (KEY_A | KEY_RIGHT)) {
+                        settings.ui.menucolor++;
+                        if (settings.ui.menucolor > 16) {
+                            settings.ui.menucolor = 0;
+                        }
+                    } else if (hDown & KEY_LEFT) {
+                        settings.ui.menucolor--;
+                        if (settings.ui.menucolor < 0) {
+                            settings.ui.menucolor = 16;
+                        }
+                    }
+                    LoadMenuColor();
+                    break;
+                case 4: // Show filename
+                    settings.ui.filename = !settings.ui.filename;
+                    break;
+                case 5: // Game counter
+                    settings.ui.counter = !settings.ui.counter;
+                    break;
+                case 6: // Custom bottom image
+                    settings.ui.custombot = !settings.ui.custombot;
+                    LoadBottomImage();
+                    break;
+                case 7: // Enable or disable autoupdate
+                    if (hDown & (KEY_A | KEY_RIGHT)) {
+                        settings.ui.autoupdate++;
+                        if (settings.ui.autoupdate > 2) {
+                            settings.ui.autoupdate = 0;
+                        }
+                    } else if (hDown & KEY_LEFT) {
+                        settings.ui.autoupdate--;
+                        if (settings.ui.autoupdate < 0) {
+                            settings.ui.autoupdate = 2;
+                        }
+                    }
+                    break;
+                case 8: // Enable or disable autodownload
+                    settings.ui.autodl = !settings.ui.autodl;
+                    break;
+                case 9: // Rom path
+                    if (hDown & KEY_A) {
+                        subscreenmode = SUBSCREEN_MODE_CHANGE_ROM_PATH;
+                    }
+                    break;
+            }
+            sfx = sfx_select;
+        } else if ((hDown & KEY_DOWN) && cursor_pos[0] < 9) {
+            cursor_pos[0]++;
+            if (is3DSX) {
+                if (cursor_pos[0] == 9) {
+                    cursor_pos[0]--;
+                }
+            }
+            sfx = sfx_select;
+        } else if ((hDown & KEY_UP) && cursor_pos[0] > 0) {
+            cursor_pos[0]--;
+            sfx = sfx_select;
+        } else if (hDown & KEY_R) {
+            subscreenmode = SUBSCREEN_MODE_NTR_TWL;
+            sfx = sfx_switch;
+        } else if (hDown & KEY_X) {
+            if (checkWifiStatus()) {
+                // Play the sound now instead of waiting.
+                if (dspfirmfound && sfx_select) {
+                    sfx_select->stop(); // Prevent freezing
+                    sfx_select->play();
+                }
+                UpdateBootstrapRelease();
+            } else {
+                // Wi-Fi is not connected.
+                sfx = sfx_wrong;
+            }
+        } else if (hDown & KEY_Y) {
+            if (checkWifiStatus()) {
+                // Play the sound now instead of waiting.
+                if (dspfirmfound && sfx_select) {
+                    sfx_select->stop(); // Prevent freezing
+                    sfx_select->play();
+                }
+                UpdateBootstrapUnofficial();
+            } else {
+                // Wi-Fi is not connected.
+                sfx = sfx_wrong;
+            }
+        } else if (hDown & KEY_START && checkWifiStatus() && !is3DSX) {
+            if (checkUpdate() == 0) {
+                // Play the sound now instead of waiting.
+                if (dspfirmfound && sfx_select) {
+                    sfx_select->stop(); // Prevent freezing
+                    sfx_select->play();
+                }
+                DownloadTWLoaderCIAs();
+            }
+        } else if (hDown & KEY_B) {
+            titleboxXmovetimer = 1;
+            fadeout = true;
+            sfx = sfx_back;
+        }
+        if (hDown & KEY_TOUCH) {
+            if (touch.px >= 248 && touch.py >= 220) {
+                subscreenmode = SUBSCREEN_MODE_NTR_TWL;
+                sfx = sfx_switch;
+            }
+        }
+    } else if (subscreenmode == SUBSCREEN_MODE_CHANGE_ROM_PATH) {
+        if (hDown & KEY_UP) {
+            cursor_pos[4]--;
+            if (cursor_pos[4] < 0) {
+                cursor_pos[4] = 0;
+            }
+            sfx = sfx_select;
+        } else if (hDown & KEY_DOWN) {
+            cursor_pos[4]++;
+            if (cursor_pos[4] > 1) {
+                cursor_pos[4] = 1;
+            }
+            sfx = sfx_select;
+        } else if (hDown & KEY_B) {
+            subscreenmode = SUBSCREEN_MODE_FRONTEND;
+            sfx = sfx_select;
+        } else if (hDown & KEY_A) {
+            std::string oldPath = (cursor_pos[4] == 0) ? settings.ui.romfolder : settings.ui.fcromfolder;
+            std::wstring widestr = (cursor_pos[4] == 0) ?
+                                   std::wstring(settings.ui.romfolder.begin(), settings.ui.romfolder.end()) :
+                                   std::wstring(settings.ui.fcromfolder.begin(), settings.ui.fcromfolder.end());
 
-			if(oldPath != newPath){						
-				// Buffers for APT_DoApplicationJump().
-				u8 param[0x300];
-				u8 hmac[0x20];
-				// Clear both buffers
-				memset(param, 0, sizeof(param));
-				memset(hmac, 0, sizeof(hmac));
-				
-				APT_PrepareToDoApplicationJump(0, 0x00040000047C4200LL, MEDIATYPE_SD);
-				// Tell APT to trigger the app launch and set the status of this app to exit
-				SaveSettings();
-				APT_DoApplicationJump(param, sizeof(param), hmac);
-			}
-		}
-	}
+            const wchar_t* currentPath = widestr.c_str();
+            std::string newPath = keyboardInput(currentPath);
 
-	// Do we need to play a sound effect?
-	if (dspfirmfound && sfx) {
-		sfx->stop();	// Prevent freezing
-		sfx->play();
-	}
+            (cursor_pos[4] == 0) ? settings.ui.romfolder = newPath : settings.ui.fcromfolder = newPath;
 
-	// Bottom screen needs to be redrawn.
-	return true;
+            if (oldPath != newPath) {
+                // Buffers for APT_DoApplicationJump().
+                u8 param[0x300];
+                u8 hmac[0x20];
+                // Clear both buffers
+                memset(param, 0, sizeof(param));
+                memset(hmac, 0, sizeof(hmac));
+
+                APT_PrepareToDoApplicationJump(0, 0x00040000047C4200LL, MEDIATYPE_SD);
+                // Tell APT to trigger the app launch and set the status of this app to exit
+                SaveSettings();
+                APT_DoApplicationJump(param, sizeof(param), hmac);
+            }
+        }
+    }
+
+    // Do we need to play a sound effect?
+    if (dspfirmfound && sfx) {
+        sfx->stop();    // Prevent freezing
+        sfx->play();
+    }
+
+    // Bottom screen needs to be redrawn.
+    return true;
 }
 
 /**
  * Load the primary color from the configuration.
  */
-void LoadColor(void) {
-	static const ColorData colors[] = {
-		{
-			"romfs:/graphics/topbg/0-gray.png",
-			"romfs:/graphics/dotcircle/0-gray.png",
-			"romfs:/graphics/start_border/0-gray.png",
-			(u32)RGBA8(99, 127, 127, 255)
-		},
-		{
-			"romfs:/graphics/topbg/1-brown.png",
-			"romfs:/graphics/dotcircle/1-brown.png",
-			"romfs:/graphics/start_border/1-brown.png",
-			(u32)RGBA8(139, 99, 0, 255)
-		},
-		{
-			"romfs:/graphics/topbg/2-red.png",
-			"romfs:/graphics/dotcircle/2-red.png",
-			"romfs:/graphics/start_border/2-red.png",
-			(u32)RGBA8(255, 0, 0, 255)
-		},
-		{
-			"romfs:/graphics/topbg/3-pink.png",
-			"romfs:/graphics/dotcircle/3-pink.png",
-			"romfs:/graphics/start_border/3-pink.png",
-			(u32)RGBA8(255, 127, 127, 255)
-		},
-		{
-			"romfs:/graphics/topbg/4-orange.png",
-			"romfs:/graphics/dotcircle/4-orange.png",
-			"romfs:/graphics/start_border/4-orange.png",
-			(u32)RGBA8(223, 63, 0, 255)
-		},
-		{
-			"romfs:/graphics/topbg/5-yellow.png",
-			"romfs:/graphics/dotcircle/5-yellow.png",
-			"romfs:/graphics/start_border/5-yellow.png",
-			(u32)RGBA8(215, 215, 0, 255)
-		},
-		{
-			"romfs:/graphics/topbg/6-yellowgreen.png",
-			"romfs:/graphics/dotcircle/6-yellowgreen.png",
-			"romfs:/graphics/start_border/6-yellowgreen.png",
-			(u32)RGBA8(215, 255, 0, 255)
-		},
-		{
-			"romfs:/graphics/topbg/7-green1.png",
-			"romfs:/graphics/dotcircle/7-green1.png",
-			"romfs:/graphics/start_border/7-green1.png",
-			(u32)RGBA8(0, 255, 0, 255)
-		},
-		{
-			"romfs:/graphics/topbg/8-green2.png",
-			"romfs:/graphics/dotcircle/8-green2.png",
-			"romfs:/graphics/start_border/8-green2.png",
-			(u32)RGBA8(63, 255, 63, 255)
-		},
-		{
-			"romfs:/graphics/topbg/9-lightgreen.png",
-			"romfs:/graphics/dotcircle/9-lightgreen.png",
-			"romfs:/graphics/start_border/9-lightgreen.png",
-			(u32)RGBA8(31, 231, 31, 255)
-		},
-		{
-			"romfs:/graphics/topbg/10-skyblue.png",
-			"romfs:/graphics/dotcircle/10-skyblue.png",
-			"romfs:/graphics/start_border/10-skyblue.png",
-			(u32)RGBA8(0, 63, 255, 255)
-		},
-		{
-			"romfs:/graphics/topbg/11-lightblue.png",
-			"romfs:/graphics/dotcircle/11-lightblue.png",
-			"romfs:/graphics/start_border/11-lightblue.png",
-			(u32)RGBA8(63, 63, 255, 255)
-		},
-		{
-			"romfs:/graphics/topbg/12-blue.png",
-			"romfs:/graphics/dotcircle/12-blue.png",
-			"romfs:/graphics/start_border/12-blue.png",
-			(u32)RGBA8(0, 0, 255, 255)
-		},
-		{
-			"romfs:/graphics/topbg/13-violet.png",
-			"romfs:/graphics/dotcircle/13-violet.png",
-			"romfs:/graphics/start_border/13-violet.png",
-			(u32)RGBA8(127, 0, 255, 255)
-		},
-		{
-			"romfs:/graphics/topbg/14-purple.png",
-			"romfs:/graphics/dotcircle/14-purple.png",
-			"romfs:/graphics/start_border/14-purple.png",
-			(u32)RGBA8(255, 0, 255, 255)
-		},
-		{
-			"romfs:/graphics/topbg/15-fuchsia.png",
-			"romfs:/graphics/dotcircle/15-fuchsia.png",
-			"romfs:/graphics/start_border/15-fuchsia.png",
-			(u32)RGBA8(255, 0, 127, 255)
-		},
-		{
-			"romfs:/graphics/topbg/16-red&blue.png",
-			"romfs:/graphics/dotcircle/16-red&blue.png",
-			"romfs:/graphics/start_border/16-red&blue.png",
-			(u32)RGBA8(255, 0, 255, 255)
-		},
-		{
-			"romfs:/graphics/topbg/17-green&yellow.png",
-			"romfs:/graphics/dotcircle/17-green&yellow.png",
-			"romfs:/graphics/start_border/17-green&yellow.png",
-			(u32)RGBA8(215, 215, 0, 255)
-		},
-		{
-			"romfs:/graphics/topbg/18-christmas.png",
-			"romfs:/graphics/dotcircle/18-christmas.png",
-			"romfs:/graphics/start_border/18-christmas.png",
-			(u32)RGBA8(255, 255, 0, 255)
-		},
-	};
+void LoadColor(void)
+{
+    static const ColorData colors[] = {
+        {
+            "romfs:/graphics/topbg/0-gray.png",
+            "romfs:/graphics/dotcircle/0-gray.png",
+            "romfs:/graphics/start_border/0-gray.png",
+            (u32)RGBA8(99, 127, 127, 255)
+        },
+        {
+            "romfs:/graphics/topbg/1-brown.png",
+            "romfs:/graphics/dotcircle/1-brown.png",
+            "romfs:/graphics/start_border/1-brown.png",
+            (u32)RGBA8(139, 99, 0, 255)
+        },
+        {
+            "romfs:/graphics/topbg/2-red.png",
+            "romfs:/graphics/dotcircle/2-red.png",
+            "romfs:/graphics/start_border/2-red.png",
+            (u32)RGBA8(255, 0, 0, 255)
+        },
+        {
+            "romfs:/graphics/topbg/3-pink.png",
+            "romfs:/graphics/dotcircle/3-pink.png",
+            "romfs:/graphics/start_border/3-pink.png",
+            (u32)RGBA8(255, 127, 127, 255)
+        },
+        {
+            "romfs:/graphics/topbg/4-orange.png",
+            "romfs:/graphics/dotcircle/4-orange.png",
+            "romfs:/graphics/start_border/4-orange.png",
+            (u32)RGBA8(223, 63, 0, 255)
+        },
+        {
+            "romfs:/graphics/topbg/5-yellow.png",
+            "romfs:/graphics/dotcircle/5-yellow.png",
+            "romfs:/graphics/start_border/5-yellow.png",
+            (u32)RGBA8(215, 215, 0, 255)
+        },
+        {
+            "romfs:/graphics/topbg/6-yellowgreen.png",
+            "romfs:/graphics/dotcircle/6-yellowgreen.png",
+            "romfs:/graphics/start_border/6-yellowgreen.png",
+            (u32)RGBA8(215, 255, 0, 255)
+        },
+        {
+            "romfs:/graphics/topbg/7-green1.png",
+            "romfs:/graphics/dotcircle/7-green1.png",
+            "romfs:/graphics/start_border/7-green1.png",
+            (u32)RGBA8(0, 255, 0, 255)
+        },
+        {
+            "romfs:/graphics/topbg/8-green2.png",
+            "romfs:/graphics/dotcircle/8-green2.png",
+            "romfs:/graphics/start_border/8-green2.png",
+            (u32)RGBA8(63, 255, 63, 255)
+        },
+        {
+            "romfs:/graphics/topbg/9-lightgreen.png",
+            "romfs:/graphics/dotcircle/9-lightgreen.png",
+            "romfs:/graphics/start_border/9-lightgreen.png",
+            (u32)RGBA8(31, 231, 31, 255)
+        },
+        {
+            "romfs:/graphics/topbg/10-skyblue.png",
+            "romfs:/graphics/dotcircle/10-skyblue.png",
+            "romfs:/graphics/start_border/10-skyblue.png",
+            (u32)RGBA8(0, 63, 255, 255)
+        },
+        {
+            "romfs:/graphics/topbg/11-lightblue.png",
+            "romfs:/graphics/dotcircle/11-lightblue.png",
+            "romfs:/graphics/start_border/11-lightblue.png",
+            (u32)RGBA8(63, 63, 255, 255)
+        },
+        {
+            "romfs:/graphics/topbg/12-blue.png",
+            "romfs:/graphics/dotcircle/12-blue.png",
+            "romfs:/graphics/start_border/12-blue.png",
+            (u32)RGBA8(0, 0, 255, 255)
+        },
+        {
+            "romfs:/graphics/topbg/13-violet.png",
+            "romfs:/graphics/dotcircle/13-violet.png",
+            "romfs:/graphics/start_border/13-violet.png",
+            (u32)RGBA8(127, 0, 255, 255)
+        },
+        {
+            "romfs:/graphics/topbg/14-purple.png",
+            "romfs:/graphics/dotcircle/14-purple.png",
+            "romfs:/graphics/start_border/14-purple.png",
+            (u32)RGBA8(255, 0, 255, 255)
+        },
+        {
+            "romfs:/graphics/topbg/15-fuchsia.png",
+            "romfs:/graphics/dotcircle/15-fuchsia.png",
+            "romfs:/graphics/start_border/15-fuchsia.png",
+            (u32)RGBA8(255, 0, 127, 255)
+        },
+        {
+            "romfs:/graphics/topbg/16-red&blue.png",
+            "romfs:/graphics/dotcircle/16-red&blue.png",
+            "romfs:/graphics/start_border/16-red&blue.png",
+            (u32)RGBA8(255, 0, 255, 255)
+        },
+        {
+            "romfs:/graphics/topbg/17-green&yellow.png",
+            "romfs:/graphics/dotcircle/17-green&yellow.png",
+            "romfs:/graphics/start_border/17-green&yellow.png",
+            (u32)RGBA8(215, 215, 0, 255)
+        },
+        {
+            "romfs:/graphics/topbg/18-christmas.png",
+            "romfs:/graphics/dotcircle/18-christmas.png",
+            "romfs:/graphics/start_border/18-christmas.png",
+            (u32)RGBA8(255, 255, 0, 255)
+        },
+    };
 
-	if (settings.ui.color < 0 || settings.ui.color > 18)
-		settings.ui.color = 0;
-	color_data = &colors[settings.ui.color];
-	if (logEnabled)	LogFM("LoadColor()", "Colors load successfully");
+    if (settings.ui.color < 0 || settings.ui.color > 18) {
+        settings.ui.color = 0;
+    }
+    color_data = &colors[settings.ui.color];
+    if (logEnabled) {
+        LogFM("LoadColor()", "Colors load successfully");
+    }
 }
 
 /**
  * Load the menu color from the configuration.
  */
-void LoadMenuColor(void) {
-	static const u32 menu_colors[] = {
-		(u32)RGBA8(255, 255, 255, 255),		// White
-		(u32)RGBA8(63, 63, 63, 195),		// Black
-		(u32)RGBA8(139, 99, 0, 195),		// Brown
-		(u32)RGBA8(255, 0, 0, 195),		// Red
-		(u32)RGBA8(255, 163, 163, 195),		// Pink
-		(u32)RGBA8(255, 127, 0, 223),		// Orange
-		(u32)RGBA8(255, 255, 0, 223),		// Yellow
-		(u32)RGBA8(215, 255, 0, 223),		// Yellow-Green
-		(u32)RGBA8(0, 255, 0, 223),		// Green 1
-		(u32)RGBA8(95, 223, 95, 193),		// Green 2
-		(u32)RGBA8(127, 231, 127, 223),		// Light Green
-		(u32)RGBA8(63, 127, 255, 223),		// Sky Blue
-		(u32)RGBA8(127, 127, 255, 223),		// Light Blue
-		(u32)RGBA8(0, 0, 255, 195),		// Blue
-		(u32)RGBA8(127, 0, 255, 195),		// Violet
-		(u32)RGBA8(255, 0, 255, 195),		// Purple
-		(u32)RGBA8(255, 63, 127, 195),		// Fuchsia
-	};
+void LoadMenuColor(void)
+{
+    static const u32 menu_colors[] = {
+        (u32)RGBA8(255, 255, 255, 255),     // White
+        (u32)RGBA8(63, 63, 63, 195),        // Black
+        (u32)RGBA8(139, 99, 0, 195),        // Brown
+        (u32)RGBA8(255, 0, 0, 195),     // Red
+        (u32)RGBA8(255, 163, 163, 195),     // Pink
+        (u32)RGBA8(255, 127, 0, 223),       // Orange
+        (u32)RGBA8(255, 255, 0, 223),       // Yellow
+        (u32)RGBA8(215, 255, 0, 223),       // Yellow-Green
+        (u32)RGBA8(0, 255, 0, 223),     // Green 1
+        (u32)RGBA8(95, 223, 95, 193),       // Green 2
+        (u32)RGBA8(127, 231, 127, 223),     // Light Green
+        (u32)RGBA8(63, 127, 255, 223),      // Sky Blue
+        (u32)RGBA8(127, 127, 255, 223),     // Light Blue
+        (u32)RGBA8(0, 0, 255, 195),     // Blue
+        (u32)RGBA8(127, 0, 255, 195),       // Violet
+        (u32)RGBA8(255, 0, 255, 195),       // Purple
+        (u32)RGBA8(255, 63, 127, 195),      // Fuchsia
+    };
 
-	if (settings.ui.menucolor < 0 || settings.ui.menucolor > 16)
-		settings.ui.menucolor = 0;
-	menucolor = menu_colors[settings.ui.menucolor];
-	if (logEnabled)	LogFM("LoadMenuColor()", "Menu color load successfully");
+    if (settings.ui.menucolor < 0 || settings.ui.menucolor > 16) {
+        settings.ui.menucolor = 0;
+    }
+    menucolor = menu_colors[settings.ui.menucolor];
+    if (logEnabled) {
+        LogFM("LoadMenuColor()", "Menu color load successfully");
+    }
 }
 
 /**
  * Load the filename of the bottom screen image.
  */
-void LoadBottomImage() {
-	bottomloc = "romfs:/graphics/bottom.png";
+void LoadBottomImage()
+{
+    bottomloc = "romfs:/graphics/bottom.png";
 
-	if (settings.ui.custombot == 1) {
-		if( access( "sdmc:/_nds/twloader/bottom.png", F_OK ) != -1 ) {
-			bottomloc = "sdmc:/_nds/twloader/bottom.png";
-			if (logEnabled)	LogFM("LoadBottomImage()", "Using custom bottom image. Method load successfully");
-		} else {
-			bottomloc = "romfs:/graphics/bottom.png";
-			if (logEnabled)	LogFM("LoadBottomImage()", "Using default bottom image. Method load successfully");
-		}
-	}
+    if (settings.ui.custombot == 1) {
+        if (access("sdmc:/_nds/twloader/bottom.png", F_OK) != -1) {
+            bottomloc = "sdmc:/_nds/twloader/bottom.png";
+            if (logEnabled) {
+                LogFM("LoadBottomImage()", "Using custom bottom image. Method load successfully");
+            }
+        } else {
+            bottomloc = "romfs:/graphics/bottom.png";
+            if (logEnabled) {
+                LogFM("LoadBottomImage()", "Using default bottom image. Method load successfully");
+            }
+        }
+    }
 }
 
 /**
@@ -1336,116 +1365,120 @@ void LoadBottomImage() {
  */
 static void RemoveTrailingSlashes(string& path)
 {
-	while (!path.empty() && path[path.size()-1] == '/') {
-		path.resize(path.size()-1);
-	}
+    while (!path.empty() && path[path.size() - 1] == '/') {
+        path.resize(path.size() - 1);
+    }
 }
 
 /**
  * Load settings.
  */
-void LoadSettings(void) {
-	// UI settings.
-	settings.ui.name = settingsini.GetString("FRONTEND", "NAME", "");
-	settings.ui.romfolder = settingsini.GetString("FRONTEND", "ROM_FOLDER", "");
-	RemoveTrailingSlashes(settings.ui.romfolder);
-	settings.ui.fcromfolder = settingsini.GetString("FRONTEND", "FCROM_FOLDER", "");
-	RemoveTrailingSlashes(settings.ui.fcromfolder);
+void LoadSettings(void)
+{
+    // UI settings.
+    settings.ui.name = settingsini.GetString("FRONTEND", "NAME", "");
+    settings.ui.romfolder = settingsini.GetString("FRONTEND", "ROM_FOLDER", "");
+    RemoveTrailingSlashes(settings.ui.romfolder);
+    settings.ui.fcromfolder = settingsini.GetString("FRONTEND", "FCROM_FOLDER", "");
+    RemoveTrailingSlashes(settings.ui.fcromfolder);
 
-	// Customizable UI settings.
-	settings.ui.language = settingsini.GetInt("FRONTEND", "LANGUAGE", -1);
-	settings.ui.theme = settingsini.GetInt("FRONTEND", "THEME", 0);
-	settings.ui.subtheme = settingsini.GetInt("FRONTEND", "SUB_THEME", 0);
-	settings.ui.color = settingsini.GetInt("FRONTEND", "COLOR", 0);
-	settings.ui.menucolor = settingsini.GetInt("FRONTEND", "MENU_COLOR", 0);
-	settings.ui.filename = settingsini.GetInt("FRONTEND", "SHOW_FILENAME", 0);
-	settings.ui.topborder = settingsini.GetInt("FRONTEND", "TOP_BORDER", 1);
-	settings.ui.iconsize = settingsini.GetInt("FRONTEND", "ICON_SIZE", 0);
-	settings.ui.counter = settingsini.GetInt("FRONTEND", "COUNTER", 0);
-	settings.ui.custombot = settingsini.GetInt("FRONTEND", "CUSTOM_BOTTOM", 0);
-	settings.romselect.toplayout = settingsini.GetInt("FRONTEND", "TOP_LAYOUT", 0);
-	settings.ui.autoupdate = settingsini.GetInt("FRONTEND", "AUTOUPDATE", 0);
-	settings.ui.autodl = settingsini.GetInt("FRONTEND", "AUTODOWNLOAD", 0);
-	// romselect_layout = settingsini.GetInt("FRONTEND", "BOTTOM_LAYOUT", 0);
+    // Customizable UI settings.
+    settings.ui.language = settingsini.GetInt("FRONTEND", "LANGUAGE", -1);
+    settings.ui.theme = settingsini.GetInt("FRONTEND", "THEME", 0);
+    settings.ui.subtheme = settingsini.GetInt("FRONTEND", "SUB_THEME", 0);
+    settings.ui.color = settingsini.GetInt("FRONTEND", "COLOR", 0);
+    settings.ui.menucolor = settingsini.GetInt("FRONTEND", "MENU_COLOR", 0);
+    settings.ui.filename = settingsini.GetInt("FRONTEND", "SHOW_FILENAME", 0);
+    settings.ui.topborder = settingsini.GetInt("FRONTEND", "TOP_BORDER", 1);
+    settings.ui.iconsize = settingsini.GetInt("FRONTEND", "ICON_SIZE", 0);
+    settings.ui.counter = settingsini.GetInt("FRONTEND", "COUNTER", 0);
+    settings.ui.custombot = settingsini.GetInt("FRONTEND", "CUSTOM_BOTTOM", 0);
+    settings.romselect.toplayout = settingsini.GetInt("FRONTEND", "TOP_LAYOUT", 0);
+    settings.ui.autoupdate = settingsini.GetInt("FRONTEND", "AUTOUPDATE", 0);
+    settings.ui.autodl = settingsini.GetInt("FRONTEND", "AUTODOWNLOAD", 0);
+    // romselect_layout = settingsini.GetInt("FRONTEND", "BOTTOM_LAYOUT", 0);
 
-	// TWL settings.
-	settings.twl.rainbowled = settingsini.GetInt("TWL-MODE", "RAINBOW_LED", 0);
-	settings.twl.cpuspeed = settingsini.GetInt("TWL-MODE", "TWL_CLOCK", 0);
-	settings.twl.extvram = settingsini.GetInt("TWL-MODE", "TWL_VRAM", 1);
-	settings.twl.lockarm9scfgext = settingsini.GetInt("TWL-MODE", "LOCK_ARM9_SCFG_EXT", 0);
-	settings.twl.bootscreen = settingsini.GetInt("TWL-MODE", "BOOT_ANIMATION", 1);
-	settings.twl.healthsafety = settingsini.GetInt("TWL-MODE", "HEALTH&SAFETY_MSG", 1);
-	settings.twl.resetslot1 = settingsini.GetInt("TWL-MODE", "RESET_SLOT1", 0);
-	settings.twl.forwarder = settingsini.GetInt("TWL-MODE", "FORWARDER", 0);
-	settings.twl.flashcard = settingsini.GetInt("TWL-MODE", "FLASHCARD", 0);
-	settings.twl.bootstrapfile = settingsini.GetInt("TWL-MODE", "BOOTSTRAP_FILE", 0);
+    // TWL settings.
+    settings.twl.rainbowled = settingsini.GetInt("TWL-MODE", "RAINBOW_LED", 0);
+    settings.twl.cpuspeed = settingsini.GetInt("TWL-MODE", "TWL_CLOCK", 0);
+    settings.twl.extvram = settingsini.GetInt("TWL-MODE", "TWL_VRAM", 1);
+    settings.twl.lockarm9scfgext = settingsini.GetInt("TWL-MODE", "LOCK_ARM9_SCFG_EXT", 0);
+    settings.twl.bootscreen = settingsini.GetInt("TWL-MODE", "BOOT_ANIMATION", 1);
+    settings.twl.healthsafety = settingsini.GetInt("TWL-MODE", "HEALTH&SAFETY_MSG", 1);
+    settings.twl.resetslot1 = settingsini.GetInt("TWL-MODE", "RESET_SLOT1", 0);
+    settings.twl.forwarder = settingsini.GetInt("TWL-MODE", "FORWARDER", 0);
+    settings.twl.flashcard = settingsini.GetInt("TWL-MODE", "FLASHCARD", 0);
+    settings.twl.bootstrapfile = settingsini.GetInt("TWL-MODE", "BOOTSTRAP_FILE", 0);
 
-	// TODO: Change the default to -1?
-	switch (settingsini.GetInt("TWL-MODE", "DEBUG", 0)) {
-		case 1:
-			settings.twl.console = 2;
-			break;
-		case 0:
-		default:
-			settings.twl.console = 1;
-			break;
-		case -1:
-			settings.twl.console = 0;
-			break;
-	}
-	if (logEnabled)	LogFM("Settings.LoadSettings", "Settings loaded successfully");
+    // TODO: Change the default to -1?
+    switch (settingsini.GetInt("TWL-MODE", "DEBUG", 0)) {
+        case 1:
+            settings.twl.console = 2;
+            break;
+        case 0:
+        default:
+            settings.twl.console = 1;
+            break;
+        case -1:
+            settings.twl.console = 0;
+            break;
+    }
+    if (logEnabled) {
+        LogFM("Settings.LoadSettings", "Settings loaded successfully");
+    }
 }
 
 /**
  * Save settings.
  */
-void SaveSettings(void) {
-	// UI settings.
-	settingsini.SetString("FRONTEND", "ROM_FOLDER", settings.ui.romfolder);
-	settingsini.SetString("FRONTEND", "FCROM_FOLDER", settings.ui.fcromfolder);
-	settingsini.SetInt("FRONTEND", "LANGUAGE", settings.ui.language);
-	settingsini.SetInt("FRONTEND", "THEME", settings.ui.theme);
-	settingsini.SetInt("FRONTEND", "SUB_THEME", settings.ui.subtheme);
-	settingsini.SetInt("FRONTEND", "COLOR", settings.ui.color);
-	settingsini.SetInt("FRONTEND", "MENU_COLOR", settings.ui.menucolor);
-	settingsini.SetInt("FRONTEND", "SHOW_FILENAME", settings.ui.filename);
-	settingsini.SetInt("FRONTEND", "TOP_BORDER", settings.ui.topborder);
-	settingsini.SetInt("FRONTEND", "ICON_SIZE", settings.ui.iconsize);
-	settingsini.SetInt("FRONTEND", "COUNTER", settings.ui.counter);
-	settingsini.SetInt("FRONTEND", "CUSTOM_BOTTOM", settings.ui.custombot);
-	settingsini.SetInt("FRONTEND", "TOP_LAYOUT", settings.romselect.toplayout);
-	settingsini.SetInt("FRONTEND", "AUTOUPDATE", settings.ui.autoupdate);
-	settingsini.SetInt("FRONTEND", "AUTODOWNLOAD", settings.ui.autodl);
-	//settingsini.SetInt("FRONTEND", "BOTTOM_LAYOUT", romselect_layout);
+void SaveSettings(void)
+{
+    // UI settings.
+    settingsini.SetString("FRONTEND", "ROM_FOLDER", settings.ui.romfolder);
+    settingsini.SetString("FRONTEND", "FCROM_FOLDER", settings.ui.fcromfolder);
+    settingsini.SetInt("FRONTEND", "LANGUAGE", settings.ui.language);
+    settingsini.SetInt("FRONTEND", "THEME", settings.ui.theme);
+    settingsini.SetInt("FRONTEND", "SUB_THEME", settings.ui.subtheme);
+    settingsini.SetInt("FRONTEND", "COLOR", settings.ui.color);
+    settingsini.SetInt("FRONTEND", "MENU_COLOR", settings.ui.menucolor);
+    settingsini.SetInt("FRONTEND", "SHOW_FILENAME", settings.ui.filename);
+    settingsini.SetInt("FRONTEND", "TOP_BORDER", settings.ui.topborder);
+    settingsini.SetInt("FRONTEND", "ICON_SIZE", settings.ui.iconsize);
+    settingsini.SetInt("FRONTEND", "COUNTER", settings.ui.counter);
+    settingsini.SetInt("FRONTEND", "CUSTOM_BOTTOM", settings.ui.custombot);
+    settingsini.SetInt("FRONTEND", "TOP_LAYOUT", settings.romselect.toplayout);
+    settingsini.SetInt("FRONTEND", "AUTOUPDATE", settings.ui.autoupdate);
+    settingsini.SetInt("FRONTEND", "AUTODOWNLOAD", settings.ui.autodl);
+    //settingsini.SetInt("FRONTEND", "BOTTOM_LAYOUT", romselect_layout);
 
-	// TWL settings.
-	settingsini.SetInt("TWL-MODE", "RAINBOW_LED", settings.twl.rainbowled);
-	settingsini.SetInt("TWL-MODE", "TWL_CLOCK", settings.twl.cpuspeed);
-	settingsini.SetInt("TWL-MODE", "TWL_VRAM", settings.twl.extvram);
-	settingsini.SetInt("TWL-MODE", "LOCK_ARM9_SCFG_EXT", settings.twl.lockarm9scfgext);
-	settingsini.SetInt("TWL-MODE", "BOOT_ANIMATION", settings.twl.bootscreen);
-	settingsini.SetInt("TWL-MODE", "HEALTH&SAFETY_MSG", settings.twl.healthsafety);
-	settingsini.SetInt("TWL-MODE", "LAUNCH_SLOT1", settings.twl.launchslot1);
-	settingsini.SetInt("TWL-MODE", "RESET_SLOT1", settings.twl.resetslot1);
-	settingsini.SetInt("TWL-MODE", "SLOT1_KEEPSD", keepsdvalue);
-	settingsini.SetInt("TWL-MODE", "BOOTSTRAP_FILE", settings.twl.bootstrapfile);
+    // TWL settings.
+    settingsini.SetInt("TWL-MODE", "RAINBOW_LED", settings.twl.rainbowled);
+    settingsini.SetInt("TWL-MODE", "TWL_CLOCK", settings.twl.cpuspeed);
+    settingsini.SetInt("TWL-MODE", "TWL_VRAM", settings.twl.extvram);
+    settingsini.SetInt("TWL-MODE", "LOCK_ARM9_SCFG_EXT", settings.twl.lockarm9scfgext);
+    settingsini.SetInt("TWL-MODE", "BOOT_ANIMATION", settings.twl.bootscreen);
+    settingsini.SetInt("TWL-MODE", "HEALTH&SAFETY_MSG", settings.twl.healthsafety);
+    settingsini.SetInt("TWL-MODE", "LAUNCH_SLOT1", settings.twl.launchslot1);
+    settingsini.SetInt("TWL-MODE", "RESET_SLOT1", settings.twl.resetslot1);
+    settingsini.SetInt("TWL-MODE", "SLOT1_KEEPSD", keepsdvalue);
+    settingsini.SetInt("TWL-MODE", "BOOTSTRAP_FILE", settings.twl.bootstrapfile);
 
-	// TODO: Change default to 0?
-	switch (settings.twl.console) {
-		case 0:
-			settingsini.SetInt("TWL-MODE", "DEBUG", -1);
-			break;
-		case 1:
-		default:
-			settingsini.SetInt("TWL-MODE", "DEBUG", 0);
-			break;
-		case 2:
-			settingsini.SetInt("TWL-MODE", "DEBUG", 1);
-			break;
-	}
+    // TODO: Change default to 0?
+    switch (settings.twl.console) {
+        case 0:
+            settingsini.SetInt("TWL-MODE", "DEBUG", -1);
+            break;
+        case 1:
+        default:
+            settingsini.SetInt("TWL-MODE", "DEBUG", 0);
+            break;
+        case 2:
+            settingsini.SetInt("TWL-MODE", "DEBUG", 1);
+            break;
+    }
 
-	settingsini.SetInt("TWL-MODE", "FORWARDER", settings.twl.forwarder);
-	settingsini.SetInt("TWL-MODE", "FLASHCARD", settings.twl.flashcard);
-	settingsini.SetInt("TWL-MODE", "GBARUNNER", gbarunnervalue);
-	settingsini.SaveIniFile("sdmc:/_nds/twloader/settings.ini");
+    settingsini.SetInt("TWL-MODE", "FORWARDER", settings.twl.forwarder);
+    settingsini.SetInt("TWL-MODE", "FLASHCARD", settings.twl.flashcard);
+    settingsini.SetInt("TWL-MODE", "GBARUNNER", gbarunnervalue);
+    settingsini.SaveIniFile("sdmc:/_nds/twloader/settings.ini");
 }

--- a/gui/source/settings.h
+++ b/gui/source/settings.h
@@ -6,7 +6,7 @@
 
 // Textures.
 #include <sf2d.h>
-extern sf2d_texture *settingstex;
+extern sf2d_texture* settingstex;
 
 /** Settings **/
 
@@ -14,93 +14,93 @@ extern sf2d_texture *settingstex;
 // Use SET_ALPHA() to replace the alpha value.
 #define SET_ALPHA(color, alpha) ((((alpha) & 0xFF) << 24) | ((color) & 0x00FFFFFF))
 typedef struct _ColorData {
-	const char *topbgloc;
-	const char *dotcircleloc;
-	const char *startborderloc;
-	u32 color;
+    const char* topbgloc;
+    const char* dotcircleloc;
+    const char* startborderloc;
+    u32 color;
 } ColorData;
-extern const ColorData *color_data;
+extern const ColorData* color_data;
 extern u32 menucolor;
 
 // 3D offsets.
 typedef struct _Offset3D {
-	float topbg;
-	float boxart;
-	float disabled;
+    float topbg;
+    float boxart;
+    float disabled;
 } Offset3D;
-extern Offset3D offset3D[2];	// 0 == Left; 1 == Right
+extern Offset3D offset3D[2];    // 0 == Left; 1 == Right
 
 // Location of the bottom screen image.
 extern const char* bottomloc;
 
 typedef struct _Settings_t {
-	struct {
-		bool toplayout;
-		//	0: Show box art
-		//	1: Hide box art
-	} romselect;
+    struct {
+        bool toplayout;
+        //  0: Show box art
+        //  1: Hide box art
+    } romselect;
 
-	// TODO: Use int8_t instead of int?
-	struct {
-		std::string name;
-		std::string romfolder;
-		std::string fcromfolder;
-    
-		int language;	// Language. (0-11; other for system)
-		int theme;
-		int subtheme;
-		int color;
-		int menucolor;
-		bool filename;
-		bool locswitch;
-		bool topborder;
-		bool iconsize;
-		bool counter;
-		bool custombot;
-		int autoupdate;	// 0 = Off, 1 = Release, 2 = Unofficial
-		bool autodl;
-	} ui;
+    // TODO: Use int8_t instead of int?
+    struct {
+        std::string name;
+        std::string romfolder;
+        std::string fcromfolder;
 
-	struct {
-		bool rainbowled;
-		bool cpuspeed;	// false == NTR, true == TWL
-		bool extvram;
-		bool forwarder;
+        int language;   // Language. (0-11; other for system)
+        int theme;
+        int subtheme;
+        int color;
+        int menucolor;
+        bool filename;
+        bool locswitch;
+        bool topborder;
+        bool iconsize;
+        bool counter;
+        bool custombot;
+        int autoupdate; // 0 = Off, 1 = Release, 2 = Unofficial
+        bool autodl;
+    } ui;
 
-		int flashcard;
-		/* Flashcard value
-			0: DSTT/R4i Gold/R4i-SDHC/R4 SDHC Dual-Core/R4 SDHC Upgrade/SC DSONE
-			1: R4DS (Original Non-SDHC version)/ M3 Simply
-			2: R4iDSN/R4i Gold RTS
-			3: Acekard 2(i)/Galaxy Eagle/M3DS Real
-			4: Acekard RPG
-			5: Ace 3DS+/Gateway Blue Card/R4iTT
-			6: SuperCard DSTWO
-		*/
+    struct {
+        bool rainbowled;
+        bool cpuspeed;  // false == NTR, true == TWL
+        bool extvram;
+        bool forwarder;
 
-		int bootscreen;	// 0 = None, 1 = Nintendo DS, 2 = Nintendo DSi
-		bool healthsafety;
-		bool launchslot1;
-		bool resetslot1;
-		int console;	// 0 = Off, 1 = On, 2 = On (Debug)
-		bool lockarm9scfgext;
-		
-		int mpuregion; // Region 0, 1, 2, 3
-		int mpusize; // Size 0, 1, 3145728
-		
-		bool bootstrapfile; // true == release, false == unofficial
-	} twl;
-	
-	struct {
-		// -1 == default; 0 == off, 1 == on
-		s8 cpuspeed;	// false == NTR, true == TWL
-		s8 extvram;
-		s8 lockarm9scfgext;
-		s8 donor;
-		int red;
-		int green;
-		int blue;
-	} pergame;
+        int flashcard;
+        /* Flashcard value
+            0: DSTT/R4i Gold/R4i-SDHC/R4 SDHC Dual-Core/R4 SDHC Upgrade/SC DSONE
+            1: R4DS (Original Non-SDHC version)/ M3 Simply
+            2: R4iDSN/R4i Gold RTS
+            3: Acekard 2(i)/Galaxy Eagle/M3DS Real
+            4: Acekard RPG
+            5: Ace 3DS+/Gateway Blue Card/R4iTT
+            6: SuperCard DSTWO
+        */
+
+        int bootscreen; // 0 = None, 1 = Nintendo DS, 2 = Nintendo DSi
+        bool healthsafety;
+        bool launchslot1;
+        bool resetslot1;
+        int console;    // 0 = Off, 1 = On, 2 = On (Debug)
+        bool lockarm9scfgext;
+
+        int mpuregion; // Region 0, 1, 2, 3
+        int mpusize; // Size 0, 1, 3145728
+
+        bool bootstrapfile; // true == release, false == unofficial
+    } twl;
+
+    struct {
+        // -1 == default; 0 == off, 1 == on
+        s8 cpuspeed;    // false == NTR, true == TWL
+        s8 extvram;
+        s8 lockarm9scfgext;
+        s8 donor;
+        int red;
+        int green;
+        int blue;
+    } pergame;
 } Settings_t;
 extern Settings_t settings;
 

--- a/gui/source/smdh.h
+++ b/gui/source/smdh.h
@@ -3,28 +3,28 @@
 #define TWLOADER_SMDH_H
 
 typedef struct {
-	u16 shortDescription[0x40];
-	u16 longDescription[0x80];
-	u16 publisher[0x40];
+    u16 shortDescription[0x40];
+    u16 longDescription[0x80];
+    u16 publisher[0x40];
 } SMDH_title;
 
 typedef struct {
-	char magic[0x04];
-	u16 version;
-	u16 reserved1;
-	SMDH_title titles[0x10];
-	u8 ratings[0x10];
-	u32 region;
-	u32 matchMakerId;
-	u64 matchMakerBitId;
-	u32 flags;
-	u16 eulaVersion;
-	u16 reserved;
-	u32 optimalBannerFrame;
-	u32 streetpassId;
-	u64 reserved2;
-	u8 smallIcon[0x480];
-	u8 largeIcon[0x1200];
+    char magic[0x04];
+    u16 version;
+    u16 reserved1;
+    SMDH_title titles[0x10];
+    u8 ratings[0x10];
+    u32 region;
+    u32 matchMakerId;
+    u64 matchMakerBitId;
+    u32 flags;
+    u16 eulaVersion;
+    u16 reserved;
+    u32 optimalBannerFrame;
+    u32 streetpassId;
+    u64 reserved2;
+    u8 smallIcon[0x480];
+    u8 largeIcon[0x1200];
 } SMDH;
 
 #endif /* TWLOADER_SMDH_H */

--- a/gui/source/sound.cpp
+++ b/gui/source/sound.cpp
@@ -9,125 +9,126 @@ using std::string;
 
 // Reference: http://yannesposito.com/Scratch/en/blog/2010-10-14-Fun-with-wav/
 typedef struct _WavHeader {
-	char magic[4];		// "RIFF"
-	u32 totallength;	// Total file length, minus 8.
-	char wavefmt[8];	// Should be "WAVEfmt "
-	u32 format;		// 16 for PCM format
-	u16 pcm;		// 1 for PCM format
-	u16 channels;		// Channels
-	u32 frequency;		// Sampling frequency
-	u32 bytes_per_second;
-	u16 bytes_by_capture;
-	u16 bits_per_sample;
-	char data[4];		// "data"
-	u32 bytes_in_data;
+    char magic[4];      // "RIFF"
+    u32 totallength;    // Total file length, minus 8.
+    char wavefmt[8];    // Should be "WAVEfmt "
+    u32 format;     // 16 for PCM format
+    u16 pcm;        // 1 for PCM format
+    u16 channels;       // Channels
+    u32 frequency;      // Sampling frequency
+    u32 bytes_per_second;
+    u16 bytes_by_capture;
+    u16 bits_per_sample;
+    char data[4];       // "data"
+    u32 bytes_in_data;
 } WavHeader;
 static_assert(sizeof(WavHeader) == 44, "WavHeader size is not 44 bytes.");
 
 sound::sound(const string& path, int channel, bool toloop)
 {
 
-	ndspSetOutputMode(NDSP_OUTPUT_STEREO);
-	ndspSetOutputCount(2); // Num of buffers
+    ndspSetOutputMode(NDSP_OUTPUT_STEREO);
+    ndspSetOutputCount(2); // Num of buffers
 
-	// Reading wav file
-	FILE* fp = fopen(path.c_str(), "rb");
+    // Reading wav file
+    FILE* fp = fopen(path.c_str(), "rb");
 
-	if (!fp) {
-		printf("Could not open the WAV file: %s\n", path.c_str());
-		return;
-	}
+    if (!fp) {
+        printf("Could not open the WAV file: %s\n", path.c_str());
+        return;
+    }
 
-	WavHeader wavHeader;
-	size_t read = fread(&wavHeader, 1, sizeof(wavHeader), fp);
-	if (read != sizeof(wavHeader)) {
-		// Short read.
-		printf("WAV file header is too short: %s\n", path.c_str());
-		fclose(fp);
-		return;
-	}
+    WavHeader wavHeader;
+    size_t read = fread(&wavHeader, 1, sizeof(wavHeader), fp);
+    if (read != sizeof(wavHeader)) {
+        // Short read.
+        printf("WAV file header is too short: %s\n", path.c_str());
+        fclose(fp);
+        return;
+    }
 
-	// Verify the header.
-	static const char RIFF_magic[4] = {'R','I','F','F'};
-	if (memcmp(wavHeader.magic, RIFF_magic, sizeof(wavHeader.magic)) != 0) {
-		// Incorrect magic number.
-		printf("Wrong file format.\n");
-		fclose(fp);
-		return;
-	}
+    // Verify the header.
+    static const char RIFF_magic[4] = {'R', 'I', 'F', 'F'};
+    if (memcmp(wavHeader.magic, RIFF_magic, sizeof(wavHeader.magic)) != 0) {
+        // Incorrect magic number.
+        printf("Wrong file format.\n");
+        fclose(fp);
+        return;
+    }
 
-	if (wavHeader.totallength == 0 ||
-	   (wavHeader.channels != 1 && wavHeader.channels != 2) ||
-	   (wavHeader.bits_per_sample != 8 && wavHeader.bits_per_sample != 16))
-	{
-		// Unsupported WAV file.
-		printf("Corrupted wav file.\n");
-		fclose(fp);
-		return;
-	}
+    if (wavHeader.totallength == 0 ||
+            (wavHeader.channels != 1 && wavHeader.channels != 2) ||
+            (wavHeader.bits_per_sample != 8 && wavHeader.bits_per_sample != 16)) {
+        // Unsupported WAV file.
+        printf("Corrupted wav file.\n");
+        fclose(fp);
+        return;
+    }
 
-	// Get the file size.
-	fseek(fp, 0, SEEK_END);
-	dataSize = ftell(fp) - sizeof(wavHeader);
+    // Get the file size.
+    fseek(fp, 0, SEEK_END);
+    dataSize = ftell(fp) - sizeof(wavHeader);
 
-	// Allocating and reading samples
-	data = static_cast<u8*>(linearAlloc(dataSize));
-	fseek(fp, 44, SEEK_SET);
-	fread(data, 1, dataSize, fp);
-	fclose(fp);
-	dataSize /= 2;	// FIXME: 16-bit or stereo?
+    // Allocating and reading samples
+    data = static_cast<u8*>(linearAlloc(dataSize));
+    fseek(fp, 44, SEEK_SET);
+    fread(data, 1, dataSize, fp);
+    fclose(fp);
+    dataSize /= 2;  // FIXME: 16-bit or stereo?
 
-	// Find the right format
-	u16 ndspFormat;
-	if (wavHeader.bits_per_sample == 8) {
-		ndspFormat = (wavHeader.channels == 1) ?
-			NDSP_FORMAT_MONO_PCM8 :
-			NDSP_FORMAT_STEREO_PCM8;
-	} else {
-		ndspFormat = (wavHeader.channels == 1) ?
-			NDSP_FORMAT_MONO_PCM16 :
-			NDSP_FORMAT_STEREO_PCM16;
-	}
+    // Find the right format
+    u16 ndspFormat;
+    if (wavHeader.bits_per_sample == 8) {
+        ndspFormat = (wavHeader.channels == 1) ?
+                     NDSP_FORMAT_MONO_PCM8 :
+                     NDSP_FORMAT_STEREO_PCM8;
+    } else {
+        ndspFormat = (wavHeader.channels == 1) ?
+                     NDSP_FORMAT_MONO_PCM16 :
+                     NDSP_FORMAT_STEREO_PCM16;
+    }
 
-	ndspChnReset(channel);
-	ndspChnSetInterp(channel, NDSP_INTERP_NONE);
-	ndspChnSetRate(channel, float(wavHeader.frequency));
-	ndspChnSetFormat(channel, ndspFormat);
+    ndspChnReset(channel);
+    ndspChnSetInterp(channel, NDSP_INTERP_NONE);
+    ndspChnSetRate(channel, float(wavHeader.frequency));
+    ndspChnSetFormat(channel, ndspFormat);
 
-	// Create and play a wav buffer
-	memset(&waveBuf, 0, sizeof(waveBuf));
+    // Create and play a wav buffer
+    memset(&waveBuf, 0, sizeof(waveBuf));
 
-	waveBuf.data_vaddr = reinterpret_cast<u32*>(data);
-	waveBuf.nsamples = dataSize / (wavHeader.bits_per_sample >> 3);
-	waveBuf.looping = toloop;
-	waveBuf.status = NDSP_WBUF_FREE;
-	chnl = channel;
+    waveBuf.data_vaddr = reinterpret_cast<u32*>(data);
+    waveBuf.nsamples = dataSize / (wavHeader.bits_per_sample >> 3);
+    waveBuf.looping = toloop;
+    waveBuf.status = NDSP_WBUF_FREE;
+    chnl = channel;
 }
 
 sound::~sound()
 {
-	waveBuf.data_vaddr = 0;
-	waveBuf.nsamples = 0;
-	waveBuf.looping = false;
-	waveBuf.status = 0;
-	ndspChnWaveBufClear(chnl);
+    waveBuf.data_vaddr = 0;
+    waveBuf.nsamples = 0;
+    waveBuf.looping = false;
+    waveBuf.status = 0;
+    ndspChnWaveBufClear(chnl);
 
-	if (data) {
-		linearFree(data);
-	}
+    if (data) {
+        linearFree(data);
+    }
 }
 
 void sound::play()
 {
-	if (!data)
-		return;
-	DSP_FlushDataCache(data, dataSize);
-	ndspChnWaveBufAdd(chnl, &waveBuf);
+    if (!data) {
+        return;
+    }
+    DSP_FlushDataCache(data, dataSize);
+    ndspChnWaveBufAdd(chnl, &waveBuf);
 }
 
 void sound::stop()
 {
-	if (!data)
-		return;
-	ndspChnWaveBufClear(chnl);
+    if (!data) {
+        return;
+    }
+    ndspChnWaveBufClear(chnl);
 }

--- a/gui/source/sound.h
+++ b/gui/source/sound.h
@@ -5,14 +5,14 @@
 class sound
 {
 public:
-	sound(const std::string& path, int channel = 1, bool toloop = true);
-	~sound();
-	void play();
-	void stop();
+    sound(const std::string& path, int channel = 1, bool toloop = true);
+    ~sound();
+    void play();
+    void stop();
 
 private:
-	u32 dataSize;
-	ndspWaveBuf waveBuf;
-	u8* data = NULL;
-	int chnl;
+    u32 dataSize;
+    ndspWaveBuf waveBuf;
+    u8* data = NULL;
+    int chnl;
 };

--- a/gui/source/textfns.cpp
+++ b/gui/source/textfns.cpp
@@ -13,51 +13,51 @@ using std::wstring;
 
 /**
  * Convert a UTF-16 string to wchar_t. (internal function
- * @param wstr	[out] UTF-32 buffer.
- * @param str	[in] UTF-16 string.
+ * @param wstr  [out] UTF-32 buffer.
+ * @param str   [in] UTF-16 string.
  * @return Number of characters used in wstr, not including the NULL terminator.
  */
-static int utf16_to_wchar_internal(wchar_t *wstr, const u16 *str)
+static int utf16_to_wchar_internal(wchar_t* wstr, const u16* str)
 {
-	if (!str) {
-		// No string.
-		*wstr = 0;
-		return 0;
-	}
+    if (!str) {
+        // No string.
+        *wstr = 0;
+        return 0;
+    }
 
-	int size = 0;
-	for (; *str != 0; str++, wstr++, size++) {
-		// Convert the UTF-16 character to UTF-32.
-		// Special handling is needed only for surrogate pairs.
-		// (TODO: Test surrogate pair handling.)
-		if ((*str & 0xFC00) == 0xD800) {
-			// High surrogate. (0xD800-0xDBFF)
-			if ((str[1] & 0xFC00) == 0xDC00) {
-				// Low surrogate. (0xDC00-0xDFFF)
-				// Recombine to get the actual character.
-				wchar_t wchr = 0x10000;
-				wchr += ((str[0] & 0x3FF) << 10);
-				wchr +=  (str[1] & 0x3FF);
-				*wstr = wchr;
-				// Make sure we don't process the low surrogate
-				// on the next iteration.
-				str++;
-			} else {
-				// Unpaired high surrogate.
-				*wstr = (wchar_t)(0xFFFD);
-			}
-		} else if ((*str & 0xFC00) == 0xDC00) {
-			// Unpaired low surrogate.
-			*wstr = (wchar_t)(0xFFFD);
-		} else {
-			// Standard UTF-16 character.
-			*wstr = (wchar_t)*str;
-		}
-	}
+    int size = 0;
+    for (; *str != 0; str++, wstr++, size++) {
+        // Convert the UTF-16 character to UTF-32.
+        // Special handling is needed only for surrogate pairs.
+        // (TODO: Test surrogate pair handling.)
+        if ((*str & 0xFC00) == 0xD800) {
+            // High surrogate. (0xD800-0xDBFF)
+            if ((str[1] & 0xFC00) == 0xDC00) {
+                // Low surrogate. (0xDC00-0xDFFF)
+                // Recombine to get the actual character.
+                wchar_t wchr = 0x10000;
+                wchr += ((str[0] & 0x3FF) << 10);
+                wchr += (str[1] & 0x3FF);
+                *wstr = wchr;
+                // Make sure we don't process the low surrogate
+                // on the next iteration.
+                str++;
+            } else {
+                // Unpaired high surrogate.
+                *wstr = (wchar_t)(0xFFFD);
+            }
+        } else if ((*str & 0xFC00) == 0xDC00) {
+            // Unpaired low surrogate.
+            *wstr = (wchar_t)(0xFFFD);
+        } else {
+            // Standard UTF-16 character.
+            *wstr = (wchar_t) * str;
+        }
+    }
 
-	// Add a NULL terminator.
-	*wstr = 0;
-	return size;
+    // Add a NULL terminator.
+    *wstr = 0;
+    return size;
 }
 
 /**
@@ -65,27 +65,27 @@ static int utf16_to_wchar_internal(wchar_t *wstr, const u16 *str)
  * @param str UTF-16 string.
  * @return wstring. (UTF-32)
  */
-wstring utf16_to_wstring(const u16 *str)
+wstring utf16_to_wstring(const u16* str)
 {
-	wstring wstr;
-	if (!str) {
-		// No string.
-		return wstr;
-	}
+    wstring wstr;
+    if (!str) {
+        // No string.
+        return wstr;
+    }
 
-	// Allocate at least as many UTF-32 units
-	// as there are characters in the string,
-	// plus one for the NULL terminator.
-	int len = 0;
-	for (const u16 *p = str; *p != 0; p++, len++) { }
-	wstr.resize(len+1);
+    // Allocate at least as many UTF-32 units
+    // as there are characters in the string,
+    // plus one for the NULL terminator.
+    int len = 0;
+    for (const u16* p = str; *p != 0; p++, len++) { }
+    wstr.resize(len + 1);
 
-	// Convert the string.
-	int size = utf16_to_wchar_internal(&wstr[0], str);
+    // Convert the string.
+    int size = utf16_to_wchar_internal(&wstr[0], str);
 
-	// Resize the string to trim extra spaces.
-	wstr.resize(size);
-	return wstr;
+    // Resize the string to trim extra spaces.
+    wstr.resize(size);
+    return wstr;
 }
 
 /**
@@ -94,65 +94,65 @@ wstring utf16_to_wstring(const u16 *str)
  * @param len Length of str.
  * @return vector<wstring>, split on newline boundaries.
  */
-vector<wstring> utf16_nl_to_vwstring(const u16 *str, int len)
+vector<wstring> utf16_nl_to_vwstring(const u16* str, int len)
 {
-	// Buffers for the strings.
-	// Assuming wchar_t is 32-bit.
-	static_assert(sizeof(wchar_t) == 4, "wchar_t is not 32-bit.");
-	vector<wstring> vec_wstr;
-	vec_wstr.reserve(3);
-	wstring wstr;
-	wstr.reserve(64);
+    // Buffers for the strings.
+    // Assuming wchar_t is 32-bit.
+    static_assert(sizeof(wchar_t) == 4, "wchar_t is not 32-bit.");
+    vector<wstring> vec_wstr;
+    vec_wstr.reserve(3);
+    wstring wstr;
+    wstr.reserve(64);
 
-	for (; *str != 0 && len > 0; str++, len--) {
-		// Convert the UTF-16 character to UTF-32.
-		// Special handling is needed only for surrogate pairs.
-		// (TODO: Test surrogate pair handling.)
-		if ((*str & 0xFC00) == 0xD800) {
-			// High surrogate. (0xD800-0xDBFF)
-			if (len > 2 && (str[1] & 0xFC00) == 0xDC00) {
-				// Low surrogate. (0xDC00-0xDFFF)
-				// Recombine to get the actual character.
-				wchar_t wchr = 0x10000;
-				wchr += ((str[0] & 0x3FF) << 10);
-				wchr +=  (str[1] & 0x3FF);
-				wstr += wchr;
-				// Make sure we don't process the low surrogate
-				// on the next iteration.
-				str++;
-				len--;
-			} else {
-				// Unpaired high surrogate.
-				wstr += (wchar_t)(0xFFFD);
-			}
-		} else if ((*str & 0xFC00) == 0xDC00) {
-			// Unpaired low surrogate.
-			wstr += (wchar_t)(0xFFFD);
-		} else {
-			// Standard UTF-16 character.
-			switch (*str) {
-				case L'\r':
-					// Skip carriage returns.
-					break;
-				case L'\n':
-					// Newline.
-					vec_wstr.push_back(wstr);
-					wstr.clear();
-					break;
-				default:
-					// Add the character.
-					wstr += *str;
-					break;
-			}
-		}
-	}
+    for (; *str != 0 && len > 0; str++, len--) {
+        // Convert the UTF-16 character to UTF-32.
+        // Special handling is needed only for surrogate pairs.
+        // (TODO: Test surrogate pair handling.)
+        if ((*str & 0xFC00) == 0xD800) {
+            // High surrogate. (0xD800-0xDBFF)
+            if (len > 2 && (str[1] & 0xFC00) == 0xDC00) {
+                // Low surrogate. (0xDC00-0xDFFF)
+                // Recombine to get the actual character.
+                wchar_t wchr = 0x10000;
+                wchr += ((str[0] & 0x3FF) << 10);
+                wchr += (str[1] & 0x3FF);
+                wstr += wchr;
+                // Make sure we don't process the low surrogate
+                // on the next iteration.
+                str++;
+                len--;
+            } else {
+                // Unpaired high surrogate.
+                wstr += (wchar_t)(0xFFFD);
+            }
+        } else if ((*str & 0xFC00) == 0xDC00) {
+            // Unpaired low surrogate.
+            wstr += (wchar_t)(0xFFFD);
+        } else {
+            // Standard UTF-16 character.
+            switch (*str) {
+                case L'\r':
+                    // Skip carriage returns.
+                    break;
+                case L'\n':
+                    // Newline.
+                    vec_wstr.push_back(wstr);
+                    wstr.clear();
+                    break;
+                default:
+                    // Add the character.
+                    wstr += *str;
+                    break;
+            }
+        }
+    }
 
-	// Add the last line if it's not empty.
-	if (!wstr.empty()) {
-		vec_wstr.push_back(wstr);
-	}
+    // Add the last line if it's not empty.
+    if (!wstr.empty()) {
+        vec_wstr.push_back(wstr);
+    }
 
-	return vec_wstr;
+    return vec_wstr;
 }
 
 /**
@@ -160,96 +160,94 @@ vector<wstring> utf16_nl_to_vwstring(const u16 *str, int len)
  * @param str UTF-16 string.
  * @return malloc()'d wchar_t*. (UTF-32) (NOTE: If str is nullptr, this returns nullptr.)
  */
-wchar_t *utf16_to_wchar(const u16 *str)
+wchar_t* utf16_to_wchar(const u16* str)
 {
-	if (!str) {
-		// No string.
-		return nullptr;
-	}
+    if (!str) {
+        // No string.
+        return nullptr;
+    }
 
-	// Allocate at least as many UTF-32 units
-	// as there are characters in the string,
-	// plus one for the NULL terminator.
-	int len = 0;
-	for (const u16 *p = str; *p != 0; p++, len++) { }
-	wchar_t *wstr = (wchar_t*)malloc((len+1) * sizeof(wchar_t));
+    // Allocate at least as many UTF-32 units
+    // as there are characters in the string,
+    // plus one for the NULL terminator.
+    int len = 0;
+    for (const u16* p = str; *p != 0; p++, len++) { }
+    wchar_t* wstr = (wchar_t*)malloc((len + 1) * sizeof(wchar_t));
 
-	// Convert the string.
-	utf16_to_wchar_internal(wstr, str);
-	return wstr;
+    // Convert the string.
+    utf16_to_wchar_internal(wstr, str);
+    return wstr;
 }
 
 /** UTF-8 **/
 
 /**
  * Convert a UTF-8 string to wchar_t. (internal function
- * @param wstr	[out] UTF-32 buffer.
- * @param str	[in] UTF-8 string.
+ * @param wstr  [out] UTF-32 buffer.
+ * @param str   [in] UTF-8 string.
  * @return Number of characters used in wstr, not including the NULL terminator.
  */
-static int utf8_to_wchar_internal(wchar_t *wstr, const char *str)
+static int utf8_to_wchar_internal(wchar_t* wstr, const char* str)
 {
-	if (!str) {
-		// No string.
-		*wstr = 0;
-		return 0;
-	}
+    if (!str) {
+        // No string.
+        *wstr = 0;
+        return 0;
+    }
 
-	int size = 0;
-	for (; *str != 0; str++, wstr++, size++) {
-		if (!(*str & 0x80)) {
-			// ASCII. (U+0000-U+007F)
-			*wstr = *str;
-		} else if ((*str & 0xE0) == 0xC0) {
-			// Two-byte UTF-8.
-			if ((str[1] & 0xC0) != 0x80) {
-				// Invalid sequence.
-				*wstr = (wchar_t)0xFFFD;
-			} else {
-				*wstr = (wchar_t)(
-					((str[0] & 0x1F) << 6) |
-					((str[1] & 0x3F)));
-				str++;
-			}
-		} else if ((*str & 0xF0) == 0xE0) {
-			// Three-byte UTF-8.
-			if ((str[1] & 0xC0) != 0x80 ||
-			    (str[2] & 0xC0) != 0x80)
-			{
-				// Invalid sequence.
-				*wstr = (wchar_t)0xFFFD;
-			} else {
-				*wstr = (wchar_t)(
-					((str[0] & 0x0F) << 12) |
-					((str[1] & 0x3F) << 6)  |
-					((str[2] & 0x3F)));
-				str += 2;
-			}
-		} else if ((*str & 0xF8) == 0xF0) {
-			// Four-byte UTF-8.
-			if ((str[1] & 0xC0) != 0x80 ||
-			    (str[2] & 0xC0) != 0x80 ||
-			    (str[3] & 0xC0) != 0x80)
-			{
-				// Invalid sequence.
-				*wstr = (wchar_t)0xFFFD;
-			} else {
-				*wstr = (wchar_t)(
-					((str[0] & 0x07) << 18) |
-					((str[1] & 0x3F) << 12) |
-					((str[2] & 0x3F) << 6)  |
-					((str[3] & 0x3F)));
-				str += 3;
-			}
-		} else {
-			// Invalid UTF-8 sequence.
-			*wstr = (wchar_t)0xFFFD;
-		}
-	}
+    int size = 0;
+    for (; *str != 0; str++, wstr++, size++) {
+        if (!(*str & 0x80)) {
+            // ASCII. (U+0000-U+007F)
+            *wstr = *str;
+        } else if ((*str & 0xE0) == 0xC0) {
+            // Two-byte UTF-8.
+            if ((str[1] & 0xC0) != 0x80) {
+                // Invalid sequence.
+                *wstr = (wchar_t)0xFFFD;
+            } else {
+                *wstr = (wchar_t)(
+                            ((str[0] & 0x1F) << 6) |
+                            ((str[1] & 0x3F)));
+                str++;
+            }
+        } else if ((*str & 0xF0) == 0xE0) {
+            // Three-byte UTF-8.
+            if ((str[1] & 0xC0) != 0x80 ||
+                    (str[2] & 0xC0) != 0x80) {
+                // Invalid sequence.
+                *wstr = (wchar_t)0xFFFD;
+            } else {
+                *wstr = (wchar_t)(
+                            ((str[0] & 0x0F) << 12) |
+                            ((str[1] & 0x3F) << 6)  |
+                            ((str[2] & 0x3F)));
+                str += 2;
+            }
+        } else if ((*str & 0xF8) == 0xF0) {
+            // Four-byte UTF-8.
+            if ((str[1] & 0xC0) != 0x80 ||
+                    (str[2] & 0xC0) != 0x80 ||
+                    (str[3] & 0xC0) != 0x80) {
+                // Invalid sequence.
+                *wstr = (wchar_t)0xFFFD;
+            } else {
+                *wstr = (wchar_t)(
+                            ((str[0] & 0x07) << 18) |
+                            ((str[1] & 0x3F) << 12) |
+                            ((str[2] & 0x3F) << 6)  |
+                            ((str[3] & 0x3F)));
+                str += 3;
+            }
+        } else {
+            // Invalid UTF-8 sequence.
+            *wstr = (wchar_t)0xFFFD;
+        }
+    }
 
-	// Add a NULL terminator.
-	*wstr = 0;
-	return size;
+    // Add a NULL terminator.
+    *wstr = 0;
+    return size;
 }
 
 /**
@@ -257,25 +255,25 @@ static int utf8_to_wchar_internal(wchar_t *wstr, const char *str)
  * @param str UTF-8 string.
  * @return wstring. (UTF-32)
  */
-wstring utf8_to_wstring(const char *str)
+wstring utf8_to_wstring(const char* str)
 {
-	wstring wstr;
-	if (!str) {
-		// No string.
-		return wstr;
-	}
+    wstring wstr;
+    if (!str) {
+        // No string.
+        return wstr;
+    }
 
-	// Allocate at least as many UTF-32 units
-	// as there are bytes in the string, plus
-	// one for the NULL terminator.
-	wstr.resize(strlen(str)+1);
+    // Allocate at least as many UTF-32 units
+    // as there are bytes in the string, plus
+    // one for the NULL terminator.
+    wstr.resize(strlen(str) + 1);
 
-	// Convert the string.
-	int size = utf8_to_wchar_internal(&wstr[0], str);
+    // Convert the string.
+    int size = utf8_to_wchar_internal(&wstr[0], str);
 
-	// Resize the string to trim extra spaces.
-	wstr.resize(size);
-	return wstr;
+    // Resize the string to trim extra spaces.
+    wstr.resize(size);
+    return wstr;
 }
 
 /**
@@ -283,47 +281,47 @@ wstring utf8_to_wstring(const char *str)
  * @param str UTF-8 string.
  * @return malloc()'d wchar_t*. (UTF-32) (NOTE: If str is nullptr, this returns nullptr.)
  */
-wchar_t *utf8_to_wchar(const char *str)
+wchar_t* utf8_to_wchar(const char* str)
 {
-	if (!str) {
-		// No string.
-		return nullptr;
-	}
+    if (!str) {
+        // No string.
+        return nullptr;
+    }
 
-	// Allocate at least as many UTF-32 units
-	// as there are bytes in the string, plus
-	// one for the NULL terminator.
-	wchar_t *wstr = (wchar_t*)malloc((strlen(str)+1) * sizeof(wchar_t));
+    // Allocate at least as many UTF-32 units
+    // as there are bytes in the string, plus
+    // one for the NULL terminator.
+    wchar_t* wstr = (wchar_t*)malloc((strlen(str) + 1) * sizeof(wchar_t));
 
-	// Convert the string.
-	utf8_to_wchar_internal(wstr, str);
-	return wstr;
+    // Convert the string.
+    utf8_to_wchar_internal(wstr, str);
+    return wstr;
 }
 
 /** Latin-1 **/
 
 /**
  * Convert a Latin-1 string to wchar_t. (internal function
- * @param wstr	[out] UTF-32 buffer.
- * @param str	[in] Latin-1 string.
+ * @param wstr  [out] UTF-32 buffer.
+ * @param str   [in] Latin-1 string.
  * @return Number of characters used in wstr, not including the NULL terminator.
  */
-static int latin1_to_wchar_internal(wchar_t *wstr, const char *str)
+static int latin1_to_wchar_internal(wchar_t* wstr, const char* str)
 {
-	if (!str) {
-		// No string.
-		*wstr = 0;
-		return 0;
-	}
+    if (!str) {
+        // No string.
+        *wstr = 0;
+        return 0;
+    }
 
-	int size = 0;
-	for (; *str != 0; str++, wstr++, size++) {
-		*wstr = *str;
-	}
+    int size = 0;
+    for (; *str != 0; str++, wstr++, size++) {
+        *wstr = *str;
+    }
 
-	// Add a NULL terminator.
-	*wstr = 0;
-	return size;
+    // Add a NULL terminator.
+    *wstr = 0;
+    return size;
 }
 
 /**
@@ -331,25 +329,25 @@ static int latin1_to_wchar_internal(wchar_t *wstr, const char *str)
  * @param str Latin-1 string.
  * @return wstring. (UTF-32)
  */
-wstring latin1_to_wstring(const char *str)
+wstring latin1_to_wstring(const char* str)
 {
-	wstring wstr;
-	if (!str) {
-		// No string.
-		return wstr;
-	}
+    wstring wstr;
+    if (!str) {
+        // No string.
+        return wstr;
+    }
 
-	// Allocate at least as many UTF-32 units
-	// as there are bytes in the string, plus
-	// one for the NULL terminator.
-	wstr.resize(strlen(str)+1);
+    // Allocate at least as many UTF-32 units
+    // as there are bytes in the string, plus
+    // one for the NULL terminator.
+    wstr.resize(strlen(str) + 1);
 
-	// Convert the string.
-	int size = latin1_to_wchar_internal(&wstr[0], str);
+    // Convert the string.
+    int size = latin1_to_wchar_internal(&wstr[0], str);
 
-	// Resize the string to trim extra spaces.
-	wstr.resize(size);
-	return wstr;
+    // Resize the string to trim extra spaces.
+    wstr.resize(size);
+    return wstr;
 }
 
 /**
@@ -357,19 +355,19 @@ wstring latin1_to_wstring(const char *str)
  * @param str Latin-1 string.
  * @return malloc()'d wchar_t*. (UTF-32) (NOTE: If str is nullptr, this returns nullptr.)
  */
-wchar_t *latin1_to_wchar(const char *str)
+wchar_t* latin1_to_wchar(const char* str)
 {
-	if (!str) {
-		// No string.
-		return nullptr;
-	}
+    if (!str) {
+        // No string.
+        return nullptr;
+    }
 
-	// Allocate at least as many UTF-32 units
-	// as there are bytes in the string, plus
-	// one for the NULL terminator.
-	wchar_t *wstr = (wchar_t*)malloc((strlen(str)+1) * sizeof(wchar_t));
+    // Allocate at least as many UTF-32 units
+    // as there are bytes in the string, plus
+    // one for the NULL terminator.
+    wchar_t* wstr = (wchar_t*)malloc((strlen(str) + 1) * sizeof(wchar_t));
 
-	// Convert the string.
-	latin1_to_wchar_internal(wstr, str);
-	return wstr;
+    // Convert the string.
+    latin1_to_wchar_internal(wstr, str);
+    return wstr;
 }

--- a/gui/source/textfns.h
+++ b/gui/source/textfns.h
@@ -11,14 +11,14 @@
  * @param str UTF-16 string.
  * @return wstring. (UTF-32)
  */
-std::wstring utf16_to_wstring(const u16 *str);
+std::wstring utf16_to_wstring(const u16* str);
 
 /**
  * Convert a UTF-16 string to wchar_t*.
  * @param str UTF-16 string.
  * @return malloc()'d wchar_t*. (UTF-32) (NOTE: If str is nullptr, this returns nullptr.)
  */
-wchar_t *utf16_to_wchar(const u16 *str);
+wchar_t* utf16_to_wchar(const u16* str);
 
 /**
  * Convert a UTF-16 string with newlines to a vector of wstrings.
@@ -26,34 +26,34 @@ wchar_t *utf16_to_wchar(const u16 *str);
  * @param len Length of str.
  * @return vector<wstring>, split on newline boundaries.
  */
-std::vector<std::wstring> utf16_nl_to_vwstring(const u16 *str, int len);
+std::vector<std::wstring> utf16_nl_to_vwstring(const u16* str, int len);
 
 /**
  * Convert a UTF-8 string to wstring.
  * @param str UTF-8 string.
  * @return wstring. (UTF-32)
  */
-std::wstring utf8_to_wstring(const char *str);
+std::wstring utf8_to_wstring(const char* str);
 
 /**
  * Convert a UTF-8 string to wchar_t*.
  * @param str UTF-8 string.
  * @return malloc()'d wchar_t*. (UTF-32) (NOTE: If str is nullptr, this returns nullptr.)
  */
-wchar_t *utf8_to_wchar(const char *str);
+wchar_t* utf8_to_wchar(const char* str);
 
 /**
  * Convert a Latin-1 string to wstring.
  * @param str Latin-1 string.
  * @return wstring. (UTF-32)
  */
-std::wstring latin1_to_wstring(const char *str);
+std::wstring latin1_to_wstring(const char* str);
 
 /**
  * Convert a Latin1- string to wchar_t*.
  * @param str Latin-1 string.
  * @return malloc()'d wchar_t*. (UTF-32) (NOTE: If str is nullptr, this returns nullptr.)
  */
-wchar_t *latin1_to_wchar(const char *str);
+wchar_t* latin1_to_wchar(const char* str);
 
 #endif /* TEXTFNS_H */


### PR DESCRIPTION
Apply astyle to improve readability and consistency.

astyle -V = Artistic Style Version 2.06
https://sourceforge.net/projects/astyle/files/

commands used
astyle -r --options=astyle.ini TWLoader\gui*.cpp
astyle -r --options=astyle.ini --keep-one-line-blocks TWLoader\gui*.h

settings used in astyle .ini:

--indent=spaces=4 --style=kr
--indent-switches --indent-namespaces --indent-col1-comments
--max-instatement-indent=65
--attach-inlines
--pad-header --pad-oper --unpad-paren
--align-pointer=type --align-reference=type
--close-templates
--add-brackets
--convert-tabs
--lineend=windows --preserve-date
--suffix=none
--ignore-exclude-errors --ignore-exclude-errors-x
--formatted