### PR TITLE
Add delete mode, delete queue and new update system

### DIFF
--- a/gui/Makefile
+++ b/gui/Makefile
@@ -55,7 +55,7 @@ VERSION_MICRO := 1
 #---------------------------------------------------------------------------------
 TARGET		:=	TWLoader
 BUILD		:=	build
-SOURCES		:=	source source/img
+SOURCES		:=	source source/img source/json
 DATA		:=	data
 INCLUDES	:=	include
 ROMFS		:=	romfs
@@ -76,7 +76,7 @@ CITRA 	?= C:\emulators\citra\citra.exe $(TARGET).3dsx
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 
-CFLAGS	:=	-g -Wall -O2 -DCOMPILE_3DSX=$(COMPILE_3DSX) -DVERSION_MAJOR=$(VERSION_MAJOR) -DVERSION_MINOR=$(VERSION_MINOR) -DVERSION_MICRO=$(VERSION_MICRO) -mword-relocations \
+CFLAGS	:=	-g -Wall -Wstrict-aliasing -O2 -DCOMPILE_3DSX=$(COMPILE_3DSX) -DVERSION_MAJOR=$(VERSION_MAJOR) -DVERSION_MINOR=$(VERSION_MINOR) -DVERSION_MICRO=$(VERSION_MICRO) -mword-relocations \
 		-ffunction-sections \
 		$(ARCH)
 

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -813,13 +813,16 @@ void downloadBoxArt(void)
 			memcpy(ba_TID, &tid, 4);
 			ba_TID[4] = 0;
 			
+			char str[256] = "";
+			snprintf(str, sizeof(str), "%zu", boxartnum);
+			
 			// Show the dialog.
 			DialogBoxAppear(title, 0);
 			sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
 			sf2d_draw_texture(dialogboxtex, 0, 0);
 			setTextColor(RGBA8(0, 0, 0, 255));
 			renderText(12, 16, 0.5f, 0.5f, false, title);
-			// renderText(12, 32, 0.5f, 0.5f, false, "%zu", boxartnum);
+			renderText(12, 32, 0.5f, 0.5f, false, str);
 			renderText(39, 32, 0.5f, 0.5f, false, "/");
 			renderText(44, 32, 0.5f, 0.5f, false, s_boxart_total);
 			renderText(12, 64, 0.5f, 0.5f, false, "Downloading:");
@@ -901,13 +904,16 @@ void downloadBoxArt(void)
 			memcpy(ba_TID, &tid, 4);
 			ba_TID[4] = 0;
 			
+			char str[256] = "";
+			snprintf(str, sizeof(str), "%zu", boxartnum);
+			
 			// Show the dialog.
 			DialogBoxAppear(title, 0);
 			sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
 			sf2d_draw_texture(dialogboxtex, 0, 0);
 			setTextColor(RGBA8(0, 0, 0, 255));
 			renderText(12, 16, 0.5f, 0.5f, false, title);
-			// renderText(12, 32, 0.5f, 0.5f, false, "%zu", boxartnum);
+			renderText(12, 32, 0.5f, 0.5f, false, str);
 			renderText(39, 32, 0.5f, 0.5f, false, "/");
 			renderText(44, 32, 0.5f, 0.5f, false, s_boxart_total);
 			renderText(12, 64, 0.5f, 0.5f, false, "Downloading:");
@@ -965,13 +971,16 @@ void downloadBoxArt(void)
 		memcpy(ba_TID, &tid, 4);
 		ba_TID[4] = 0;
 		
+		char str[256] = "";
+		snprintf(str, sizeof(str), "%zu", boxartnum);
+		
 		// Show the dialog.
 		DialogBoxAppear(title, 0);
 		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
 		sf2d_draw_texture(dialogboxtex, 0, 0);
 		setTextColor(RGBA8(0, 0, 0, 255));
 		renderText(12, 16, 0.5f, 0.5f, false, title);
-		// renderText(12, 32, 0.5f, 0.5f, false, "%zu", boxartnum);
+		renderText(12, 32, 0.5f, 0.5f, false, str);
 		renderText(39, 32, 0.5f, 0.5f, false, "/");
 		renderText(44, 32, 0.5f, 0.5f, false, s_boxart_total);
 		renderText(12, 64, 0.5f, 0.5f, false, "Downloading:");

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -214,7 +214,6 @@ int checkUpdate(void) {
     if (responseCode != 200) {
         // This is an error trying to reach the file, so insert error here.
     }
-	httpcCloseContext(&context);	
 	
 	u32 size = 0;
 	httpcGetDownloadSizeState(&context, NULL, &size);	

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -829,9 +829,10 @@ void downloadBoxArt(void)
 			renderText(108, 64, 0.5f, 0.5f, false, ba_TID);
 			sf2d_end_frame();
 			sf2d_swapbuffers();
-
+			
 			downloadBoxArt_internal(ba_TID, ROM_SD);
 		}
+		DialogBoxDisappear(NULL, 0);
 		boxart_dl_tids.clear();
 	}
 	// Check if we're missing any boxart for ROMs on the flashcard.
@@ -923,6 +924,7 @@ void downloadBoxArt(void)
 
 			downloadBoxArt_internal(ba_TID, ROM_FLASHCARD);
 		}
+		DialogBoxDisappear(NULL, 0);
 		boxart_dl_tids.clear();
 	}
 	

--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -247,18 +247,17 @@ int checkUpdate(void) {
 					if(subVal->type == json_string) {
 
 						if(strncmp(name, "latest_major", nameLen) == 0) {
-						// Found latest major										
-						strncpy(read_major, subVal->u.string.ptr, sizeof(read_major));
+							// Found latest major										
+							strncpy(read_major, subVal->u.string.ptr, sizeof(read_major));
 						} else if(strncmp(name, "latest_minor", nameLen) == 0) {
-						// Read latest minor
-						strncpy(read_minor, subVal->u.string.ptr, sizeof(read_minor));
+							// Read latest minor
+							strncpy(read_minor, subVal->u.string.ptr, sizeof(read_minor));
 						} else if(strncmp(name, "latest_micro", nameLen) == 0) {
-						// Read latest micro
-						strncpy(read_micro, subVal->u.string.ptr, sizeof(read_micro));
+							// Read latest micro
+							strncpy(read_micro, subVal->u.string.ptr, sizeof(read_micro));
 						} else if(strncmp(name, "gui_url", nameLen) == 0) {
-						// Found update url!									
-						strncpy(gui_url, subVal->u.string.ptr, sizeof(gui_url));
-if (logEnabled) LogFMA("checkUpdate", "url", gui_url);
+							// Found update url!									
+							strncpy(gui_url, subVal->u.string.ptr, sizeof(gui_url));
 						}
 					}
 				}

--- a/gui/source/download.h
+++ b/gui/source/download.h
@@ -13,6 +13,12 @@ enum MediaType {
 	MEDIA_NAND_CIA = 2,	// CIA installed to NAND.
 };
 
