### PR TITLE
Re-enable update functionality using Kaeru CDN update server

### DIFF
--- a/gui/source/download.cpp
+++ b/gui/source/download.cpp
@@ -27,8 +27,8 @@ using std::vector;
 
 #include "json/json.h"
 
-const char* JSON_URL = "https://raw.githubusercontent.com/Jolty95/TWLoader-update/master/update.json";
-const char* JSON_NIGHTLIES_URL = "https://raw.githubusercontent.com/Jolty95/TWLoader-update/master/beta/updatenightlies.json";
+const char* JSON_URL = "http://cdn.kaeru.world/TWLoader-update/update.json";
+const char* JSON_NIGHTLIES_URL = "http://cdn.kaeru.world/TWLoader-update/master/beta/updatenightlies.json";
 bool updateGUI = false;
 bool updateNAND = false;
 bool updateNAND_part2 = false;

--- a/gui/source/main.cpp
+++ b/gui/source/main.cpp
@@ -3097,7 +3097,7 @@ int main(){
 	"If the issue persists, reboot, then do the same,\n"
 	"and also hold  to turn on quick start.";
 
-	/*if(!(hHeld & KEY_Y)) {
+	if(!(hHeld & KEY_Y)) {
 		pp2d_begin_draw(GFX_BOTTOM, GFX_LEFT);
 		pp2d_draw_text(12, 16, 0.5f, 0.5f, WHITE, wifiStuckMsg);
 		pp2d_end_draw();
@@ -3106,7 +3106,7 @@ int main(){
 		if (checkWifiStatus() && (DownloadMissingFiles() == 0)) {
 			// Nothing
 		}
-	}*/
+	}
 
 	if(!settings.ui.quickStart) {
 		wifiStuckMsg =
@@ -3155,7 +3155,7 @@ int main(){
 			fclose(f_nds_file);
 		}
 	
-		/*pp2d_begin_draw(GFX_BOTTOM, GFX_LEFT);
+		pp2d_begin_draw(GFX_BOTTOM, GFX_LEFT);
 		pp2d_draw_text(12, 16, 0.5f, 0.5f, WHITE, wifiStuckMsg);
 		pp2d_end_draw();
 
@@ -3175,7 +3175,7 @@ int main(){
 					UpdateBootstrapUnofficial();
 					break;
 			}
-		}*/
+		}
 	}
 
 	botscreenoff();

