### PR TITLE
dsbootsplash.cpp: Remove Slot-1 polling entirely.

### DIFF
--- a/gui/source/dsbootsplash.cpp
+++ b/gui/source/dsbootsplash.cpp
@@ -269,9 +269,7 @@ void bootSplash() {
 	while (aptMainLoop()) {
 		// Scan hid shared memory for input events
 		hidScanInput();
-
 		const u32 hDown = hidKeysDown();
-		const u32 hHeld = hidKeysHeld();
 		
 		textVtxArrayPos = 0; // Clear the text vertex array
 		

--- a/gui/source/dsbootsplash.cpp
+++ b/gui/source/dsbootsplash.cpp
@@ -96,8 +96,8 @@ void bootSplash() {
 		bigotex = sfil_load_PNG_file("romfs:/graphics/BootSplash/bigo.png", SF2D_PLACE_RAM);
 		nintendotex = sfil_load_PNG_file("romfs:/graphics/BootSplash/nintendo.png", SF2D_PLACE_RAM);
 	}
-	sf2d_texture *hstexttex;
-	sf2d_texture *hstouchtex;
+	sf2d_texture *hstexttex = NULL;
+	sf2d_texture *hstouchtex = NULL;
 	if (settings.ui.bootscreen >= 3) {
 		if (settings.ui.language == 0) {
 			hstexttex = sfil_load_PNG_file("romfs:/graphics/BootSplash/inv_HS_JP.png", SF2D_PLACE_RAM);
@@ -640,26 +640,16 @@ void bootSplash() {
 
 	if (logEnabled)	LogFM("BootSplash", "Freeing textures");
 	sf2d_free_texture(ndslogotex);
-	ndslogotex = NULL;
 	sf2d_free_texture(itex);
-	itex = NULL;
 	sf2d_free_texture(topotex);
-	topotex = NULL;
 	sf2d_free_texture(bottomotex);
-	bottomotex = NULL;
 	sf2d_free_texture(bigotex);
-	bigotex = NULL;
 	sf2d_free_texture(nintendotex);
-	nintendotex = NULL;
 	if (settings.ui.language == 0 || settings.ui.language == 6 || settings.ui.language == 7 || settings.ui.language == 11) {
 		sf2d_free_texture(hstexttex);
-		hstexttex = NULL;
 		sf2d_free_texture(hstouchtex);
-		hstouchtex = NULL;
 	}
 	sf2d_free_texture(hstex);
-	hstex = NULL;
 	sf2d_free_texture(wipetex);
-	wipetex = NULL;
 	if (logEnabled)	LogFM("BootSplash", "Textures freed up");
 }

--- a/gui/source/dsbootsplash.cpp
+++ b/gui/source/dsbootsplash.cpp
@@ -350,8 +350,8 @@ void bootSplash() {
 				else offset3D_temp = -offset3D_nint;
 				sf2d_draw_texture(nintendotex, offset3D_temp+40+84, 177);
 			}
-			if (settings.ui.bootscreen == 2 && splashScreenTime > 60*1
-				|| settings.ui.bootscreen == 4 && splashScreenTime > 60*1) {
+			if ((settings.ui.bootscreen == 2 && splashScreenTime > 60*1) ||
+			    (settings.ui.bootscreen == 4 && splashScreenTime > 60*1)) {
 				if (topfb == 1) offset3D_temp = offset3D_i;
 				else offset3D_temp = -offset3D_i;
 				i_alpha += 10;

--- a/gui/source/dsbootsplash.cpp
+++ b/gui/source/dsbootsplash.cpp
@@ -273,22 +273,6 @@ void bootSplash() {
 		const u32 hDown = hidKeysDown();
 		const u32 hHeld = hidKeysHeld();
 		
-		// Poll for Slot-1 changes.
-		bool forcePoll = false;
-		bool doSlot1Update = false;
-		if (gamecardIsInserted() && gamecardGetType() == CARD_TYPE_UNKNOWN) {
-			// Card is inserted, but we don't know its type.
-			// Force an update.
-			forcePoll = true;
-		}
-		bool s1chg = gamecardPoll(forcePoll);
-		if (s1chg) {
-			// Update Slot-1 if:
-			// - forcePoll is false
-			// - forcePoll is true, and card is no longer unknown.
-			doSlot1Update = (!forcePoll || gamecardGetType() != CARD_TYPE_UNKNOWN);
-		}
-
 		textVtxArrayPos = 0; // Clear the text vertex array
 		
 		offset3D_oeffect1 = CONFIG_3D_SLIDERSTATE * offset3D_oeffect1_chng;


### PR DESCRIPTION
This caused a half-speed issue before, but Slot-1 isn't needed at all when showing the DS(i) boot splash, so there's no point in polling here.

(Sidenote: I still need to rebase my wchar_t/text centering branch. May end up doing that tonight once I get everything cleared up.)

#### What's new?

Removal of unneeded code.

#### What is fixed?

Some minor gcc warning fixes.

#### Where have you tested it?

New 3DS XL running 11.4.0-37U

*** 
#### Pull Request status
- [x]  This PR has been tested using latest DEVKITPRO, DEVKITARM, SFILLIB, SF2DLIB, LIBNDS and Citro3DS.  

_(Do not edit after this point)_
- [x]  This PR is fully documented.
- [x]  This PR has been tested before sending.
- [x]  This PR follows C style and convention.