+enum RomLocation {
+	ROM_SD = 0,			// Location for SD files
+	ROM_FLASHCARD = 1,	// Location for flashcard files
+	ROM_SLOT_1 = 2,		// Location for SLOT-1 files
+};
+
 /**
  * Download a file.
  * @param url URL of the file.

--- a/gui/source/json/LICENSE
+++ b/gui/source/json/LICENSE
@@ -1,0 +1,26 @@
+
+  Copyright (C) 2012, 2013 James McLaughlin et al.  All rights reserved.
+ 
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+ 
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 
+  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+  SUCH DAMAGE.
+

--- a/gui/source/json/json.c
+++ b/gui/source/json/json.c
@@ -1,0 +1,1011 @@
+/* vim: set et ts=3 sw=3 sts=3 ft=c:
+ *
+ * Copyright (C) 2012, 2013, 2014 James McLaughlin et al.  All rights reserved.
+ * https://github.com/udp/json-parser
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "json.h"
+
+#ifdef _MSC_VER
+   #ifndef _CRT_SECURE_NO_WARNINGS
+      #define _CRT_SECURE_NO_WARNINGS
+   #endif
+#endif
+
+const struct _json_value json_value_none;
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <math.h>
+
+typedef unsigned int json_uchar;
+
+static unsigned char hex_value (json_char c)
+{
+   if (isdigit(c))
+      return c - '0';
+
+   switch (c) {
+      case 'a': case 'A': return 0x0A;
+      case 'b': case 'B': return 0x0B;
+      case 'c': case 'C': return 0x0C;
+      case 'd': case 'D': return 0x0D;
+      case 'e': case 'E': return 0x0E;
+      case 'f': case 'F': return 0x0F;
+      default: return 0xFF;
+   }
+}
+
+typedef struct
+{
+   unsigned long used_memory;
+
+   unsigned int uint_max;
+   unsigned long ulong_max;
+
+   json_settings settings;
+   int first_pass;
+
+   const json_char * ptr;
+   unsigned int cur_line, cur_col;
+
+} json_state;
+
+static void * default_alloc (size_t size, int zero, void * user_data)
+{
+   return zero ? calloc (1, size) : malloc (size);
+}
+
+static void default_free (void * ptr, void * user_data)
+{
+   free (ptr);
+}
+
+static void * json_alloc (json_state * state, unsigned long size, int zero)
+{
+   if ((state->ulong_max - state->used_memory) < size)
+      return 0;
+
+   if (state->settings.max_memory
+         && (state->used_memory += size) > state->settings.max_memory)
+   {
+      return 0;
+   }
+
+   return state->settings.mem_alloc (size, zero, state->settings.user_data);
+}
+
+static int new_value (json_state * state,
+                      json_value ** top, json_value ** root, json_value ** alloc,
+                      json_type type)
+{
+   json_value * value;
+   int values_size;
+
+   if (!state->first_pass)
+   {
+      value = *top = *alloc;
+      *alloc = (*alloc)->_reserved.next_alloc;
+
+      if (!*root)
+         *root = value;
+
+      switch (value->type)
+      {
+         case json_array:
+
+            if (value->u.array.length == 0)
+               break;
+
+            if (! (value->u.array.values = (json_value **) json_alloc
+               (state, value->u.array.length * sizeof (json_value *), 0)) )
+            {
+               return 0;
+            }
+
+            value->u.array.length = 0;
+            break;
+
+         case json_object:
+
+            if (value->u.object.length == 0)
+               break;
+
+            values_size = sizeof (*value->u.object.values) * value->u.object.length;
+
+            if (! (value->u.object.values = (json_object_entry *) json_alloc
+                  (state, values_size + ((unsigned long) value->u.object.values), 0)) )
+            {
+               return 0;
+            }
+
+            value->_reserved.object_mem = (*(char **) &value->u.object.values) + values_size;
+
+            value->u.object.length = 0;
+            break;
+
+         case json_string:
+
+            if (! (value->u.string.ptr = (json_char *) json_alloc
+               (state, (value->u.string.length + 1) * sizeof (json_char), 0)) )
+            {
+               return 0;
+            }
+
+            value->u.string.length = 0;
+            break;
+
+         default:
+            break;
+      };
+
+      return 1;
+   }
+
+   if (! (value = (json_value *) json_alloc
+         (state, sizeof (json_value) + state->settings.value_extra, 1)))
+   {
+      return 0;
+   }
+
+   if (!*root)
+      *root = value;
+
+   value->type = type;
+   value->parent = *top;
+
+   #ifdef JSON_TRACK_SOURCE
+      value->line = state->cur_line;
+      value->col = state->cur_col;
+   #endif
+
+   if (*alloc)
+      (*alloc)->_reserved.next_alloc = value;
+
+   *alloc = *top = value;
+
+   return 1;
+}
+
+#define whitespace \
+   case '\n': ++ state.cur_line;  state.cur_col = 0; \
+   case ' ': case '\t': case '\r'
+
+#define string_add(b)  \
+   do { if (!state.first_pass) string [string_length] = b;  ++ string_length; } while (0);
+
+#define line_and_col \
+   state.cur_line, state.cur_col
+
+static const long
+   flag_next             = 1 << 0,
+   flag_reproc           = 1 << 1,
+   flag_need_comma       = 1 << 2,
+   flag_seek_value       = 1 << 3, 
+   flag_escaped          = 1 << 4,
+   flag_string           = 1 << 5,
+   flag_need_colon       = 1 << 6,
+   flag_done             = 1 << 7,
+   flag_num_negative     = 1 << 8,
+   flag_num_zero         = 1 << 9,
+   flag_num_e            = 1 << 10,
+   flag_num_e_got_sign   = 1 << 11,
+   flag_num_e_negative   = 1 << 12,
+   flag_line_comment     = 1 << 13,
+   flag_block_comment    = 1 << 14;
+
+json_value * json_parse_ex (json_settings * settings,
+                            const json_char * json,
+                            size_t length,
+                            char * error_buf)
+{
+   json_char error [json_error_max];
+   const json_char * end;
+   json_value * top, * root, * alloc = 0;
+   json_state state = { 0 };
+   long flags;
+   long num_digits = 0, num_e = 0;
+   json_int_t num_fraction = 0;
+
+   /* Skip UTF-8 BOM
+    */
+   if (length >= 3 && ((unsigned char) json [0]) == 0xEF
+                   && ((unsigned char) json [1]) == 0xBB
+                   && ((unsigned char) json [2]) == 0xBF)
+   {
+      json += 3;
+      length -= 3;
+   }
+
+   error[0] = '\0';
+   end = (json + length);
+
+   memcpy (&state.settings, settings, sizeof (json_settings));
+
+   if (!state.settings.mem_alloc)
+      state.settings.mem_alloc = default_alloc;
+
+   if (!state.settings.mem_free)
+      state.settings.mem_free = default_free;
+
+   memset (&state.uint_max, 0xFF, sizeof (state.uint_max));
+   memset (&state.ulong_max, 0xFF, sizeof (state.ulong_max));
+
+   state.uint_max -= 8; /* limit of how much can be added before next check */
+   state.ulong_max -= 8;
+
+   for (state.first_pass = 1; state.first_pass >= 0; -- state.first_pass)
+   {
+      json_uchar uchar;
+      unsigned char uc_b1, uc_b2, uc_b3, uc_b4;
+      json_char * string = 0;
+      unsigned int string_length = 0;
+
+      top = root = 0;
+      flags = flag_seek_value;
+
+      state.cur_line = 1;
+
+      for (state.ptr = json ;; ++ state.ptr)
+      {
+         json_char b = (state.ptr == end ? 0 : *state.ptr);
+         
+         if (flags & flag_string)
+         {
+            if (!b)
+            {  sprintf (error, "Unexpected EOF in string (at %d:%d)", line_and_col);
+               goto e_failed;
+            }
+
+            if (string_length > state.uint_max)
+               goto e_overflow;
+
+            if (flags & flag_escaped)
+            {
+               flags &= ~ flag_escaped;
+
+               switch (b)
+               {
+                  case 'b':  string_add ('\b');  break;
+                  case 'f':  string_add ('\f');  break;
+                  case 'n':  string_add ('\n');  break;
+                  case 'r':  string_add ('\r');  break;
+                  case 't':  string_add ('\t');  break;
+                  case 'u':
+
+                    if (end - state.ptr < 4 || 
+                        (uc_b1 = hex_value (*++ state.ptr)) == 0xFF ||
+                        (uc_b2 = hex_value (*++ state.ptr)) == 0xFF ||
+                        (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
+                        (uc_b4 = hex_value (*++ state.ptr)) == 0xFF)
+                    {
+                        sprintf (error, "Invalid character value `%c` (at %d:%d)", b, line_and_col);
+                        goto e_failed;
+                    }
+
+                    uc_b1 = (uc_b1 << 4) | uc_b2;
+                    uc_b2 = (uc_b3 << 4) | uc_b4;
+                    uchar = (uc_b1 << 8) | uc_b2;
+
+                    if ((uchar & 0xF800) == 0xD800) {
+                        json_uchar uchar2;
+                        
+                        if (end - state.ptr < 6 || (*++ state.ptr) != '\\' || (*++ state.ptr) != 'u' ||
+                            (uc_b1 = hex_value (*++ state.ptr)) == 0xFF ||
+                            (uc_b2 = hex_value (*++ state.ptr)) == 0xFF ||
+                            (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
+                            (uc_b4 = hex_value (*++ state.ptr)) == 0xFF)
+                        {
+                            sprintf (error, "Invalid character value `%c` (at %d:%d)", b, line_and_col);
+                            goto e_failed;
+                        }
+
+                        uc_b1 = (uc_b1 << 4) | uc_b2;
+                        uc_b2 = (uc_b3 << 4) | uc_b4;
+                        uchar2 = (uc_b1 << 8) | uc_b2;
+                        
+                        uchar = 0x010000 | ((uchar & 0x3FF) << 10) | (uchar2 & 0x3FF);
+                    }
+
+                    if (sizeof (json_char) >= sizeof (json_uchar) || (uchar <= 0x7F))
+                    {
+                       string_add ((json_char) uchar);
+                       break;
+                    }
+
+                    if (uchar <= 0x7FF)
+                    {
+                        if (state.first_pass)
+                           string_length += 2;
+                        else
+                        {  string [string_length ++] = 0xC0 | (uchar >> 6);
+                           string [string_length ++] = 0x80 | (uchar & 0x3F);
+                        }
+
+                        break;
+                    }
+
+                    if (uchar <= 0xFFFF) {
+                        if (state.first_pass)
+                           string_length += 3;
+                        else
+                        {  string [string_length ++] = 0xE0 | (uchar >> 12);
+                           string [string_length ++] = 0x80 | ((uchar >> 6) & 0x3F);
+                           string [string_length ++] = 0x80 | (uchar & 0x3F);
+                        }
+                        
+                        break;
+                    }
+
+                    if (state.first_pass)
+                       string_length += 4;
+                    else
+                    {  string [string_length ++] = 0xF0 | (uchar >> 18);
+                       string [string_length ++] = 0x80 | ((uchar >> 12) & 0x3F);
+                       string [string_length ++] = 0x80 | ((uchar >> 6) & 0x3F);
+                       string [string_length ++] = 0x80 | (uchar & 0x3F);
+                    }
+
+                    break;
+
+                  default:
+                     string_add (b);
+               };
+
+               continue;
+            }
+
+            if (b == '\\')
+            {
+               flags |= flag_escaped;
+               continue;
+            }
+
+            if (b == '"')
+            {
+               if (!state.first_pass)
+                  string [string_length] = 0;
+
+               flags &= ~ flag_string;
+               string = 0;
+
+               switch (top->type)
+               {
+                  case json_string:
+
+                     top->u.string.length = string_length;
+                     flags |= flag_next;
+
+                     break;
+
+                  case json_object:
+
+                     if (state.first_pass)
+                        (*(json_char **) &top->u.object.values) += string_length + 1;
+                     else
+                     {  
+                        top->u.object.values [top->u.object.length].name
+                           = (json_char *) top->_reserved.object_mem;
+
+                        top->u.object.values [top->u.object.length].name_length
+                           = string_length;
+
+                        (*(json_char **) &top->_reserved.object_mem) += string_length + 1;
+                     }
+
+                     flags |= flag_seek_value | flag_need_colon;
+                     continue;
+
+                  default:
+                     break;
+               };
+            }
+            else
+            {
+               string_add (b);
+               continue;
+            }
+         }
+
+         if (state.settings.settings & json_enable_comments)
+         {
+            if (flags & (flag_line_comment | flag_block_comment))
+            {
+               if (flags & flag_line_comment)
+               {
+                  if (b == '\r' || b == '\n' || !b)
+                  {
+                     flags &= ~ flag_line_comment;
+                     -- state.ptr;  /* so null can be reproc'd */
+                  }
+
+                  continue;
+               }
+
+               if (flags & flag_block_comment)
+               {
+                  if (!b)
+                  {  sprintf (error, "%d:%d: Unexpected EOF in block comment", line_and_col);
+                     goto e_failed;
+                  }
+
+                  if (b == '*' && state.ptr < (end - 1) && state.ptr [1] == '/')
+                  {
+                     flags &= ~ flag_block_comment;
+                     ++ state.ptr;  /* skip closing sequence */
+                  }
+
+                  continue;
+               }
+            }
+            else if (b == '/')
+            {
+               if (! (flags & (flag_seek_value | flag_done)) && top->type != json_object)
+               {  sprintf (error, "%d:%d: Comment not allowed here", line_and_col);
+                  goto e_failed;
+               }
+
+               if (++ state.ptr == end)
+               {  sprintf (error, "%d:%d: EOF unexpected", line_and_col);
+                  goto e_failed;
+               }
+
+               switch (b = *state.ptr)
+               {
+                  case '/':
+                     flags |= flag_line_comment;
+                     continue;
+
+                  case '*':
+                     flags |= flag_block_comment;
+                     continue;
+
+                  default:
+                     sprintf (error, "%d:%d: Unexpected `%c` in comment opening sequence", line_and_col, b);
+                     goto e_failed;
+               };
+            }
+         }
+
+         if (flags & flag_done)
+         {
+            if (!b)
+               break;
+
+            switch (b)
+            {
+               whitespace:
+                  continue;
+
+               default:
+
+                  sprintf (error, "%d:%d: Trailing garbage: `%c`",
+                           state.cur_line, state.cur_col, b);
+
+                  goto e_failed;
+            };
+         }
+
+         if (flags & flag_seek_value)
+         {
+            switch (b)
+            {
+               whitespace:
+                  continue;
+
+               case ']':
+
+                  if (top && top->type == json_array)
+                     flags = (flags & ~ (flag_need_comma | flag_seek_value)) | flag_next;
+                  else
+                  {  sprintf (error, "%d:%d: Unexpected ]", line_and_col);
+                     goto e_failed;
+                  }
+
+                  break;
+
+               default:
+
+                  if (flags & flag_need_comma)
+                  {
+                     if (b == ',')
+                     {  flags &= ~ flag_need_comma;
+                        continue;
+                     }
+                     else
+                     {
+                        sprintf (error, "%d:%d: Expected , before %c",
+                                 state.cur_line, state.cur_col, b);
+
+                        goto e_failed;
+                     }
+                  }
+
+                  if (flags & flag_need_colon)
+                  {
+                     if (b == ':')
+                     {  flags &= ~ flag_need_colon;
+                        continue;
+                     }
+                     else
+                     { 
+                        sprintf (error, "%d:%d: Expected : before %c",
+                                 state.cur_line, state.cur_col, b);
+
+                        goto e_failed;
+                     }
+                  }
+
+                  flags &= ~ flag_seek_value;
+
+                  switch (b)
+                  {
+                     case '{':
+
+                        if (!new_value (&state, &top, &root, &alloc, json_object))
+                           goto e_alloc_failure;
+
+                        continue;
+
+                     case '[':
+
+                        if (!new_value (&state, &top, &root, &alloc, json_array))
+                           goto e_alloc_failure;
+
+                        flags |= flag_seek_value;
+                        continue;
+
+                     case '"':
+
+                        if (!new_value (&state, &top, &root, &alloc, json_string))
+                           goto e_alloc_failure;
+
+                        flags |= flag_string;
+
+                        string = top->u.string.ptr;
+                        string_length = 0;
+
+                        continue;
+
+                     case 't':
+
+                        if ((end - state.ptr) < 3 || *(++ state.ptr) != 'r' ||
+                            *(++ state.ptr) != 'u' || *(++ state.ptr) != 'e')
+                        {
+                           goto e_unknown_value;
+                        }
+
+                        if (!new_value (&state, &top, &root, &alloc, json_boolean))
+                           goto e_alloc_failure;
+
+                        top->u.boolean = 1;
+
+                        flags |= flag_next;
+                        break;
+
+                     case 'f':
+
+                        if ((end - state.ptr) < 4 || *(++ state.ptr) != 'a' ||
+                            *(++ state.ptr) != 'l' || *(++ state.ptr) != 's' ||
+                            *(++ state.ptr) != 'e')
+                        {
+                           goto e_unknown_value;
+                        }
+
+                        if (!new_value (&state, &top, &root, &alloc, json_boolean))
+                           goto e_alloc_failure;
+
+                        flags |= flag_next;
+                        break;
+
+                     case 'n':
+
+                        if ((end - state.ptr) < 3 || *(++ state.ptr) != 'u' ||
+                            *(++ state.ptr) != 'l' || *(++ state.ptr) != 'l')
+                        {
+                           goto e_unknown_value;
+                        }
+
+                        if (!new_value (&state, &top, &root, &alloc, json_null))
+                           goto e_alloc_failure;
+
+                        flags |= flag_next;
+                        break;
+
+                     default:
+
+                        if (isdigit (b) || b == '-')
+                        {
+                           if (!new_value (&state, &top, &root, &alloc, json_integer))
+                              goto e_alloc_failure;
+
+                           if (!state.first_pass)
+                           {
+                              while (isdigit (b) || b == '+' || b == '-'
+                                        || b == 'e' || b == 'E' || b == '.')
+                              {
+                                 if ( (++ state.ptr) == end)
+                                 {
+                                    b = 0;
+                                    break;
+                                 }
+
+                                 b = *state.ptr;
+                              }
+
+                              flags |= flag_next | flag_reproc;
+                              break;
+                           }
+
+                           flags &= ~ (flag_num_negative | flag_num_e |
+                                        flag_num_e_got_sign | flag_num_e_negative |
+                                           flag_num_zero);
+
+                           num_digits = 0;
+                           num_fraction = 0;
+                           num_e = 0;
+
+                           if (b != '-')
+                           {
+                              flags |= flag_reproc;
+                              break;
+                           }
+
+                           flags |= flag_num_negative;
+                           continue;
+                        }
+                        else
+                        {  sprintf (error, "%d:%d: Unexpected %c when seeking value", line_and_col, b);
+                           goto e_failed;
+                        }
+                  };
+            };
+         }
+         else
+         {
+            switch (top->type)
+            {
+            case json_object:
+               
+               switch (b)
+               {
+                  whitespace:
+                     continue;
+
+                  case '"':
+
+                     if (flags & flag_need_comma)
+                     {  sprintf (error, "%d:%d: Expected , before \"", line_and_col);
+                        goto e_failed;
+                     }
+
+                     flags |= flag_string;
+
+                     string = (json_char *) top->_reserved.object_mem;
+                     string_length = 0;
+
+                     break;
+                  
+                  case '}':
+
+                     flags = (flags & ~ flag_need_comma) | flag_next;
+                     break;
+
+                  case ',':
+
+                     if (flags & flag_need_comma)
+                     {
+                        flags &= ~ flag_need_comma;
+                        break;
+                     }
+
+                  default:
+                     sprintf (error, "%d:%d: Unexpected `%c` in object", line_and_col, b);
+                     goto e_failed;
+               };
+
+               break;
+
+            case json_integer:
+            case json_double:
+
+               if (isdigit (b))
+               {
+                  ++ num_digits;
+
+                  if (top->type == json_integer || flags & flag_num_e)
+                  {
+                     if (! (flags & flag_num_e))
+                     {
+                        if (flags & flag_num_zero)
+                        {  sprintf (error, "%d:%d: Unexpected `0` before `%c`", line_and_col, b);
+                           goto e_failed;
+                        }
+
+                        if (num_digits == 1 && b == '0')
+                           flags |= flag_num_zero;
+                     }
+                     else
+                     {
+                        flags |= flag_num_e_got_sign;
+                        num_e = (num_e * 10) + (b - '0');
+                        continue;
+                     }
+
+                     top->u.integer = (top->u.integer * 10) + (b - '0');
+                     continue;
+                  }
+
+                  num_fraction = (num_fraction * 10) + (b - '0');
+                  continue;
+               }
+
+               if (b == '+' || b == '-')
+               {
+                  if ( (flags & flag_num_e) && !(flags & flag_num_e_got_sign))
+                  {
+                     flags |= flag_num_e_got_sign;
+
+                     if (b == '-')
+                        flags |= flag_num_e_negative;
+
+                     continue;
+                  }
+               }
+               else if (b == '.' && top->type == json_integer)
+               {
+                  if (!num_digits)
+                  {  sprintf (error, "%d:%d: Expected digit before `.`", line_and_col);
+                     goto e_failed;
+                  }
+
+                  top->type = json_double;
+                  top->u.dbl = (double) top->u.integer;
+
+                  num_digits = 0;
+                  continue;
+               }
+
+               if (! (flags & flag_num_e))
+               {
+                  if (top->type == json_double)
+                  {
+                     if (!num_digits)
+                     {  sprintf (error, "%d:%d: Expected digit after `.`", line_and_col);
+                        goto e_failed;
+                     }
+
+                     top->u.dbl += ((double) num_fraction) / (pow (10.0, (double) num_digits));
+                  }
+
+                  if (b == 'e' || b == 'E')
+                  {
+                     flags |= flag_num_e;
+
+                     if (top->type == json_integer)
+                     {
+                        top->type = json_double;
+                        top->u.dbl = (double) top->u.integer;
+                     }
+
+                     num_digits = 0;
+                     flags &= ~ flag_num_zero;
+
+                     continue;
+                  }
+               }
+               else
+               {
+                  if (!num_digits)
+                  {  sprintf (error, "%d:%d: Expected digit after `e`", line_and_col);
+                     goto e_failed;
+                  }
+
+                  top->u.dbl *= pow (10.0, (double)
+                      (flags & flag_num_e_negative ? - num_e : num_e));
+               }
+
+               if (flags & flag_num_negative)
+               {
+                  if (top->type == json_integer)
+                     top->u.integer = - top->u.integer;
+                  else
+                     top->u.dbl = - top->u.dbl;
+               }
+
+               flags |= flag_next | flag_reproc;
+               break;
+
+            default:
+               break;
+            };
+         }
+
+         if (flags & flag_reproc)
+         {
+            flags &= ~ flag_reproc;
+            -- state.ptr;
+         }
+
+         if (flags & flag_next)
+         {
+            flags = (flags & ~ flag_next) | flag_need_comma;
+
+            if (!top->parent)
+            {
+               /* root value done */
+
+               flags |= flag_done;
+               continue;
+            }
+
+            if (top->parent->type == json_array)
+               flags |= flag_seek_value;
+               
+            if (!state.first_pass)
+            {
+               json_value * parent = top->parent;
+
+               switch (parent->type)
+               {
+                  case json_object:
+
+                     parent->u.object.values
+                        [parent->u.object.length].value = top;
+
+                     break;
+
+                  case json_array:
+
+                     parent->u.array.values
+                           [parent->u.array.length] = top;
+
+                     break;
+
+                  default:
+                     break;
+               };
+            }
+
+            if ( (++ top->parent->u.array.length) > state.uint_max)
+               goto e_overflow;
+
+            top = top->parent;
+
+            continue;
+         }
+      }
+
+      alloc = root;
+   }
+
+   return root;
+
+e_unknown_value:
+
+   sprintf (error, "%d:%d: Unknown value", line_and_col);
+   goto e_failed;
+
+e_alloc_failure:
+
+   strcpy (error, "Memory allocation failure");
+   goto e_failed;
+
+e_overflow:
+
+   sprintf (error, "%d:%d: Too long (caught overflow)", line_and_col);
+   goto e_failed;
+
+e_failed:
+
+   if (error_buf)
+   {
+      if (*error)
+         strcpy (error_buf, error);
+      else
+         strcpy (error_buf, "Unknown error");
+   }
+
+   if (state.first_pass)
+      alloc = root;
+
+   while (alloc)
+   {
+      top = alloc->_reserved.next_alloc;
+      state.settings.mem_free (alloc, state.settings.user_data);
+      alloc = top;
+   }
+
+   if (!state.first_pass)
+      json_value_free_ex (&state.settings, root);
+
+   return 0;
+}
+
+json_value * json_parse (const json_char * json, size_t length)
+{
+   json_settings settings = { 0 };
+   return json_parse_ex (&settings, json, length, 0);
+}
+
+void json_value_free_ex (json_settings * settings, json_value * value)
+{
+   json_value * cur_value;
+
+   if (!value)
+      return;
+
+   value->parent = 0;
+
+   while (value)
+   {
+      switch (value->type)
+      {
+         case json_array:
+
+            if (!value->u.array.length)
+            {
+               settings->mem_free (value->u.array.values, settings->user_data);
+               break;
+            }
+
+            value = value->u.array.values [-- value->u.array.length];
+            continue;
+
+         case json_object:
+
+            if (!value->u.object.length)
+            {
+               settings->mem_free (value->u.object.values, settings->user_data);
+               break;
+            }
+
+            value = value->u.object.values [-- value->u.object.length].value;
+            continue;
+
+         case json_string:
+
+            settings->mem_free (value->u.string.ptr, settings->user_data);
+            break;
+
+         default:
+            break;
+      };
+
+      cur_value = value;
+      value = value->parent;
+      settings->mem_free (cur_value, settings->user_data);
+   }
+}
+
+void json_value_free (json_value * value)
+{
+   json_settings settings = { 0 };
+   settings.mem_free = default_free;
+   json_value_free_ex (&settings, value);
+}
+

--- a/gui/source/json/json.h
+++ b/gui/source/json/json.h
@@ -1,0 +1,283 @@
+
+/* vim: set et ts=3 sw=3 sts=3 ft=c:
+ *
+ * Copyright (C) 2012, 2013, 2014 James McLaughlin et al.  All rights reserved.
+ * https://github.com/udp/json-parser
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _JSON_H
+#define _JSON_H
+
+#ifndef json_char
+   #define json_char char
+#endif
+
+#ifndef json_int_t
+   #ifndef _MSC_VER
+      #include <inttypes.h>
+      #define json_int_t int64_t
+   #else
+      #define json_int_t __int64
+   #endif
+#endif
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+   #include <string.h>
+
+   extern "C"
+   {
+
+#endif
+
+typedef struct
+{
+   unsigned long max_memory;
+   int settings;
+
+   /* Custom allocator support (leave null to use malloc/free)
+    */
+
+   void * (* mem_alloc) (size_t, int zero, void * user_data);
+   void (* mem_free) (void *, void * user_data);
+
+   void * user_data;  /* will be passed to mem_alloc and mem_free */
+
+   size_t value_extra;  /* how much extra space to allocate for values? */
+
+} json_settings;
+
+#define json_enable_comments  0x01
+
+typedef enum
+{
+   json_none,
+   json_object,
+   json_array,
+   json_integer,
+   json_double,
+   json_string,
+   json_boolean,
+   json_null
+
+} json_type;
+
+extern const struct _json_value json_value_none;
+       
+typedef struct _json_object_entry
+{
+    json_char * name;
+    unsigned int name_length;
+    
+    struct _json_value * value;
+    
+} json_object_entry;
+
+typedef struct _json_value
+{
+   struct _json_value * parent;
+
+   json_type type;
+
+   union
+   {
+      int boolean;
+      json_int_t integer;
+      double dbl;
+
+      struct
+      {
+         unsigned int length;
+         json_char * ptr; /* null terminated */
+
+      } string;
+
+      struct
+      {
+         unsigned int length;
+
+         json_object_entry * values;
+
+         #if defined(__cplusplus) && __cplusplus >= 201103L
+         decltype(values) begin () const
+         {  return values;
+         }
+         decltype(values) end () const
+         {  return values + length;
+         }
+         #endif
+
+      } object;
+
+      struct
+      {
+         unsigned int length;
+         struct _json_value ** values;
+
+         #if defined(__cplusplus) && __cplusplus >= 201103L
+         decltype(values) begin () const
+         {  return values;
+         }
+         decltype(values) end () const
+         {  return values + length;
+         }
+         #endif
+
+      } array;
+
+   } u;
+
+   union
+   {
+      struct _json_value * next_alloc;
+      void * object_mem;
+
+   } _reserved;
+
+   #ifdef JSON_TRACK_SOURCE
+
+      /* Location of the value in the source JSON
+       */
+      unsigned int line, col;
+
+   #endif
+
+
+   /* Some C++ operator sugar */
+
+   #ifdef __cplusplus
+
+      public:
+
+         inline _json_value ()
+         {  memset (this, 0, sizeof (_json_value));
+         }
+
+         inline const struct _json_value &operator [] (int index) const
+         {
+            if (type != json_array || index < 0
+                     || ((unsigned int) index) >= u.array.length)
+            {
+               return json_value_none;
+            }
+
+            return *u.array.values [index];
+         }
+
+         inline const struct _json_value &operator [] (const char * index) const
+         { 
+            if (type != json_object)
+               return json_value_none;
+
+            for (unsigned int i = 0; i < u.object.length; ++ i)
+               if (!strcmp (u.object.values [i].name, index))
+                  return *u.object.values [i].value;
+
+            return json_value_none;
+         }
+
+         inline operator const char * () const
+         {  
+            switch (type)
+            {
+               case json_string:
+                  return u.string.ptr;
+
+               default:
+                  return "";
+            };
+         }
+
+         inline operator json_int_t () const
+         {  
+            switch (type)
+            {
+               case json_integer:
+                  return u.integer;
+
+               case json_double:
+                  return (json_int_t) u.dbl;
+
+               default:
+                  return 0;
+            };
+         }
+
+         inline operator bool () const
+         {  
+            if (type != json_boolean)
+               return false;
+
+            return u.boolean != 0;
+         }
+
+         inline operator double () const
+         {  
+            switch (type)
+            {
+               case json_integer:
+                  return (double) u.integer;
+
+               case json_double:
+                  return u.dbl;
+
+               default:
+                  return 0;
+            };
+         }
+
+   #endif
+
+} json_value;
+       
+json_value * json_parse (const json_char * json,
+                         size_t length);
+
+#define json_error_max 128
+json_value * json_parse_ex (json_settings * settings,
+                            const json_char * json,
+                            size_t length,
+                            char * error);
+
+void json_value_free (json_value *);
+
+
+/* Not usually necessary, unless you used a custom mem_alloc and now want to
+ * use a custom mem_free.
+ */
+void json_value_free_ex (json_settings * settings,
+                         json_value *);
+
+
+#ifdef __cplusplus
+   } /* extern "C" */
+#endif
+
+#endif
+
+

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -1889,11 +1889,21 @@ int main()
 									StoreBoxArtPath(path);
 								} else {
 									// example: ASME.png
-									snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
-									if (access(path, F_OK) != -1) {
+									// check first if boxart exist on fcboxartfolder by TID
+									memset(path, 0, sizeof(path));
+									snprintf(path, sizeof(path), "%s/%.4s.png", fcboxartfolder, ba_TID);
+									if (access(path, F_OK ) != -1 ) {
 										StoreBoxArtPath(path);
 									} else {
-										StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+										// Boxart doesn't exist in fxboxartfolder neither by name nor by TID
+										// maybe on boxart (sd) folder?
+										memset(path, 0, sizeof(path));
+										snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
+										if (access(path, F_OK) != -1) {
+											StoreBoxArtPath(path);
+										} else {
+											StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+										}
 									}
 								}
 							} else {
@@ -1924,11 +1934,21 @@ int main()
 									StoreBoxArtPath(path);
 								} else {
 									// example: ASME.png
-									snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
-									if (access(path, F_OK) != -1) {
+									// check first if boxart exist on fcboxartfolder by TID
+									memset(path, 0, sizeof(path)); 
+									snprintf(path, sizeof(path), "%s/%.4s.png", fcboxartfolder, ba_TID);
+									if (access(path, F_OK ) != -1 ) {
 										StoreBoxArtPath(path);
 									} else {
-										StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+										// Boxart doesn't exist in fxboxartfolder neither by name nor by TID
+										// maybe on boxart (sd) folder?
+										memset(path, 0, sizeof(path));
+										snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
+										if (access(path, F_OK) != -1) {
+											StoreBoxArtPath(path);
+										} else {
+											StoreBoxArtPath("romfs:/graphics/boxart_unknown.png");
+										}
 									}
 								}
 							} else {

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -3626,12 +3626,12 @@ int main()
 							} else {
 								rom = matching_files.at(cursorPosition).c_str();
 							}