--- a/gui/source/settings.cpp
+++ b/gui/source/settings.cpp
@@ -271,8 +271,8 @@ void settingsDrawTopScreen(void)
 				pp2d_draw_texture(disabledtex, offset3D[topfb].disabled+136, 124); // Draw disabled texture	
 			}
 		} else if (subscreenmode == SUBSCREEN_MODE_NTR) {
-			//pp2d_draw_wtext(offset3D[topfb].disabled+72, 30, 0.60, 0.60, BLUE, TR(STR_SETTINGS_XBUTTON_RELEASE));
-			//pp2d_draw_wtext(offset3D[topfb].disabled+72, 46, 0.60, 0.60, GREEN, TR(STR_SETTINGS_YBUTTON_UNOFFICIAL));
+			pp2d_draw_wtext(offset3D[topfb].disabled+72, 30, 0.60, 0.60, BLUE, TR(STR_SETTINGS_XBUTTON_RELEASE));
+			pp2d_draw_wtext(offset3D[topfb].disabled+72, 46, 0.60, 0.60, GREEN, TR(STR_SETTINGS_YBUTTON_UNOFFICIAL));
 			if (settings.twl.loadingscreen == 3) {
 				pp2d_draw_texture(tictactoeloadtex, offset3D[topfb].boxart+120, 72); // Draw Tic-Tac-Toe loading screen
 			} else if (settings.twl.loadingscreen == 2) {
@@ -737,8 +737,7 @@ void settingsDrawBottomScreen(void)
 			pp2d_draw_text(8, 198, 0.60, 0.60f, WHITE, "you're using.");
 		}
 		if (cursor_pos[1] == 3) {
-			//pp2d_draw_text(8, 184, 0.60, 0.60f, WHITE, "Press  to update TWLoader.");
-			pp2d_draw_text(8, 184, 0.60, 0.60f, WHITE, "This feature cannot be used at this time.");
+			pp2d_draw_text(8, 184, 0.60, 0.60f, WHITE, "Press  to update TWLoader.");
 		}
 		if (cursor_pos[1] == 4) {
 			pp2d_draw_wtext(8, 184, 0.60, 0.60f, WHITE, TR(STR_SETTINGS_DESCRIPTION_DS_DSi_BOOT_SCREEN_1));
@@ -1488,7 +1487,7 @@ bool settingsMoveCursor(u32 hDown)
 			subscreenmode = SUBSCREEN_MODE_FRONTEND;
 			sfx = sfx_switch;
 		} else if (hDown & KEY_X) {
-			/*if (checkWifiStatus()) {
+			if (checkWifiStatus()) {
 				// Play the sound now instead of waiting.
 				if (dspfirmfound && sfx_select) {
 					sfx_select->stop();	// Prevent freezing
@@ -1498,9 +1497,9 @@ bool settingsMoveCursor(u32 hDown)
 			} else {
 				// Wi-Fi is not connected.
 				sfx = sfx_wrong;
-			}*/
+			}
 		} else if (hDown & KEY_Y) {
-			/*if (checkWifiStatus()) {
+			if (checkWifiStatus()) {
 				// Play the sound now instead of waiting.
 				if (dspfirmfound && sfx_select) {
 					sfx_select->stop();	// Prevent freezing
@@ -1510,7 +1509,7 @@ bool settingsMoveCursor(u32 hDown)
 			} else {
 				// Wi-Fi is not connected.
 				sfx = sfx_wrong;
-			}*/
+			}
 		} else if (hDown & KEY_B) {
 			titleboxXmovetimer = 1;
 			fadeout = true;
@@ -1628,7 +1627,7 @@ bool settingsMoveCursor(u32 hDown)
 					}
 					break;
 				case 3:
-					/*if (checkWifiStatus()) {
+					if (checkWifiStatus()) {
 						if (checkUpdate() == 0) {
 							// Play the sound now instead of waiting.
 							if (dspfirmfound && sfx_select) {
@@ -1637,10 +1636,10 @@ bool settingsMoveCursor(u32 hDown)
 							}
 							DownloadTWLoaderCIAs();
 						}
-					} else {*/
+					} else {
 						// Wi-Fi is not connected.
 						sfx = sfx_wrong;
-					//}
+					}
 					break;
 				case 4:	// Boot screen
 					if (hDown & KEY_A) {
@@ -1659,7 +1658,7 @@ bool settingsMoveCursor(u32 hDown)
 					settings.ui.healthsafety = !settings.ui.healthsafety;
 					break;
 			}
-			if (cursor_pos[SUBSCREEN_MODE_FRONTEND2] != 3) sfx = sfx_select;
+			sfx = sfx_select;
 		} else if ((hDown & KEY_DOWN) && cursor_pos[1] < 6) {
 			cursor_pos[1] += 2;
 			if (cursor_pos[1] > 5) cursor_pos[1] -= 2;


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's new?

Switched to fetching updates from http://cdn.kaeru.world/TWLoader-update/ , which is setup to mirror Jolty95/TWLoader-update pending addition of a webhook to that repository. Update functionality has been re-enabled.

#### What is fixed?

Update functionality should work again.

#### Where have you tested it?

Not tested, however changes are almost entirely reverting the "disable update" changes as well as changing a string and as such should not cause any issues.

*** 
#### Pull Request status
- [ ]  This PR has been tested using latest DEVKITPRO, DEVKITARM, SFILLIB, SF2DLIB, LIBNDS and Citro3DS.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
