### PR TITLE
Update bootstrap settings

### DIFF
--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -643,6 +643,21 @@ static void LoadBoxArt_WoodTheme(const int idx) {
  */
 static void LoadBootstrapConfig(void)
 {
+	
+bootstrapini.GetString("bootstrapini_ndsbootstrap", "NDS_PATH", "");
+bootstrapini.GetString("bootstrapini_ndsbootstrap", "SAV_PATH", "");
+bootstrapini.GetString("bootstrapini_ndsbootstrap", "BOOTSTRAP_PATH", "");
+bootstrapini.GetString("bootstrapini_ndsbootstrap", "ARM7_DONOR_PATH", "");
+bootstrapini.GetInt("bootstrapini_ndsbootstrap", "NTR_MODE_SWITCH", "0");
+bootstrapini.GetInt("bootstrapini_ndsbootstrap", "BOOST_CPU", "0");
+bootstrapini.GetInt("bootstrapini_ndsbootstrap", "BOOST_VRAM", "1");
+bootstrapini.GetInt("bootstrapini_ndsbootstrap", "BOOTSPLASH", "0");
+bootstrapini.GetInt("bootstrapini_ndsbootstrap", "DEBUG", "0");
+bootstrapini.GetInt("bootstrapini_ndsbootstrap", "RESETSLOT1", "0");
+bootstrapini.GetInt("bootstrapini_ndsbootstrap", "LOCK_ARM9_SCFG_EXT", "0");
+bootstrapini.GetInt("bootstrapini_ndsbootstrap", "PATCH_MPU_REGION", "0");
+bootstrapini.GetInt("bootstrapini_ndsbootstrap", "PATCH_MPU_SIZE", "0");
+bootstrapini.GetInt("bootstrapini_ndsbootstrap", "NDS-BOOTSTRAP", ""); //fixme: appears to be unused
 	switch (bootstrapini.GetInt(bootstrapini_ndsbootstrap, bootstrapini_debug, -1)) {
 		case 1:
 			settings.twl.console = 2;

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -161,15 +161,20 @@ static const char fcrompathini_bnriconaniseq[] = "BNR_ICONANISEQ";
 	
 
 // Bootstrap .ini file
-static const char bootstrapini_ndsbootstrap[] = "NDS-BOOTSTRAP";
 static const char bootstrapini_ndspath[] = "NDS_PATH";
 static const char bootstrapini_savpath[] = "SAV_PATH";
+static const char bootstrapini_bootstrappath[] = "BOOTSTRAP_PATH";
+static const char bootstrapini_arm7donorpath[] = "ARM7_DONOR_PATH";
+static const char bootstrapini_ntrmodeswitch[] = "NTR_MODE_SWITCH";
+static const char bootstrapini_boostcpu[] = "BOOST_CPU";
+static const char bootstrapini_boostvram[] = "BOOST_VRAM";
+static const char bootstrapini_bootsplash[] = "BOOTSPLASH";
+static const char bootstrapini_debug[] = "DEBUG";
+static const char bootstrapini_resetslot1[] = "RESETSLOT1"
+static const char bootstrapini_lockarm9scfgext[] = "LOCK_ARM9_SCFG_EXT";
 static const char bootstrapini_mpuregion[] = "PATCH_MPU_REGION";
 static const char bootstrapini_mpusize[] = "PATCH_MPU_SIZE";
-static const char bootstrapini_boostcpu[] = "BOOST_CPU";
-static const char bootstrapini_debug[] = "DEBUG";
-static const char bootstrapini_lockarm9scfgext[] = "LOCK_ARM9_SCFG_EXT";
-static const char bootstrapini_bootstrappath[] = "BOOTSTRAP_PATH";
+static const char bootstrapini_ndsbootstrap[] = "NDS-BOOTSTRAP"; //fixme: appears to be unused
 // End
 
 // Run

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -697,7 +697,11 @@ static void SaveBootstrapConfig(void)
 			}
 		}
 	}
+	// bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_arm7donorpath, 0); fixme
+	bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_ntrmodeswitch, 0);
 	bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_boostcpu, settings.twl.cpuspeed);
+	bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_boostvram, settings.twl.extvram);
+	bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_bootsplash, 0);
 
 	// TODO: Change the default to 0?
 	switch (settings.twl.console) {
@@ -712,7 +716,8 @@ static void SaveBootstrapConfig(void)
 			bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_debug, 1);
 			break;
 	}
-
+	bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_resetslot1, settings.twl.resetslot1);
+	bootstrapini.SetInt(bootstrapini_ndsbootstrap, bootstrapini_lockarm9scfgext, settings.twl.lockarm9scfgext);
 	bootstrapini.SaveIniFile("sdmc:/_nds/nds-bootstrap.ini");
 }
 


### PR DESCRIPTION
I need some help testing this and dealing with the fixme's.

bootstrapini_ndsbootstrap[] = "NDS-BOOTSTRAP"; appears to be unused.

bootstrapini_arm7donorpath i don't know how to set this, as the action for it appears to be hidden in the per game settings menu

future work:
When this is fully working i can add code to delete and rebuild the ini file after an update was made to twloader or ndsbootstrap (without losing settings)