-							LogFM("Delete mode enabled (flashcard)", rom);
+							if (logEnabled)	LogFM("Delete mode enabled (flashcard)", rom);
 							snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), rom);
 							fcfiles.erase(fcfiles.begin() + cursorPosition);
 							snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size());
 							
-							LogFMA("Delete mode", ".ini file deleted", path);
+							if (logEnabled)	LogFMA("Delete mode", ".ini file deleted", path);
 							CIniFile setfcrompathini(path);
 							std::string ba_TIDini = setfcrompathini.GetString(fcrompathini_flashcardrom, fcrompathini_tid, "");
 
@@ -3643,27 +3643,27 @@ int main()
 							
 							memset(path, 0, sizeof(path));
 							snprintf(path, sizeof(path), "%s/%.4s.png", fcboxartfolder, ba_TID);
-							LogFM("Trying to delete boxart", path);
+							if (logEnabled)	LogFM("Trying to delete boxart", path);
 							remove(path); // Remove .png
-							LogFM("Delete mode", ".png file deleted");
+							if (logEnabled)	LogFM("Delete mode", ".png file deleted");
 							
 							memset(path, 0, sizeof(path));
 							snprintf(path, sizeof(path), "%s/%s.bin", fcbnriconfolder, rom);
-							LogFM("Trying to delete banner data", path);
+							if (logEnabled)	LogFM("Trying to delete banner data", path);
 							remove(path); // Remove the .bin
