### PR TITLE
main.cpp: fix for https://github.com/Robz8/TWLoader/issues/270

### DIFF
--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -2447,9 +2447,29 @@ int main()
 						if (cursorPosition < 0)
 							cursorPosition = 0;
 					} else {
-						cursorPosition = 0+pagenum*20; // This is to reset cursor position after switching from R4 theme.
-						storedcursorPosition = cursorPosition; // This is to reset cursor position after switching from R4 theme.
+						pagenum = 0; // Go to page 0
 						titleboxXmovepos = 0;
+						cursorPosition = 0 + pagenum * 20; // This is to reset cursor position after switching from R4 theme.
+						if (settings.twl.forwarder) {
+							if (fcfiles.size() <= 0) {
+								startbordermovepos = 0;
+								startborderscalesize = 1.0;
+								// No ROMs were found.
+								cursorPosition = -1;
+								titleboxXmovepos = +64;
+								noromsfound = true;
+							}
+						} else {
+							if (files.size() <= 0) {
+								startbordermovepos = 0;
+								startborderscalesize = 1.0;
+								// No ROMs were found.
+								cursorPosition = -1;
+								titleboxXmovepos = +64;
+								noromsfound = true;
+							}
+						}							
+						storedcursorPosition = cursorPosition; // This is to reset cursor position after switching from R4 theme.
 						boxartXmovepos = 0;
 						// Reload 1st box art
 						LoadBoxArt_WoodTheme(0-pagenum*20);


### PR DESCRIPTION
This is a fix affecting  "no roms" detection after exiting settings.

<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->

#### What's new?
Bug fixing.
#### What is fixed?
A bug affecting "no roms" after exiting settings.
#### Where have you tested it?
OLD 3DSXL as always. Same config as always too. 
Tested with and without roms, on SD and FC side too.
*** 
#### Pull Request status
- [x]  This PR has been tested using latest DEVKITPRO, DEVKITARM, SFILLIB, SF2DLIB, LIBNDS and Citro3DS.  

_(Do not edit after this point)_
- [x]  This PR is fully documented.
- [x]  This PR has been tested before sending.
- [x]  This PR follows C style and convention.
