### PR TITLE
Fix text is out of screen when using other languages

### DIFF
--- a/gui/source/dsbootsplash.cpp
+++ b/gui/source/dsbootsplash.cpp
@@ -426,7 +426,8 @@ void bootSplash() {
 		
 		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
 		drawRectangle(0, 0, 320, 240, RGBA8(255, 255, 255, 255));
-		switch (settings.ui.language) {
+
+		switch ((settings.ui.language < 0 || settings.ui.language >= 12)? sys_language : settings.ui.language) {
 			case 0:
 			// Japanese
 				if (settings.ui.healthsafety) {


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's new?

Nothing, it's a fix

#### What is fixed?

Fix issue: https://github.com/Robz8/TWLoader/issues/317
When we are going to show ds boot screen, it will check setting language, and if there's any error or system language is select, it will choose the language based on the 3ds system language.

#### Where have you tested it?

I tested on my real N3DS, Boot9Strap 1.2, Luma 8.1

*** 
#### Pull Request status
- [X]  This PR has been tested using latest DEVKITPRO, DEVKITARM, SFILLIB, SF2DLIB, LIBNDS and Citro3DS.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