-							LogFM("Delete mode", ".bin file deleted");
+							if (logEnabled)	LogFM("Delete mode", ".bin file deleted");
 						} else {
 							if(matching_files.size() == 0){
 								rom = files.at(cursorPosition).c_str();
 							} else {
 								rom = matching_files.at(cursorPosition).c_str();
 							}
-							LogFM("Delete mode enabled (SD)", rom);
+							if (logEnabled)	LogFM("Delete mode enabled (SD)", rom);
 							snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), rom);
 							files.erase(files.begin() + cursorPosition);
 							snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
 							
-							LogFM("Delete mode", ".nds file deleted");
+							if (logEnabled)	LogFMA("Delete mode", ".nds file deleted", path);
 							FILE *f_nds_file = fopen(path, "rb");
 							
 							char ba_TID[5];
@@ -3675,15 +3675,15 @@ int main()
 							
 							memset(path, 0, sizeof(path));
 							snprintf(path, sizeof(path), "%s/%.4s.png", fcboxartfolder, ba_TID);
-							LogFM("Trying to delete boxart", path);
+							if (logEnabled)	LogFM("Trying to delete boxart", path);
 							remove(path); // Remove .png
-							LogFM("Delete mode", ".png file deleted");
+							if (logEnabled)	LogFM("Delete mode", ".png file deleted");
 							
 							memset(path, 0, sizeof(path));
 							snprintf(path, sizeof(path), "%s/%s.bin", bnriconfolder, rom);
-							LogFM("Trying to delete banner data", path);
+							if (logEnabled)	LogFM("Trying to delete banner data", path);
 							remove(path); // Remove the .bin
-							LogFM("Delete mode", ".bin file deleted");
+							if (logEnabled)	LogFM("Delete mode", ".bin file deleted");
 						}
 						pagenum = 0; // Go to page 0
 						cursorPosition = 0; // Move the cursor to 0

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -4238,20 +4238,7 @@ int main()
 											rom = fcfiles.at(cursorPosition).c_str();
 										}else{
 											rom = matching_files.at(cursorPosition).c_str();
-										}
-										char path[0xFF];
-										snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), rom);
-										remove(path);
-										// Now is deleted from SD but not from memory									
-										fcfiles.erase(fcfiles.begin() + cursorPosition); // Because we already know the rom position									
-										pagenum = 0; // Go to page 0
-										cursorPosition = 0; // Move the cursor to 0
-										storedcursorPosition = cursorPosition; // Move the cursor to 0
-										titleboxXmovepos = 0; // Move the cursor to 0
-										boxartXmovepos = 0; // Move the cursor to 0
-										snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size()); // Reload counter
-										boxarttexloaded = false; // Reload boxarts
-										bnricontexloaded = false; // Reload banner icons
+										}										
 									} else {
 										if(matching_files.size() == 0){
 											rom = files.at(cursorPosition).c_str();

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -3616,12 +3616,14 @@ int main()
 				if(titleboxXmovetimer == 0 && menu_ctrlset == CTRL_SET_GAMESEL) {
 					if(hDown & KEY_R) {
 						menuaction_nextpage = true;
-					} else if(hDown & KEY_L) {
-						menuaction_prevpage = true;
+					} else if(hidKeysUp() & KEY_L) {
+						if ((hHeld & KEY_X) | (hDown & KEY_X) | (hidKeysUp() & KEY_X)) {
+							addgametodeletequeue = true;							
+						} else {
+							menuaction_prevpage = true;
+						}
 					} else if(hDown & KEY_X) {
 						buttondeletegame = true;
-					} else if((hDown & KEY_L) && (hDown & KEY_X)) {
-						addgametodeletequeue = true;
 					}
 					if(hDown & KEY_Y) {
 						if (dspfirmfound) {

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -3593,6 +3593,30 @@ int main()
 						}
 						settings.ui.iconsize = !settings.ui.iconsize;
 					}
+					if(hDown & KEY_X) {
+						// Delete game mode
+						if (settings.twl.forwarder) {
+							if(matching_files.size() == 0){
+								rom = fcfiles.at(cursorPosition).c_str();
+							} else {
+								rom = matching_files.at(cursorPosition).c_str();
+							}
+						}
+						char path[0xFF];
+						snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), rom);
+						remove(path);
+						// Now is deleted from SD but not from memory									
+						fcfiles.erase(fcfiles.begin() + cursorPosition); // Because we already know the rom position									
+						pagenum = 0; // Go to page 0
+						cursorPosition = 0; // Move the cursor to 0
+						storedcursorPosition = cursorPosition; // Move the cursor to 0
+						titleboxXmovepos = 0; // Move the cursor to 0
+						boxartXmovepos = 0; // Move the cursor to 0
+						snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size()); // Reload counter
+						boxarttexloaded = false; // Reload boxarts
+						bnricontexloaded = false; // Reload banner icons
+						bannertextloaded = false; // Reload banner text after deletion
+					}
 					hidTouchRead(&touch);
 					if(hDown & KEY_TOUCH){
 						if (touch.px >= 128 && touch.px <= 192 && touch.py >= 112 && touch.py <= 192) {
@@ -4113,20 +4137,6 @@ int main()
 									} else {
 										rom = matching_files.at(cursorPosition).c_str();
 									}
-									char path[0xFF];
-									snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), rom);
-									remove(path);
-									// Now is deleted from SD but not from memory									
-									fcfiles.erase(fcfiles.begin() + cursorPosition); // Because we already know the rom position									
-									pagenum = 0; // Go to page 0
-									cursorPosition = 0; // Move the cursor to 0
-									storedcursorPosition = cursorPosition; // Move the cursor to 0
-									titleboxXmovepos = 0; // Move the cursor to 0
-									boxartXmovepos = 0; // Move the cursor to 0
-									snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size()); // Reload counter
-									boxarttexloaded = false; // Reload boxarts
-									bnricontexloaded = false; // Reload banner icons
-									bannertextloaded = false; // Reload banner text after deletion
 								} else {
 									if(matching_files.size() == 0){
 										rom = files.at(cursorPosition).c_str();

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -54,6 +54,7 @@ bool menuaction_nextpage = false;
 bool menuaction_prevpage = false;
 bool menuaction_launch = false;
 bool menudboxaction_switchloc = false;
+bool buttondeletegame = false;
 
 CIniFile bootstrapini( "sdmc:/_nds/nds-bootstrap.ini" );
 #include "ndsheaderbanner.h"
@@ -3608,6 +3609,8 @@ int main()
 						menuaction_nextpage = true;
 					} else if(hDown & KEY_L) {
 						menuaction_prevpage = true;
+					} else if(hDown & KEY_X) {
+						buttondeletegame = true;
 					}
 					if(hDown & KEY_Y) {
 						if (dspfirmfound) {
@@ -3616,8 +3619,9 @@ int main()
 						}
 						settings.ui.iconsize = !settings.ui.iconsize;
 					}
-					if(hDown & KEY_X) {
+					if(buttondeletegame) {
 						// Delete game mode
+						buttondeletegame = false; // Prevent deleting by accident
 						
 						char path[256];
 						if (settings.twl.forwarder) {

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -3674,7 +3674,7 @@ int main()
 							remove(path); // Remove .nds after reading TID.
 							
 							memset(path, 0, sizeof(path));
-							snprintf(path, sizeof(path), "%s/%.4s.png", fcboxartfolder, ba_TID);
+							snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, ba_TID);
 							if (logEnabled)	LogFM("Trying to delete boxart", path);
 							remove(path); // Remove .png
 							if (logEnabled)	LogFM("Delete mode", ".png file deleted");

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -194,8 +194,6 @@ const char* noromtext2;
 int RGB[3]; // Pergame LED
 
 // Version numbers.
-
-char settings_previousvertext[13];
 char settings_vertext[13];
 
 std::string settings_releasebootstrapver;
@@ -1419,7 +1417,7 @@ int main()
 	//mkdir("sdmc:/_nds/twloader/tmp", 0777);
 	if (logEnabled)	LogFM("Main.Directories", "Directories are made, or already made");
 	
-	snprintf(settings_vertext, 13, "Ver. %d.%d.%d   ", VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO);
+	snprintf(settings_vertext, 13, "Ver. %d.%d.%d", VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO);
 	if (logEnabled)	LogFMA("Main.GUI version", "Successful reading version", settings_vertext);
 
 	LoadSettings();	

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -224,6 +224,7 @@ static const char bnriconfolder[] = "sdmc:/_nds/twloader/bnricons";
 static const char fcbnriconfolder[] = "sdmc:/_nds/twloader/bnricons/flashcard";
 static const char boxartfolder[] = "sdmc:/_nds/twloader/boxart";
 static const char fcboxartfolder[] = "sdmc:/_nds/twloader/boxart/flashcard";
+static const char slot1boxartfolder[] = "sdmc:/_nds/twloader/boxart/slot1";
 // End
 	
 bool keepsdvalue = false;
@@ -1004,7 +1005,7 @@ static void loadSlot1BoxArt(void)
 		char path[256];
 		// example: ASME.png
 		if (logEnabled)	LogFMA("Main", "Loading Slot-1 box art", gameID);
-		snprintf(path, sizeof(path), "%s/%.4s.png", boxartfolder, gameID);
+		snprintf(path, sizeof(path), "%s/%.4s.png", slot1boxartfolder, gameID);
 		if (access(path, F_OK) != -1) {
 			new_tex = sfil_load_PNG_file(path, SF2D_PLACE_RAM);
 		} else {
@@ -1331,6 +1332,8 @@ int main()
 	mkdir("sdmc:/_nds/twloader/bnricons", 0777);
 	mkdir("sdmc:/_nds/twloader/bnricons/flashcard", 0777);
 	mkdir("sdmc:/_nds/twloader/boxart", 0777);
+	mkdir("sdmc:/_nds/twloader/boxart/flashcard", 0777);
+	mkdir("sdmc:/_nds/twloader/boxart/slot1", 0777);
 	mkdir("sdmc:/_nds/twloader/gamesettings", 0777);
 	mkdir("sdmc:/_nds/twloader/gamesettings/flashcard", 0777);
 	mkdir("sdmc:/_nds/twloader/loadflashcard", 0777);

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -3626,7 +3626,7 @@ int main()
 							} else {
 								rom = matching_files.at(cursorPosition).c_str();
 							}
-							LogFM("Delete mode enabled (flashcard)", rom);						
+							LogFM("Delete mode enabled (flashcard)", rom);
 							snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), rom);
 							fcfiles.erase(fcfiles.begin() + cursorPosition);
 							snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size());
@@ -3643,9 +3643,15 @@ int main()
 							
 							memset(path, 0, sizeof(path));
 							snprintf(path, sizeof(path), "%s/%.4s.png", fcboxartfolder, ba_TID);
-							LogFM("Trying to delete boxart", path);							
+							LogFM("Trying to delete boxart", path);
 							remove(path); // Remove .png
 							LogFM("Delete mode", ".png file deleted");
+							
+							memset(path, 0, sizeof(path));
+							snprintf(path, sizeof(path), "%s/%s.bin", fcbnriconfolder, rom);
+							LogFM("Trying to delete banner data", path);
+							remove(path); // Remove the .bin
+							LogFM("Delete mode", ".bin file deleted");
 						} else {
 							if(matching_files.size() == 0){
 								rom = files.at(cursorPosition).c_str();
@@ -3672,6 +3678,12 @@ int main()
 							LogFM("Trying to delete boxart", path);
 							remove(path); // Remove .png
 							LogFM("Delete mode", ".png file deleted");
+							
+							memset(path, 0, sizeof(path));
+							snprintf(path, sizeof(path), "%s/%s.bin", bnriconfolder, rom);
+							LogFM("Trying to delete banner data", path);
+							remove(path); // Remove the .bin
+							LogFM("Delete mode", ".bin file deleted");
 						}
 						pagenum = 0; // Go to page 0
 						cursorPosition = 0; // Move the cursor to 0

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -3708,7 +3708,7 @@ int main()
 									remove(path); // Remove the .bin
 									if (logEnabled)	LogFM("Delete mode", ".bin file deleted");
 									
-									delete_queue.erase(it);
+									delete_queue.erase(iter);
 									if (logEnabled)	LogFMA("Delete mode", "Rom deleted from queue", rom_iter.c_str());
 								}
 							}
@@ -3750,7 +3750,7 @@ int main()
 									remove(path); // Remove the .bin
 									if (logEnabled)	LogFM("Delete mode", ".bin file deleted");
 									
-									delete_queue.erase(it);
+									delete_queue.erase(iter);
 									if (logEnabled)	LogFMA("Delete mode", "Rom deleted from queue", rom_iter.c_str());
 								}
 							}							

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -3618,24 +3618,66 @@ int main()
 					}
 					if(hDown & KEY_X) {
 						// Delete game mode
+						
+						char path[256];
 						if (settings.twl.forwarder) {
 							if(matching_files.size() == 0){
 								rom = fcfiles.at(cursorPosition).c_str();
 							} else {
 								rom = matching_files.at(cursorPosition).c_str();
 							}
+							LogFM("Delete mode enabled (flashcard)", rom);						
+							snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), rom);
+							fcfiles.erase(fcfiles.begin() + cursorPosition);
+							snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size());
+							
+							LogFMA("Delete mode", ".ini file deleted", path);
+							CIniFile setfcrompathini(path);
+							std::string ba_TIDini = setfcrompathini.GetString(fcrompathini_flashcardrom, fcrompathini_tid, "");
+
+							char ba_TID[5];
+							strcpy(ba_TID, ba_TIDini.c_str());
+							ba_TID[4] = 0;
+							
+							remove(path); // Remove .ini after reading TID.
+							
+							memset(path, 0, sizeof(path));
+							snprintf(path, sizeof(path), "%s/%.4s.png", fcboxartfolder, ba_TID);
+							LogFM("Trying to delete boxart", path);							
+							remove(path); // Remove .png
+							LogFM("Delete mode", ".png file deleted");
+						} else {
+							if(matching_files.size() == 0){
+								rom = files.at(cursorPosition).c_str();
+							} else {
+								rom = matching_files.at(cursorPosition).c_str();
+							}
+							LogFM("Delete mode enabled (SD)", rom);
+							snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.romfolder.c_str(), rom);
+							files.erase(files.begin() + cursorPosition);
+							snprintf(romsel_counter2sd, sizeof(romsel_counter2sd), "%zu", files.size());
+							
+							LogFM("Delete mode", ".nds file deleted");
+							FILE *f_nds_file = fopen(path, "rb");
+							
+							char ba_TID[5];
+							grabTID(f_nds_file, ba_TID);
+							ba_TID[4] = 0;
+							fclose(f_nds_file);
+							
+							remove(path); // Remove .nds after reading TID.
+							
+							memset(path, 0, sizeof(path));
+							snprintf(path, sizeof(path), "%s/%.4s.png", fcboxartfolder, ba_TID);
+							LogFM("Trying to delete boxart", path);
+							remove(path); // Remove .png
+							LogFM("Delete mode", ".png file deleted");
 						}
-						char path[0xFF];
-						snprintf(path, sizeof(path), "sdmc:/%s/%s", settings.ui.fcromfolder.c_str(), rom);
-						remove(path);
-						// Now is deleted from SD but not from memory									
-						fcfiles.erase(fcfiles.begin() + cursorPosition); // Because we already know the rom position									
 						pagenum = 0; // Go to page 0
 						cursorPosition = 0; // Move the cursor to 0
 						storedcursorPosition = cursorPosition; // Move the cursor to 0
 						titleboxXmovepos = 0; // Move the cursor to 0
 						boxartXmovepos = 0; // Move the cursor to 0
-						snprintf(romsel_counter2fc, sizeof(romsel_counter2fc), "%zu", fcfiles.size()); // Reload counter
 						boxarttexloaded = false; // Reload boxarts
 						bnricontexloaded = false; // Reload banner icons
 						bannertextloaded = false; // Reload banner text after deletion

--- a/gui/source/main.h
+++ b/gui/source/main.h
@@ -44,7 +44,6 @@ extern sf2d_texture *settingslogotex;	// TWLoader logo.
 extern std::string settings_releasebootstrapver;
 extern std::string settings_unofficialbootstrapver;
 extern char settings_vertext[13];
-extern char settings_previousvertext[13];
 
 extern const u64 TWLNAND_TID;	// TWLNAND title ID.
 extern bool checkTWLNANDSide(void);


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->

EDIT: The crash is only present if you have exactly (only found the bug with this number), 12 roms/.ini files on memory. I mean, you have 15, delete one, go to game 12 of 14 and it crash.

#### What's new?
-Delete code now is assigned to X button (only tested on DSi theme)
-Move boxarts to boxart\flashcard and boxart\slot1 (sd rom boxarts are still on boxart folder)
-Modify a bit boxart download code adding a new enum.
09/05/17
-Add some code to prevent double press on X button. This would avoid also accident deletions.
-Render boxart cont in dialogbox
10/05/17
-Add more code to delete mode 
-Add a delete queue pressing L+X
11/05/17
-Now you can delete only one or a queue
-Simplify a lot delete code using a new internal method
12/05/17
-Add a new selective update method (WIP and really need more help to add it since this PR it's too huge to just add it myself)

#### What is fixed?

-Some bugs affecting boxarts and it location
09/05/17
-Display correctly dialogbox of boxarts
11/05/17
-Fix a bug in delete mode affecting boxarts
12/05/17
-Some errors of yesterday's commit iirc

#### Where have you tested it?

Only on OLD 3DS XL + A9LH + Luma + 11.4 without flashcard
Only with .nds and .ini files (with and without banner and with and without boxarts)
Boxarts have been tested by TID and filename (only one of them, in order filename -> TID -> no boxart)
Unable to test with real flashcard banner files (atm)
Only tested on DSi theme. (X and L+X are not added to others themes yet until DSi theme is perfectly done without issues)

#### Why is not ready yet?

It's almost ready. There are some bugs yet
a) Crash after deleting games if you go to position 12 (only after deleting)
b) Strange boxart after curpostition+1
c) Not all selective update method is fully completed

*** 
#### Pull Request status
- [x]  This PR has been tested using latest DEVKITPRO, DEVKITARM, SFILLIB, SF2DLIB, LIBNDS and Citro3DS.  

_(Do not edit after this point)_
- [x]  This PR is fully documented.
- [x]  This PR has been tested before sending.
- [x]  This PR follows C style and convention.

